### PR TITLE
test: prove signup logs redact private data

### DIFF
--- a/functions/ensureMemberProfile.test.js
+++ b/functions/ensureMemberProfile.test.js
@@ -296,4 +296,67 @@ describe('signup profile compatibility', () => {
     expect(admin.__read(AUTH_USER.uid)).toMatchObject({ role: 'unverified' });
     expect(admin.__mocks.setCustomUserClaims).not.toHaveBeenCalled();
   });
+
+  test('logs only the fixed failure outcome and never user or provider data', async () => {
+    const canaries = [
+      'signup-member@example.test',
+      '+1-555-010-4242',
+      'oauth-token-canary',
+      'provider-response-canary',
+      'request-body-canary',
+      'https://runmprc.com/account?token=capability-canary#private',
+      'signup-uid-canary',
+      'Private Signup Name Canary',
+    ];
+    const hostileUser = {
+      ...AUTH_USER,
+      uid: canaries[6],
+      email: canaries[0],
+      displayName: canaries[7],
+      phoneNumber: canaries[1],
+      providerData: [{ providerId: canaries[3] }],
+    };
+    const providerFailure = Object.assign(new Error(canaries.join(' ')), {
+      email: canaries[0],
+      phone: canaries[1],
+      token: canaries[2],
+      response: { message: canaries[3] },
+      request: { body: canaries[4] },
+      url: canaries[5],
+    });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { onSignUp } = require('./signup');
+
+    try {
+      await onSignUp(AUTH_USER);
+      expect(consoleError).not.toHaveBeenCalled();
+
+      admin.__mocks.firestoreApi.runTransaction.mockRejectedValueOnce(providerFailure);
+      let caught;
+      try {
+        await onSignUp(hostileUser);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toMatchObject({
+        code: 'internal',
+        message: 'Failed to create member record',
+      });
+      expect(caught).not.toBe(providerFailure);
+      expect(caught.cause).toBeUndefined();
+      expect(consoleError.mock.calls).toEqual([
+        ['Member profile setup failed during account creation.'],
+      ]);
+
+      const serializedConsole = JSON.stringify(consoleError.mock.calls);
+      const returnedError = `${caught.code}: ${caught.message}`;
+      canaries.forEach((canary) => {
+        expect(serializedConsole).not.toContain(canary);
+        expect(returnedError).not.toContain(canary);
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });

--- a/functions/ensureMemberProfile.test.js
+++ b/functions/ensureMemberProfile.test.js
@@ -324,12 +324,18 @@ describe('signup profile compatibility', () => {
       request: { body: canaries[4] },
       url: canaries[5],
     });
+    const consoleDebug = jest.spyOn(console, 'debug').mockImplementation(() => {});
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const otherConsoleSpies = [consoleDebug, consoleInfo, consoleLog, consoleWarn];
+    const allConsoleSpies = [consoleError, ...otherConsoleSpies];
     const { onSignUp } = require('./signup');
 
     try {
       await onSignUp(AUTH_USER);
-      expect(consoleError).not.toHaveBeenCalled();
+      allConsoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
 
       admin.__mocks.firestoreApi.runTransaction.mockRejectedValueOnce(providerFailure);
       let caught;
@@ -348,15 +354,18 @@ describe('signup profile compatibility', () => {
       expect(consoleError.mock.calls).toEqual([
         ['Member profile setup failed during account creation.'],
       ]);
+      otherConsoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
 
-      const serializedConsole = JSON.stringify(consoleError.mock.calls);
+      const serializedConsole = JSON.stringify(
+        allConsoleSpies.map((spy) => spy.mock.calls),
+      );
       const returnedError = `${caught.code}: ${caught.message}`;
       canaries.forEach((canary) => {
         expect(serializedConsole).not.toContain(canary);
         expect(returnedError).not.toContain(canary);
       });
     } finally {
-      consoleError.mockRestore();
+      allConsoleSpies.forEach((spy) => spy.mockRestore());
     }
   });
 });


### PR DESCRIPTION
## Outcome

The existing fixed signup failure message now has hostile-canary regression coverage. The test proves a successful signup emits no error log, while a failed profile transaction emits exactly one fixed phrase and returns only the existing generic error.

Tracks #146. Parent tracker: #111.

## Security invariant and failure behavior

- The Auth user and caught provider failure contain synthetic UID, name, email, phone, token, provider-response, request-body, and capability-URL values.
- None of those values may reach serialized `console.error` arguments or the returned error code/message.
- Success produces no `console.debug`, `error`, `info`, `log`, or `warn` call.
- Failure produces only `Member profile setup failed during account creation.` and the existing `internal` / `Failed to create member record` response.
- On failure, `console.debug`, `info`, `log`, and `warn` remain silent.
- The original provider error is not returned or attached as a cause.

## Scope

- `functions/ensureMemberProfile.test.js` only

No runtime, dependency, schema, frontend, Rules, workflow, root-document, officer-guide, provider, production-data, or sitemap change.

## Test evidence

Node 20.20.2 on exact head `329b58808b8e09d0f284c2f6b7369920aa6afdc6`, base `f2caaae3b3f25adfd4fc552008871408f18e5931`:

- Pre-change coverage check confirmed the hostile signup-console regression was absent.
- Focused `ensureMemberProfile.test.js`: 1 suite / 20 tests passed.
- Complete Functions suite: 5 suites / 160 tests passed; the existing emulator-only suite remained skipped by the unit-test command.
- Functions ESLint: passed.
- `git diff --check`: passed.
- An independent review found the first version watched only `console.error`; the final version closes that gap across all five standard console levels.
- Two independent exact-head re-reviews approve the corrected one-file range and agree it resolves #111's remaining Functions-log canary gap.
- Hosted CI run `29246004213` passed frontend, Functions, and Firestore Rules on this exact head.
- Diff SHA-256: `e3a40a405ffaa79d1cffdbfd336e27edeae20e986f8e2ea4f24fc16abce14ff6`.

Tests use the existing Firebase Admin/Functions mocks and synthetic values. They make no Firebase or outside-provider call.

## Compatibility / rollback

Runtime behavior is byte-for-byte unchanged. Removing this test would remove regression proof but would not change deployed behavior.

Officer impact: None — member and officer tasks/screens are unchanged.

Officer documentation: None — no procedure, navigation, permission, collected field, deployment duty, or external account changed.

Deployment evidence:

- **Source/tests:** exact head is pushed, independently reviewed, and green in hosted CI; not merged.
- **Website publication:** not performed. #135 keeps Git-triggered production publication paused.
- **`runmprc.com` verification:** not performed; no exact revision is claimed live.
- **Firebase deployment:** not required or performed; this is a mocked Functions test only.
- **Outside-provider configuration:** not inspected or changed.
- **Production behavior:** not tested; no production account, email, record, or provider traffic was used.
