### PR TITLE
OAUTH-001C1A: redact Strava authorization-exchange failures

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -7,6 +7,11 @@ const STRAVA_TOKEN_URL = 'https://www.strava.com/api/v3/oauth/token';
 const STRAVA_DEAUTH_URL = 'https://www.strava.com/oauth/deauthorize';
 const STRAVA_ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities';
 const STRAVA_STATS_URL = (id) => `https://www.strava.com/api/v3/athletes/${id}/stats`;
+const STRAVA_AUTHORIZATION_ERROR_MESSAGE = 'Strava authorization could not be completed.';
+
+function stravaAuthorizationError(code) {
+  return new functions.https.HttpsError(code, STRAVA_AUTHORIZATION_ERROR_MESSAGE);
+}
 
 function getStravaCreds() {
   const clientId = process.env.STRAVA_CLIENT_ID;
@@ -34,24 +39,29 @@ function secretDocRef(uid) {
 
 async function exchangeCode(code) {
   const { clientId, clientSecret } = getStravaCreds();
-  const resp = await fetch(STRAVA_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      client_id: clientId,
-      client_secret: clientSecret,
-      code,
-      grant_type: 'authorization_code',
-    }),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new functions.https.HttpsError(
-      'invalid-argument',
-      `Strava token exchange failed: ${resp.status} ${text.slice(0, 200)}`,
-    );
+  let resp;
+  try {
+    resp = await fetch(STRAVA_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        grant_type: 'authorization_code',
+      }),
+    });
+  } catch (_error) {
+    throw stravaAuthorizationError('unavailable');
   }
