### PR TITLE
Addressing small changes in text per Ted's request

### DIFF
--- a/src/components/VideoCarousel.jsx
+++ b/src/components/VideoCarousel.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function VideoContainer({ videos }) {
+  return (
+    <div className="flex flex-col md:flex-row overflow-hidden my-4 w-full">
+      {videos.map((videoSrc, index) => (
+        <div
+          key={`video-container-${videoSrc}`}
+          className="w-full aspect-w-16 aspect-h-9 overflow-hidden mb-4 md:mb-0"
+        >
+          <iframe
+            src={videoSrc}
+            title={`video ${index + 1}`}
+            className="w-full h-64 md:mx-10"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+VideoContainer.propTypes = {
+  videos: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default VideoContainer;

--- a/src/pages/activities/Activities.jsx
+++ b/src/pages/activities/Activities.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import './activities.css';
 import { Link } from 'react-router-dom';
 import HeaderImage from '../../images/activities/header_bg_1.jpg';
@@ -18,45 +18,42 @@ import Extra1 from '../../images/activities/extra1.jpg';
 import Extra2 from '../../images/activities/extra2.jpeg';
 import Extra3 from '../../images/activities/extra3.jpeg';
 import FlexColumnContainer from '../../components/FlexColumnContainer';
-import { WAIVER_TEXT } from '../../text/JoinUs';
+import VideoContainer from '../../components/VideoCarousel';
 
 const brunchImages = [Brunch1, Brunch2, Brunch3];
 const activityImages = [Activity1, Activity2];
 const extraImages = [Extra1, Extra2, Extra3];
+const videos = [
+  'https://www.youtube.com/embed/Wf7stsuFcT8?si=eEHfx8PgP7NljpJW',
+  'https://www.youtube.com/embed/EsuECjg4qng?si=i5RjsOhou5sjh8Gy',
+];
 
 function Activities() {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const toggleExpand = () => {
-    setIsExpanded(!isExpanded);
-  };
   return (
     <>
       <Header title="Activities" image={HeaderImage} />
       <FlexColumnContainer>
         <div className="first:mt-8">
-          <Subheader title="Saturday Morning Run" />
+          <Subheader title="Saturday Morning Runs" />
         </div>
         <Paragraph>
-          Every Saturday morning, we run on the part of the Bay trail near
-          downtown San Mateo. We welcome all paces and walkers as well.
-          Non-members can run with us, but must agree to the waiver
+          Every Saturday morning, we run along the scenic Bay trail near downtown San Mateo.
+          We welcome runners of all paces as well as walkers.
+          Non-members are welcome to run with us.
+          For more details on how to run with us, check out our
           {' '}
-          <Link className="hyperlink" onClick={toggleExpand}>
-            here.
-          </Link>
-          {isExpanded && (
-            <p className="waiver-text">{WAIVER_TEXT}</p>
-          )}
+          <Link className="hyperlink" to="/joinus">Join Us</Link>
+          {' '}
+          page.
         </Paragraph>
-        <Subheader title="Brunch" />
+        <Subheader title="Brunches" />
         <Paragraph>
           &ldquo;Our informal motto is &ldquo;the eating club with a running problem&rdquo;.
           We love to eat just as much as we love to run (or more)!
           After most Saturday runs, we organize a group to try brunch at nearby places.&rdquo;
         </Paragraph>
         <ImageCarousel images={brunchImages} />
-        <Subheader title="Run Club Social" />
+        <Subheader title="Run Club Socials" />
         <Paragraph>
           Celebrate the end of each month with our Run Club Socials!
           On the last Saturday of each month, our club members bring food and drink to share.
@@ -70,6 +67,8 @@ function Activities() {
           and have costumed runs on some holidays!
         </Paragraph>
         <ImageCarousel images={extraImages} />
+        <h2 className="my-8">Experience the MPRC through these videos</h2>
+        <VideoContainer videos={videos} />
       </FlexColumnContainer>
     </>
   );

--- a/src/pages/activities/activities.css
+++ b/src/pages/activities/activities.css
@@ -1,3 +1,29 @@
 #activities {
   margin: 80px;
 }
+.video-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.video-item {
+  width: 100%;
+  height: 250px; /* Set default height for mobile */
+  max-width: 450px; /* Set maximum width for larger screens */
+  margin-bottom: 20px; /* Add vertical spacing between videos */
+}
+
+@media (min-width: 768px) {
+  .video-item {
+    width: calc(50% - 20px); /* Two videos side by side with spacing */
+    height: auto; /* Reset height for larger screens */
+    margin-right: 20px; /* Add horizontal spacing between videos */
+    margin-bottom: 0; /* Remove vertical margin for larger screens */
+  }
+
+  .video-item:last-child {
+    margin-right: 0; /* Remove margin from the last video to prevent overflow */
+  }
+}
+
+

--- a/src/pages/joinUs/JoinUs.jsx
+++ b/src/pages/joinUs/JoinUs.jsx
@@ -6,13 +6,20 @@ import { faGoogle, faMeetup } from '@fortawesome/free-brands-svg-icons';
 import MetaText from '../../components/MetaText';
 import {
   ARM,
+  BECOME_A_MEMBER,
   GOOGLE_FORM,
-  MEMBER_BENEFITS,
+  JOIN_US_BUTTON_1,
+  JOIN_US_BUTTON_2,
   JOIN_US_DESCRIPTION_1,
   JOIN_US_DESCRIPTION_2,
   JOIN_US_DESCRIPTION_3,
   JOIN_US_DESCRIPTION_4,
   JOIN_US_DESCRIPTION_5,
+  JOIN_US_HEADING_DESC,
+  JUST_RUN_WITH_US,
+  JUST_RUN_WITH_US_CONTENT_1,
+  JUST_RUN_WITH_US_CONTENT_2,
+  JUST_RUN_WITH_US_CONTENT_3,
   LI_ACCESS_TO_STRAVA_FACEBOOK,
   LI_AFFORDABLE_MEMBERSHIP_FEES,
   LI_CLUB_GATHERINGS,
@@ -25,15 +32,11 @@ import {
   LI_SATURDAY_CLUB_RUNS,
   LI_SOCIAL_RACE_ACTIVITIES,
   MEETUP_GROUP,
-  JOIN_US_BUTTON_1,
-  JOIN_US_BUTTON_2, WAYS_TO_RUN, JOIN_US_HEADING_DESC, BECOME_A_MEMBER,
+  MEMBER_BENEFITS,
+  WAYS_TO_RUN,
 } from '../../text/JoinUs';
 import Card from '../../UI/Card';
-import {
-  ARM_URI,
-  GOOGLE_FORM_LINK,
-  MEETUP_URI,
-} from '../../text/externalLinks';
+import { ARM_URI, GOOGLE_FORM_LINK, MEETUP_URI } from '../../text/externalLinks';
 import Route from './Route';
 import Paragraph from '../../components/Paragraph';
 
@@ -51,6 +54,19 @@ const sectionHeading = () => (
 );
 
 const sectionRunWithUs = () => (
+  <Card className="joinus__card">
+    <h2 className="h2_joinus">
+      {JUST_RUN_WITH_US}
+    </h2>
+    <ul className="ul_joinus">
+      <li className="li_joinus">{JUST_RUN_WITH_US_CONTENT_1}</li>
+      <li className="li_joinus">{JUST_RUN_WITH_US_CONTENT_2}</li>
+      <li className="li_joinus">{JUST_RUN_WITH_US_CONTENT_3}</li>
+    </ul>
+  </Card>
+);
+
+const sectionMeetup = () => (
   <Card className="joinus__card">
     <h2 className="h2_joinus">
       {JOIN_US_DESCRIPTION_1}
@@ -131,6 +147,8 @@ function JoinUs() {
           {sectionHeading()}
           &nbsp;&nbsp;
           {sectionRunWithUs()}
+          &nbsp;&nbsp;
+          {sectionMeetup()}
           &nbsp;&nbsp;
           {sectionBecomeMember()}
           &nbsp;&nbsp;

--- a/src/text/Home.js
+++ b/src/text/Home.js
@@ -5,7 +5,7 @@ export const ABOUT_STORY_TITLE = 'Welcome to MPRC!';
 
 export const ABOUT_STORY_CONTENT = [
   "Welcome to the Mid-Peninsula Running Club, where running is more than just a workout – it's a community! Since 1988, we've been bringing together runners from all walks of life on the San Francisco Peninsula (San Mateo County).",
-  'Our club emphasizes forging connections while enjoying the outdoors. We have over 120 friendly club members who share a love for staying active and appreciating the beauty of nature.',
+  'Our club emphasizes forging connections while enjoying the outdoors. We have over 130 friendly club members who share a love for staying active and appreciating the beauty of nature.',
   "Every Saturday morning at 8:45 AM, we have our main run/walk on the Bay Trail in San Mateo. You can choose to run or walk any distance from 4-6 miles. It's a great way to start the weekend!",
   'We also have special events just for our members throughout the year, giving us more chances to have fun together.',
   "Come and join us! We're all about running, making friends, and having a good time.",

--- a/src/text/JoinUs.js
+++ b/src/text/JoinUs.js
@@ -3,11 +3,16 @@ export const JOIN_US_HEADING_DESC = 'We gather every Saturday morning at Seal Po
 export const JOIN_US_DESCRIPTION_1 = 'Join us through ';
 export const MEETUP_GROUP = 'Meetup ';
 export const JOIN_US_DESCRIPTION_2 = 'Joining Meetup and attending runs are both free of charge.';
-export const JOIN_US_DESCRIPTION_3 = 'You don\'t have to be an MPRC member to run with us but feel free to check out our meetup for the calendar invites.';
+export const JOIN_US_DESCRIPTION_3 = 'You don\'t have to be an MPRC member to run with us but feel free to check out our meetup for the calendar events.';
 export const JOIN_US_DESCRIPTION_4 = 'Fill out the ';
 export const JOIN_US_DESCRIPTION_5 = 'The fee is $15 per calendar year for individuals and $20 per calendar year for families.';
 export const GOOGLE_FORM = 'Google Form';
 export const BECOME_A_MEMBER = 'Become an MPRC Member';
+
+export const JUST_RUN_WITH_US = 'Just Come Out and Run With Us';
+export const JUST_RUN_WITH_US_CONTENT_1 = 'Just show up at a run and see what we\'re all about!';
+export const JUST_RUN_WITH_US_CONTENT_2 = 'There\'s no need to be a member of any group or organization.';
+export const JUST_RUN_WITH_US_CONTENT_3 = 'Details about time and location are provided above.';
 
 export const WAYS_TO_RUN = 'Ways To Run With Us';
 
@@ -32,6 +37,6 @@ export const WAIVER_TITLE = 'Club Activity Terms and Consent';
 export const WAIVER_TEXT = `
 Liability Waiver: I know that running in and volunteering for organized group runs, social events, and races with this club are potentially hazardous activities, which could cause injury or death. I will not participate in any activities associated with the club, unless I am medically able and properly trained. I agree to abide by all rules established by the club, including the right of any official to deny or suspend my participation for any reason whatsoever. I assume all risks associated with participating in club activities which may include, but not limited to: falls, contact with other participants, the effects of the weather, traffic and the road conditions. Having read this waiver and knowing these facts, I, for myself and anyone entitled to act on my behalf, waive and release the Mid-Peninsula Running Club (including its officers and other members), all sponsors, and their representatives and successors, from all claims or liabilities of any kind arising out of my participation in club activities, even though that liability may arise out of negligence or carelessness on the part of persons named in this waiver.
 
-Consent to use Photographic Images: I hereby authorize and grant to The Mid-Peninsula Running Club full rights and permissions to use and publish onto various MPRC websites and social media outlets, photographs taken of members and their guests, or contributed by them, or published on their public social media.
+Consent to use Photographic Images: I hereby authorize and grant to The Mid-Peninsula Running Club full rights and permissions to use and publish onto various MPRC websites and social media outlets, photographs taken of members and guests, or contributed by them, or published on their public social media.
 `;
 export const WAIVER_AGREEMENT = 'I agree to the terms and conditions.';


### PR DESCRIPTION
Changes:
1.  Home page says "more than 120 runners".  We now have more than 130.  Change it now, but don't worry, we are not going to ask you to change the number very often.  I'd like to keep the website as maintenance free as possible.

2.  You put in the liability waiver exactly as we told you to.  However, after reading it again, I have one simple change.  Near the end of the Photographic Images Consent, it states " photographs taken of members and their guests...".  Please remove the word "their".

3.  On the "Join Us" page, in the Meetup section, just above the button, it says "calendar invites".  I think that should be "calendar events".

4.             Just Come Out and Run With Us                              |
             |                                                                                                           |
             |     +   Just show up at a run and check us out.                                 |
             |     +   No need to be a member of any group or organization.          |
             |     +   Time and place detailed above.                                             
            
5. Added Dalton's YouTube videos on Activities page