### PR TITLE
test: cover members-only Firestore access rules

### DIFF
--- a/tests/firestore-rules/members-only.test.js
+++ b/tests/firestore-rules/members-only.test.js
@@ -40,14 +40,19 @@ describe('members_only collection', () => {
     await assertSucceeds(admin.doc('members_only/benefits').get());
   });
 
-  test('members CANNOT create, update, or delete private content', async () => {
+  test.each([
+    ['anonymous users', undefined],
+    ['users without a role claim', { uid: 'u1' }],
+    ['unverified users', { uid: 'u2', role: 'unverified' }],
+    ['members', { uid: 'u3', role: 'member' }],
+  ])('%s CANNOT create, update, or delete private content', async (_label, auth) => {
     await seed('members_only/benefits', PRIVATE_CONTENT);
-    const member = await db({ uid: 'u1', role: 'member' });
+    const user = await db(auth);
 
-    await assertFails(member.doc('members_only/new-benefit').set(PRIVATE_CONTENT));
-    await assertFails(member.doc('members_only/benefits').update({
-      discounts: '<p>Changed by a member.</p>',
+    await assertFails(user.doc('members_only/new-benefit').set(PRIVATE_CONTENT));
+    await assertFails(user.doc('members_only/benefits').update({
+      discounts: '<p>Changed without admin access.</p>',
     }));
-    await assertFails(member.doc('members_only/benefits').delete());
+    await assertFails(user.doc('members_only/benefits').delete());
   });
 });

--- a/tests/firestore-rules/members-only.test.js
+++ b/tests/firestore-rules/members-only.test.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+
+const {
+  clearFirestore, teardown, db, seed, assertFails, assertSucceeds,
+} = require('./setup');
+
+const PRIVATE_CONTENT = {
+  discounts: '<p>Members save 10%.</p>',
+};
+
+beforeEach(clearFirestore);
+afterAll(teardown);
+
+describe('members_only collection', () => {
+  test('anonymous users CANNOT read private content', async () => {
+    await seed('members_only/benefits', PRIVATE_CONTENT);
+    const anon = await db();
+
+    await assertFails(anon.doc('members_only/benefits').get());
+  });
+
+  test('unverified users CANNOT read private content', async () => {
+    await seed('members_only/benefits', PRIVATE_CONTENT);
+    const unverified = await db({ uid: 'u1', role: 'unverified' });
+
+    await assertFails(unverified.doc('members_only/benefits').get());
+  });
+
+  test('members CAN read private content', async () => {
+    await seed('members_only/benefits', PRIVATE_CONTENT);
+    const member = await db({ uid: 'u1', role: 'member' });
+
+    await assertSucceeds(member.doc('members_only/benefits').get());
+  });
+
+  test('admins CAN read private content through the admin catch-all', async () => {
+    await seed('members_only/benefits', PRIVATE_CONTENT);
+    const admin = await db({ uid: 'a1', role: 'admin' });
+
+    await assertSucceeds(admin.doc('members_only/benefits').get());
+  });
+
+  test('members CANNOT create, update, or delete private content', async () => {
+    await seed('members_only/benefits', PRIVATE_CONTENT);
+    const member = await db({ uid: 'u1', role: 'member' });
+
+    await assertFails(member.doc('members_only/new-benefit').set(PRIVATE_CONTENT));
+    await assertFails(member.doc('members_only/benefits').update({
+      discounts: '<p>Changed by a member.</p>',
+    }));
+    await assertFails(member.doc('members_only/benefits').delete());
+  });
+});


### PR DESCRIPTION
## Summary
- add direct security-rules coverage for the private members_only collection
- verify anonymous and unverified users are denied read access
- verify members and admins can read
- verify anonymous, no-role, unverified, and member users cannot create, update, or delete private content

## Validation
- npm run test:rules (97 tests passed)
- npx eslint tests/firestore-rules/members-only.test.js
- git diff --check

Closes #77