-  return resp.json();
+  if (!resp || resp.ok !== true) {
+    throw stravaAuthorizationError('invalid-argument');
+  }
+  try {
+    return await resp.json();
+  } catch (_error) {
+    throw stravaAuthorizationError('unavailable');
+  }
 }
 
 async function refreshToken(refresh) {

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -1,0 +1,285 @@
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message) {
+      super(message);
+      this.code = code;
+    }
+  }
+
+  const https = {
+    onCall: (handler) => handler,
+    HttpsError,
+  };
+
+  return {
+    runWith: () => ({ https }),
+    https,
+  };
+});
+
+jest.mock('firebase-admin', () => {
+  const writes = [];
+
+  function document(path) {
+    return {
+      collection: (name) => ({
+        doc: (id) => document(`${path}/${name}/${id}`),
+      }),
+      set: async (data, options) => {
+        writes.push({ path, data, options });
+      },
+    };
+  }
+
+  return {
+    firestore: () => ({
+      collection: (name) => ({
+        doc: (id) => document(`${name}/${id}`),
+      }),
+    }),
+    __clearWrites: () => writes.splice(0, writes.length),
+    __getWrites: () => [...writes],
+  };
+});
+
+jest.mock('firebase-admin/firestore', () => {
+  let tick = 1_800_000_000;
+  return {
+    Timestamp: {
+      now: () => ({ _seconds: tick += 1 }),
+    },
+  };
+});
+
+jest.mock('./stripeHelpers', () => ({
+  requireAppCheck: jest.fn(),
+}));
+
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const { requireAppCheck } = require('./stripeHelpers');
+const { stravaExchangeCode } = require('./strava');
+
+const FIXED_AUTHORIZATION_ERROR = 'Strava authorization could not be completed.';
+const GUARDED_FETCH = global.fetch;
+const CONTEXT = Object.freeze({
+  app: Object.freeze({ appId: 'synthetic-app-check' }),
+  auth: Object.freeze({ uid: 'synthetic-member-000001' }),
+});
+const CODE = 'synthetic_authorization_code';
+
+function publicError(error) {
+  return {
+    code: error?.code,
+    message: error?.message,
+    details: error?.details,
+    cause: error?.cause,
+  };
+}
+
+async function captureFailure(action) {
+  try {
+    await action();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected Strava exchange to fail.');
+}
+
+describe('Strava authorization exchange failure boundary', () => {
+  let fetchMock;
+  let consoleSpies;
+
+  beforeEach(() => {
+    process.env.STRAVA_CLIENT_ID = 'strava_client_test';
+    process.env.STRAVA_CLIENT_SECRET = 'strava_secret_test';
+    admin.__clearWrites();
+    requireAppCheck.mockReset();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  });
+
+  afterEach(() => {
+    global.fetch = GUARDED_FETCH;
+    consoleSpies.forEach((spy) => spy.mockRestore());
+    delete process.env.STRAVA_CLIENT_ID;
+    delete process.env.STRAVA_CLIENT_SECRET;
+  });
+
+  function expectNoSideEffects() {
+    expect(admin.__getWrites()).toEqual([]);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  }
+
+  test('runs App Check before Auth, provider exchange, or Firestore', async () => {
+    const appCheckFailure = new functions.https.HttpsError(
+      'failed-precondition',
+      'synthetic app check rejection',
+    );
+    requireAppCheck.mockImplementationOnce(() => {
+      throw appCheckFailure;
+    });
+
+    await expect(stravaExchangeCode({ code: CODE }, CONTEXT)).rejects.toBe(appCheckFailure);
+
+    expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expectNoSideEffects();
+  });
+
+  test('rejects a missing caller before provider exchange or Firestore', async () => {
+    await expect(stravaExchangeCode({ code: CODE }, { ...CONTEXT, auth: null }))
+      .rejects.toMatchObject({ code: 'unauthenticated' });
+
+    expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expectNoSideEffects();
+  });
+
+  test('rejects a missing code before credentials, provider exchange, or Firestore', async () => {
+    delete process.env.STRAVA_CLIENT_ID;
+    delete process.env.STRAVA_CLIENT_SECRET;
+
+    await expect(stravaExchangeCode({}, CONTEXT))
+      .rejects.toMatchObject({ code: 'invalid-argument' });
+
+    expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expectNoSideEffects();
+  });
+
+  test('does not read or expose a failed provider response body or status', async () => {
+    const text = jest.fn().mockResolvedValue(
+      'provider-body-canary refresh_token=provider-secret-canary',
+    );
+    const json = jest.fn();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 599,
+      text,
+      json,
+    });
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'invalid-argument',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/599|provider-body-canary|provider-secret-canary/i);
+    expect(text).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expectNoSideEffects();
+  });
+
+  test('turns a transport failure into one fixed unavailable result', async () => {
+    fetchMock.mockRejectedValue(Object.assign(
+      new Error('transport-canary https://provider.example.test/?code=secret-canary'),
+      { providerBody: 'provider-body-canary' },
+    ));
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/transport-canary|provider\.example|secret-canary|provider-body-canary/i);
+    expectNoSideEffects();
+  });
+
+  test('turns malformed provider JSON into one fixed unavailable result', async () => {
+    const json = jest.fn().mockRejectedValue(
+      new Error('json-canary access_token=provider-secret-canary'),
+    );
+    fetchMock.mockResolvedValue({ ok: true, json });
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/json-canary|provider-secret-canary/i);
+    expect(json).toHaveBeenCalledTimes(1);
+    expectNoSideEffects();
+  });
+
+  test('preserves the successful server-only exchange, writes, and minimal result', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        access_token: 'access_token_test',
+        refresh_token: 'refresh_token_test',
+        expires_at: 1_900_000_000,
+        scope: 'read',
+        athlete: {
+          id: 123456,
+          firstname: 'Synthetic',
+          lastname: 'Athlete',
+          username: 'synthetic-athlete',
+          profile: 'https://images.example.test/synthetic-athlete.png',
+        },
+      }),
+    });
+
+    const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+    expect(result).toEqual({ ok: true, athleteId: 123456 });
+    expect(requireAppCheck.mock.invocationCallOrder[0])
+      .toBeLessThan(fetchMock.mock.invocationCallOrder[0]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.strava.com/api/v3/oauth/token',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: 'strava_client_test',
+          client_secret: 'strava_secret_test',
+          code: CODE,
+          grant_type: 'authorization_code',
+        }),
+      },
+    );
+    expect(admin.__getWrites()).toEqual([
+      {
+        path: 'members/synthetic-member-000001/secrets/strava',
+        data: {
+          access_token: 'access_token_test',
+          refresh_token: 'refresh_token_test',
+          expires_at: 1_900_000_000,
+          scope: 'read',
+          updatedAt: expect.any(Object),
+        },
+        options: { merge: true },
+      },
+      {
+        path: 'members/synthetic-member-000001/connections/strava',
+        data: {
+          provider: 'strava',
+          athleteId: 123456,
+          firstName: 'Synthetic',
+          lastName: 'Athlete',
+          username: 'synthetic-athlete',
+          profileUrl: 'https://images.example.test/synthetic-athlete.png',
+          connectedAt: expect.any(Object),
+          updatedAt: expect.any(Object),
+        },
+        options: { merge: true },
+      },
+    ]);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Outcome

