### PR TITLE
TEST-001A3: make validation-error recapture test portable

### DIFF
--- a/functions/requestValidation.test.js
+++ b/functions/requestValidation.test.js
@@ -526,9 +526,13 @@ describe('bounded array and string primitives', () => {
     const fabricated = new RequestValidationError(
       REQUEST_VALIDATION_REASONS.INVALID_EMAIL,
     );
+    expect(Object.isFrozen(fabricated)).toBe(true);
     expect(Reflect.set(fabricated, 'message', HOSTILE_CANARY)).toBe(false);
-    expect(Reflect.set(fabricated, 'stack', HOSTILE_CANARY)).toBe(false);
-    expectSafeError(
+    // V8's special lazy Error.stack slot can report or accept this write in
+    // some Jest hosts even when Object.isFrozen is true. The fabricated error
+    // is untrusted; the boundary is that the parser replaces it below.
+    Reflect.set(fabricated, 'stack', HOSTILE_CANARY);
+    const recaptured = expectSafeError(
       () => parseBoundedArray(['safe'], {
         maxItems: 1,
         itemParser: () => {
@@ -537,6 +541,7 @@ describe('bounded array and string primitives', () => {
       }),
       REQUEST_VALIDATION_REASONS.INVALID_VALUE,
     );
+    expect(recaptured).not.toBe(fabricated);
   });
 
   test('recaptures a genuine parser error without a value-derived function name', () => {


### PR DESCRIPTION
## Outcome

Makes the existing untrusted-error recapture test deterministic on macOS and Linux Node 20 without changing production code.

The test no longer relies on V8's platform-specific return value for writing the special lazy `Error.stack` slot. It still attempts the hostile write, then proves `parseBoundedArray` emits a distinct fresh error with the fixed safe reason/message, empty serialization, and no hostile canary.

Closes #187.

## Scope

- `functions/requestValidation.test.js` only
- no runtime, dependency, workflow, Rules, frontend, documentation, provider, or deployment change

## Verification

- Exact head: `5004389bcc729b03b3615917eadc5922c926c0cb`
- Node 20.20.2 macOS focused test: 152/152 passed
- Node 20.20.2 macOS Functions suite: 990 passed, 32 skipped
- Functions lint: passed
- `git diff --check`: passed
- Three independent read-only reviews: approved
- Exact main reproduction before the fix: the old assertion failed on macOS; hosted Linux exact-main run 29288647739 passed 990/990

## Boundaries

- Production `requestValidation.js` is unchanged.
- No test uses production data, network access, Firebase, Stripe, email, or provider authority.
- This does not deploy or change website/Firebase/provider behavior.

Officer impact: None — test portability only.

Officer documentation: None — no officer task or public behavior changes.

Deployment evidence: Source/test/merge evidence only. Website, Firebase, Stripe, provider settings, and production behavior are unchanged and unverified by this PR.
