### PR TITLE
WEB-UX-001 — Keep fixed navigation from covering page content

### DIFF
--- a/src/components/navbar.css
+++ b/src/components/navbar.css
@@ -1,5 +1,5 @@
 nav {
-  height: 5.5rem;
+  height: var(--site-nav-height);
   width: 100vw; /*100% of the window/browser*/
   background: var(--color-primary);
   display: grid;

--- a/src/headerClearance.test.js
+++ b/src/headerClearance.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const readStylesheet = (...parts) => readFileSync(join(__dirname, ...parts), 'utf8');
+
+const getRule = (stylesheet, selector) => {
+  const stylesheetWithoutComments = stylesheet.replace(/\/\*[\s\S]*?\*\//g, '');
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = stylesheetWithoutComments.match(
+    new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`),
+  );
+
+  return match?.[1] ?? '';
+};
+
+describe('persistent navigation clearance', () => {
+  const globalStyles = readStylesheet('index.css');
+  const navbarStyles = readStylesheet('components', 'navbar.css');
+  const homeStyles = readStylesheet('pages', 'home', 'home.css');
+
+  test('uses one shared height for the fixed navigation and main content offset', () => {
+    expect(getRule(globalStyles, ':root')).toMatch(
+      /--site-nav-height:\s*5\.5rem\s*;/,
+    );
+
+    const navigationRule = getRule(navbarStyles, 'nav');
+    expect(navigationRule).toMatch(/height:\s*var\(--site-nav-height\)\s*;/);
+    expect(navigationRule).toMatch(/position:\s*fixed\s*;/);
+    expect(navigationRule).toMatch(/top:\s*0\s*;/);
+
+    const mainRule = getRule(globalStyles, '#main-content');
+    expect(mainRule).toMatch(
+      /padding-top:\s*var\(--site-nav-height\)\s*;/,
+    );
+  });
+
+  test('does not add legacy hero offsets on top of the shared clearance', () => {
+    expect(getRule(globalStyles, '.header')).toMatch(/margin-top:\s*0\s*;/);
+    expect(getRule(homeStyles, '.main__header')).toMatch(/margin-top:\s*0\s*;/);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,7 @@
 
   --container-width-lg: 80%;
   --container-width-md: 90%;
+  --site-nav-height: 5.5rem;
 
   --transition: all 500ms ease; /* make sure all transition have a constant effect*/
 }
@@ -62,6 +63,10 @@ body {
   line-height: 1.7;
   overflow-x: hidden;
   background: var(--color-gray-600) url(./images/bg_texture.png);
+}
+
+#main-content {
+  padding-top: var(--site-nav-height);
 }
 
 .container {
@@ -246,7 +251,7 @@ section {
 }
 
 .header {
-  margin-top: 5rem;
+  margin-top: 0;
   height: 20rem;
   overflow: hidden;
   border-bottom: 2px solid var(--color-gray-400);

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -2,7 +2,7 @@
   width: 100vw;
   height: calc(100vh - 3.49rem);
   display: grid;
-  margin-top: 3rem;
+  margin-top: 0;
 }
 
 .main__header-container {


### PR DESCRIPTION
Closes #170

## Outcome

Pages with and without image banners now reserve the same fixed-navigation height, so the first heading or hero begins below the navigation instead of underneath it. No placeholder images, route components, account code, or content changed.

## Layout invariant

- `--site-nav-height: 5.5rem` is the single height source.
- The fixed `nav` consumes that value.
- `#main-content` reserves that value.
- Shared hero and Home no longer add old route-specific top margins.

## Verification

- Focused regression first failed on the baseline, then passed: 2/2.
- Full frontend Jest: 10 suites, 134 tests passed.
- SPA callback safety: 10/10 passed.
- Strict changed-file ESLint: passed with zero warnings.
- `git diff --check`: passed.
- Diagnostic production build with Node 20: compiled successfully.
- Browser at 1280x720:
  - `/events` and `/shop`: nav bottom 88px, route root 88px, heading 104px.
  - Home and `/activities`: route root 88px with no doubled top gap.
- Browser at 390x844:
  - same 88px shared clearance on Home, `/events`, `/shop`, and `/activities`;
  - mobile menu opened and navigated successfully.
- 640px effective-width / 200%-zoom-equivalent check: route root remained at 88px and hamburger navigation was present.
- Exact `/#main-content` target: first route content began at 88px, equal to nav bottom.

The local Events and Shop data requests intentionally remained fail-closed without production member data; layout was verified around their visible error/loading surface only.

## Scope and safety review

Claimed paths only:

- `src/index.css`
- `src/components/navbar.css`
- `src/pages/home/home.css`
- `src/headerClearance.test.js`

No Auth, Account, route component, Firebase, Functions, Rules, commerce, provider, workflow, image, or `public/sitemap.xml` change.

## Officer handoff

- Officer impact: page titles and controls are visible below navigation on computer and phone-sized screens.
- Officer documentation: None — no officer procedure, navigation destination, permission, collected data, public wording, or deployment duty changed.
- Deployment evidence:
  - Source changed: commit `be08855`.
  - Tests passed: local evidence above; hosted CI pending.
  - Merged: no.
  - Website published: no.
  - `runmprc.com` verified with this change: no.
  - Firebase deployed: not relevant; no backend change.
  - Outside provider configured or verified: not relevant.

## Undo

Revert the single merge commit in a reviewed pull request. This restores the old CSS offsets; no data or provider rollback is involved.