### PR TITLE
MEMBERS-IDENTITY-001B: separate My Account from paid membership

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -290,6 +290,57 @@ Officer review steps after the source merge:
 
 **Escalation:** membership lead plus treasurer and privacy/security owner. Add the platform owner for source/deployment evidence and use the private incident path if real data or unintended access is involved.
 
+## My Account membership truth — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** stop My Account from presenting website-account details or a legacy website role as proof of current paid club membership.
+
+**Approver:** membership lead plus treasurer and privacy/security owner.
+
+**Prerequisites:** issue [#221](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/221) must be merged for source review. A protected website release, exact revision check on `runmprc.com`, and made-up account checks are also required before describing the wording as live. A future real membership-status display still requires the policy and server-authority work under #114 and #115; #221 does not provide it.
+
+```mermaid
+flowchart TD
+    Open["Member opens My Account"] --> Load{"Profile loads?"}
+    Load -- "No" --> Retry["Show a plain retry or sign-out path"]
+    Load -- "Yes" --> Details["Show website-account details"]
+    Details --> Created["Label the date Account created"]
+    Details --> Hide["Do not show a website role as Membership"]
+    Details --> Notice["Say paid membership and dues status is unavailable"]
+    Identity["Account creation / email verification / website access"] -. "Not membership proof" .-> Notice
+    Future["Future server-authoritative membership term"] -. "NOT AVAILABLE YET" .-> Notice
+```
+
+In words: My Account may show account details, including when the account was created, but it does not turn a website role, sign-in, email verification, or website access into proof of paid membership; the page says the real membership and dues status is not available there yet.
+
+Officer review steps after the source merge:
+
+1. Keep membership lookup and membership changes marked **NOT AVAILABLE YET**.
+2. Do not infer paid membership from a website role.
+3. Do not infer paid membership from account creation.
+4. Do not infer paid membership from email verification.
+5. Do not infer paid membership from website access.
+6. Ask the platform owner for the exact #221 synthetic test report.
+7. Confirm the report covers made-up pending, member-role, and admin-role profiles.
+8. Confirm `Membership` and `Member since` are absent from each made-up profile view.
+9. Confirm the account date is labeled `Account created`.
+10. Confirm every made-up profile sees the same unavailable-status notice.
+11. Confirm email verification remains a separate account action.
+12. Confirm profile recovery, name editing, phone pause, events, Strava, and sign-out are unchanged.
+13. Require a protected website publication before calling the wording live.
+14. Check the published revision on `runmprc.com` without opening a real member account.
+
+**Expected result:** the source page shows account facts without displaying a legacy role as membership. It uses `Account created`, not `Member since`. Every loaded profile sees one plain notice that paid membership and dues status is not available in My Account and that account creation, email verification, and website use do not prove current club membership. No actual membership, dues, entitlement, payment, role, provider, or member record changes.
+
+**Stop conditions:** a real member account; a request to confirm dues or membership from the page; a manual role or database change; a change to membership policy; a Firebase, payment, Google, WhatsApp, Strava, or other provider action; skipped website publication; or a claim that source, tests, merge, or a green workflow alone proves the wording is live.
+
+**Success proof:** for source completion, record the exact #221 issue, pull request, reviewed commit, focused account tests, full frontend checks, and merge commit. For live availability, separately record the website publication, the published revision, and a dated `runmprc.com` check with made-up accounts. Record Firebase deployment, outside-provider configuration, and production-data changes as **not performed** for this wording-only correction.
+
+**Undo:** before publication, revert or safely roll forward the three #221 source/documentation paths through review. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com`. Never undo by changing a role, membership, payment, or database record.
+
+**Escalation:** membership lead plus treasurer and privacy/security owner. Add the platform owner for source or publication evidence. Use the private incident path if real account or membership data appears.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -123,6 +123,39 @@ describe('Account profile recovery', () => {
     expect(getMyProfile).toHaveBeenCalledWith(firestore, USER.uid);
   });
 
+  test.each([
+    ['unverified', 'Unverified'],
+    ['member', 'Member'],
+    ['admin', 'Admin'],
+  ] as const)(
+    'keeps the %s website role separate from paid membership',
+    async (role, displayedRole) => {
+      (getMyProfile as jest.Mock).mockResolvedValue({ ...PROFILE, role });
+
+      const view = renderAccount();
+
+      expect(await screen.findByText('Synthetic Member')).toBeInTheDocument();
+      const details = view.container.querySelector('dl');
+      expect(details).not.toBeNull();
+      const labels = Array.from(details?.querySelectorAll('dt') || [])
+        .map((label) => label.textContent);
+      const values = Array.from(details?.querySelectorAll('dd') || [])
+        .map((value) => value.textContent);
+
+      expect(labels).toContain('Account created');
+      expect(labels).not.toContain('Membership');
+      expect(labels).not.toContain('Member since');
+      expect(values).not.toContain(displayedRole);
+      expect(document.body).not.toHaveTextContent(/pending member verification/i);
+      expect(document.body).not.toHaveTextContent(/upgrade your membership/i);
+      expect(document.body).not.toHaveTextContent(/dues are confirmed/i);
+      expect(screen.getByText(
+        /current paid membership and dues status is not available in My Account yet/i,
+      )).toBeInTheDocument();
+      expect(screen.getByText(/your email address is unverified/i)).toBeInTheDocument();
+    },
+  );
+
   test('shows a generic recovery state and disables editing when setup fails', async () => {
     (ensureMyProfile as jest.Mock)
       .mockRejectedValueOnce(new Error('Missing or insufficient permissions.'))

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -21,13 +21,6 @@ import StravaSection from './StravaSection';
 import { getLocationReturnPath } from '../login/loginReturnPath';
 import './Account.css';
 
-function roleLabel(role: string) {
-  if (role === 'admin') return 'Admin';
-  if (role === 'member') return 'Member';
-  if (role === 'unverified') return 'Unverified';
-  return role;
-}
-
 function tsToDate(ts: Timestamp | null | undefined) {
   if (!ts) return '';
   const d = typeof ts.toDate === 'function' ? ts.toDate() : new Date(ts as any);
@@ -412,11 +405,7 @@ export function AccountContent({
                 </dd>
               </div>
               <div>
-                <dt className="text-gray-500 text-xs">Membership</dt>
-                <dd>{roleLabel(profile.role)}</dd>
-              </div>
-              <div>
-                <dt className="text-gray-500 text-xs">Member since</dt>
+                <dt className="text-gray-500 text-xs">Account created</dt>
                 <dd>{tsToDate(profile.createdAt)}</dd>
               </div>
               <div>
@@ -490,10 +479,12 @@ export function AccountContent({
               <ResendVerificationButton key={user.uid} />
             </div>
           )}
-          {profile?.role === 'unverified' && (
+          {profileState === 'ready' && profile && (
             <div className="mt-3 p-3 bg-amber-100 border border-amber-300 rounded text-sm">
-              Your account is pending member verification. An admin will upgrade your
-              membership once dues are confirmed. You can still register for public events.
+              Current paid membership and dues status is not available in My Account yet.
+              {' '}
+              Creating an account, verifying an email address, or using the website does
+              not prove current club membership.
             </div>
           )}
         </section>


### PR DESCRIPTION
## Outcome

My Account no longer presents a legacy website role or account-creation date as paid annual membership. Every loaded profile now receives the same plain notice that current paid membership and dues status is not available there yet.

Closes #221.

Officer impact: Officers and members will no longer be told that a website role, account creation, email verification, or website access proves current paid membership. This does not add membership lookup or membership changes.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — new separately named `My Account membership truth — SOURCE ONLY, NOT LIVE` section with diagram, text alternative, review procedure, proof, stop, and undo guidance.

Deployment evidence: Website source and tests changed only. The website has not been published from this PR, `runmprc.com` has not been checked for this revision, Firebase was not changed or deployed, no outside provider was configured or called, no production data changed, and no live behavior is claimed.

## Change

- Remove the `Membership` row backed by the legacy profile role.
- Rename `Member since` to `Account created`.
- Remove the role-dependent admin/dues-upgrade promise.
- Show one fixed membership-unavailable notice for pending, member-role, and admin-role profiles.
- Preserve email verification, resend cooldown/truth, profile recovery and editing, phone pause, registrations, Strava, sign-out, and verified-role projection.

## Invariants and compatibility

- No role, claim, authorization, membership record, term, entitlement, payment, profile schema, write, provider link, or registration changes.
- No migration or backfill is needed because stored data is unchanged.
- #208 remains the provider-neutral membership authority truth; #114/#115 retain future annual membership and activation work.
- #219 owns a separate race-signup section in the shared officer guide; this PR changes only the separately named #221 section.

## Verification

Red proof before implementation:

- Focused Account suite failed exactly 3 new role cases because `Account created` was absent and the legacy membership projection remained.

Green proof on Node 20:

- Focused Account: 17/17
- Full frontend: 11 suites, 235/235
- Frontend lint baseline: 104 files; unchanged 125 reviewed errors and 7 reviewed warnings
- SPA navigation: 11/11
- Diagnostic production build: compiled successfully
- `git diff --check`: passed
- Three independent exact-commit reviews passed for membership/security, UI/tests/accessibility, and officer continuity/coordination at `4a68215b83aa95cc9892c5bf49d7ad8f4f7b09c2`

Hosted CI and any later publication evidence remain pending.