The Strava authorization exchange no longer reads or exposes a failed provider response body or status. HTTP, transport, and malformed-JSON failures now return fixed non-identifying callable errors and perform no log or Firestore write.

Closes #223. Canonical parent #88 remains open; this does not complete OAUTH-001C.

Officer impact: Members will receive one fixed failure result if server-side Strava authorization cannot complete. Officers gain no new task, access, or provider procedure.

Officer documentation: None — this atomic server-error redaction changes no officer procedure, permission, collected field, provider operation, or public content. Existing canonical #88/security documentation remains accurate because callback/state, refresh, scope, revoke, storage, deployment, and provider work stays open.

Deployment evidence: Functions source and synthetic tests changed only. Firebase was not deployed, Strava was not called or configured, no website was published, no production data or migration was touched, and no live behavior is claimed.

## Change

- Stop calling `resp.text()` for failed authorization exchanges.
- Keep HTTP non-success as fixed `invalid-argument` without status/body/details.
- Convert fetch rejection and successful-response JSON-decoding rejection to fixed `unavailable` without cause/details.
- Preserve App Check → Auth → input → credentials/provider order.
- Preserve the successful request shape, server-only secret/connection writes, and minimal `{ ok, athleteId }` result.

## Security and compatibility

- Provider status/body, error causes, URLs, tokens, and canaries cannot enter the callable result, console, or Firestore on the covered failure paths.
- Tests replace `global.fetch`, mock Firebase Admin/Functions, and restore the repository's network guard after every case; no real Strava or Firebase endpoint can be reached.
- No schema, successful response, role, membership, authorization, package, Rules, index, frontend, or deployment change.
- No migration or backfill is needed.
- Residual #88 work remains: code/state bounds and one-use state, token/scope/account validation, native App Check handoff, refresh redaction/concurrency, disconnect/revoke/audit, encryption/IAM, provider configuration/capacity, deployment, and live proof.

## Verification

Red proof against the base:

- Exactly 3 new cases failed: the old code embedded HTTP 599/body canaries and propagated raw transport and JSON errors.

Green proof on Node 20:

- Focused Strava tests: 7/7
- Final rebased full Functions suite: 25 suites / 1,460 applicable tests; 2 emulator suites / 39 tests intentionally skipped in the pure run
- Functions lint: passed
- Demo Firestore member-profile emulator: 1/1
- Demo Firestore commerce-journal emulator: 38/38
- `git diff --check`: passed
- Final head `51e46b34e0a71bf2976d34dd4fb1bbd8bec773b4` is a clean child of released #219 main `c7156a025defe2e4a66766d59fd579f3dd1bee15`
- Stable patch ID remained `32d8ee98822b89e2c370ad5bf8bf096f1e903906` across the rebase
- Three independent final exact-head reviews passed: security/redaction, tests/network isolation, and scope/coordination

Hosted CI remains pending.
