### PR TITLE
OAUTH-001A2: Redact Strava activity-data failures

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -9,6 +9,7 @@ const STRAVA_ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities'
 const STRAVA_STATS_URL = (id) => `https://www.strava.com/api/v3/athletes/${id}/stats`;
 const STRAVA_AUTHORIZATION_ERROR_MESSAGE = 'Strava authorization could not be completed.';
 const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.';
+const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
 
 function stravaAuthorizationError(code) {
   return new functions.https.HttpsError(code, STRAVA_AUTHORIZATION_ERROR_MESSAGE);
@@ -16,6 +17,10 @@ function stravaAuthorizationError(code) {
 
 function stravaRefreshError(code) {
   return new functions.https.HttpsError(code, STRAVA_REFRESH_ERROR_MESSAGE);
+}
+
+function stravaDataError(code) {
+  return new functions.https.HttpsError(code, STRAVA_DATA_ERROR_MESSAGE);
 }
 
 function getStravaCreds() {
@@ -174,16 +179,34 @@ exports.stravaFetchStats = functions
 
     const headers = { Authorization: `Bearer ${token}` };
 
-    const [activitiesResp, statsResp] = await Promise.all([
-      fetch(`${STRAVA_ACTIVITIES_URL}?per_page=5`, { headers }),
-      conn.athleteId ? fetch(STRAVA_STATS_URL(conn.athleteId), { headers }) : null,
-    ]);
-
-    if (!activitiesResp.ok) {
-      throw new functions.https.HttpsError('internal', `Strava activities: ${activitiesResp.status}`);
+    let activitiesResp;
+    let statsResp;
+    try {
+      [activitiesResp, statsResp] = await Promise.all([
+        fetch(`${STRAVA_ACTIVITIES_URL}?per_page=5`, { headers }),
+        conn.athleteId ? fetch(STRAVA_STATS_URL(conn.athleteId), { headers }) : null,
+      ]);
+    } catch (_error) {
+      throw stravaDataError('unavailable');
     }
-    const activities = await activitiesResp.json();
-    const stats = statsResp && statsResp.ok ? await statsResp.json() : null;
+
+    if (!activitiesResp || !activitiesResp.ok) {
+      throw stravaDataError('internal');
+    }
+    let activities;
+    try {
+      activities = await activitiesResp.json();
+    } catch (_error) {
+      throw stravaDataError('unavailable');
+    }
+    let stats = null;
+    if (statsResp && statsResp.ok) {
+      try {
+        stats = await statsResp.json();
+      } catch (_error) {
+        throw stravaDataError('unavailable');
+      }
+    }
 
     return {
       connected: true,

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -76,6 +76,7 @@ const { stravaExchangeCode, stravaFetchStats } = require('./strava');
 
 const FIXED_AUTHORIZATION_ERROR = 'Strava authorization could not be completed.';
 const FIXED_REFRESH_ERROR = 'Strava connection could not be refreshed.';
+const FIXED_DATA_ERROR = 'Strava activity data could not be loaded.';
 const GUARDED_FETCH = global.fetch;
 const CONTEXT = Object.freeze({
   app: Object.freeze({ appId: 'synthetic-app-check' }),
@@ -579,5 +580,259 @@ describe('Strava token refresh failure boundary', () => {
       options: { merge: true },
     }]);
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});
+
+describe('Strava activity data failure boundary', () => {
+  let fetchMock;
+  let consoleSpies;
+
+  const CONNECTION = Object.freeze({
+    provider: 'strava',
+    athleteId: 123456,
+    firstName: 'Synthetic',
+    lastName: 'Athlete',
+    username: 'synthetic-athlete',
+    profileUrl: 'https://images.example.test/synthetic-athlete.png',
+  });
+  const FRESH_SECRET = Object.freeze({
+    access_token: 'fresh_access_token_test',
+    refresh_token: 'synthetic_refresh_token_test',
+    expires_at: 4_102_444_800,
+    scope: 'read',
+  });
+
+  beforeEach(() => {
+    process.env.STRAVA_CLIENT_ID = 'strava_client_test';
+    process.env.STRAVA_CLIENT_SECRET = 'strava_secret_test';
+    admin.__clearDocuments();
+    admin.__clearReads();
+    admin.__clearWrites();
+    requireAppCheck.mockReset();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  });
+
+  afterEach(() => {
+    global.fetch = GUARDED_FETCH;
+    consoleSpies.forEach((spy) => spy.mockRestore());
+    delete process.env.STRAVA_CLIENT_ID;
+    delete process.env.STRAVA_CLIENT_SECRET;
+  });
+
+  function seedFreshConnection() {
+    admin.__setDocument(CONNECTION_PATH, CONNECTION);
+    admin.__setDocument(SECRET_PATH, FRESH_SECRET);
+  }
+
+  function expectTwoFreshBearerReads() {
+    const headers = { Authorization: 'Bearer fresh_access_token_test' };
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://www.strava.com/api/v3/athlete/activities?per_page=5',
+      { headers },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://www.strava.com/api/v3/athletes/123456/stats',
+      { headers },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  }
+
+  function expectNoWritesOrLogs() {
+    expect(admin.__getWrites()).toEqual([]);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  }
+
+  test('does not read or expose a failed activities response body or status', async () => {
+    seedFreshConnection();
+    const text = jest.fn().mockResolvedValue(
+      'provider-body-canary access_token=provider-secret-canary',
+    );
+    const activitiesJson = jest.fn();
+    const statsJson = jest.fn().mockResolvedValue({});
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 599,
+        text,
+        json: activitiesJson,
+      })
+      .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+    const error = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'internal',
+      message: FIXED_DATA_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/599|provider-body-canary|provider-secret-canary/i);
+    expect(text).not.toHaveBeenCalled();
+    expect(activitiesJson).not.toHaveBeenCalled();
+    expect(statsJson).not.toHaveBeenCalled();
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
+  });
+
+  test('turns an activities transport failure into one fixed unavailable result', async () => {
+    seedFreshConnection();
+    fetchMock
+      .mockRejectedValueOnce(Object.assign(
+        new Error('activities-transport-canary https://provider.example.test/?token=secret-canary'),
+        { providerBody: 'provider-body-canary' },
+      ))
+      .mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue({}) });
+
+    const error = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_DATA_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/transport-canary|provider\.example|secret-canary|provider-body-canary/i);
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
+  });
+
+  test('turns a statistics transport failure into one fixed unavailable result', async () => {
+    seedFreshConnection();
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue([]) })
+      .mockRejectedValueOnce(Object.assign(
+        new Error('stats-transport-canary https://provider.example.test/?token=secret-canary'),
+        { providerBody: 'provider-body-canary' },
+      ));
+
+    const error = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_DATA_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/transport-canary|provider\.example|secret-canary|provider-body-canary/i);
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
+  });
+
+  test('turns malformed activities JSON into one fixed unavailable result', async () => {
+    seedFreshConnection();
+    const activitiesJson = jest.fn().mockRejectedValue(
+      new Error('activities-json-canary access_token=provider-secret-canary'),
+    );
+    const statsJson = jest.fn().mockResolvedValue({});
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: activitiesJson })
+      .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+    const error = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_DATA_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/json-canary|provider-secret-canary/i);
+    expect(activitiesJson).toHaveBeenCalledTimes(1);
+    expect(statsJson).not.toHaveBeenCalled();
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
+  });
+
+  test('turns malformed statistics JSON into one fixed unavailable result', async () => {
+    seedFreshConnection();
+    const activitiesJson = jest.fn().mockResolvedValue([]);
+    const statsJson = jest.fn().mockRejectedValue(
+      new Error('stats-json-canary access_token=provider-secret-canary'),
+    );
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: activitiesJson })
+      .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+    const error = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_DATA_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(publicError(error)))
+      .not.toMatch(/json-canary|provider-secret-canary/i);
+    expect(activitiesJson).toHaveBeenCalledTimes(1);
+    expect(statsJson).toHaveBeenCalledTimes(1);
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
+  });
+
+  test('preserves recent activities when optional statistics HTTP access fails', async () => {
+    seedFreshConnection();
+    const activitiesJson = jest.fn().mockResolvedValue([{
+      id: 987654,
+      name: 'Synthetic Morning Run',
+      sport_type: 'Run',
+      distance: 5000,
+      moving_time: 1500,
+      start_date: '2026-01-02T12:00:00Z',
+    }]);
+    const statsText = jest.fn().mockResolvedValue(
+      'provider-body-canary access_token=provider-secret-canary',
+    );
+    const statsJson = jest.fn();
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: activitiesJson })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 599,
+        text: statsText,
+        json: statsJson,
+      });
+
+    const result = await stravaFetchStats({}, CONTEXT);
+
+    expect(result).toEqual({
+      connected: true,
+      athlete: {
+        id: 123456,
+        firstName: 'Synthetic',
+        lastName: 'Athlete',
+        username: 'synthetic-athlete',
+        profileUrl: 'https://images.example.test/synthetic-athlete.png',
+      },
+      recentActivities: [{
+        id: 987654,
+        name: 'Synthetic Morning Run',
+        type: 'Run',
+        distanceMeters: 5000,
+        movingTimeSeconds: 1500,
+        startDate: '2026-01-02T12:00:00Z',
+      }],
+      yearToDate: null,
+      allTime: null,
+    });
+    expect(activitiesJson).toHaveBeenCalledTimes(1);
+    expect(statsText).not.toHaveBeenCalled();
+    expect(statsJson).not.toHaveBeenCalled();
+    expectTwoFreshBearerReads();
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+    expectNoWritesOrLogs();
   });
 });


### PR DESCRIPTION
Closes #233

Parent tracker: #88

Officer impact: Members receive one fixed, plain failure result when Strava activity/stat data cannot be loaded. Officers gain no new Strava task, access, or provider procedure.

Officer documentation: None — this atomic server-error redaction changes no officer procedure, permission, collected field, provider operation, or public content. Canonical #88 remains open for the full lifecycle.

Deployment evidence: Source and synthetic tests only at PR creation. No website publication, Firebase deployment, Strava configuration or call, provider action, production-data action, migration, or live-behavior proof occurred. Merge and hosted CI do not prove Firebase or Strava behavior is live.

## Outcome

The existing `stravaFetchStats` provider boundary no longer exposes an activities HTTP status or passes raw activities/stats transport and successful-response JSON exceptions to the Firebase Functions wrapper. Activities HTTP non-success preserves the `internal` code with one fixed message. Transport and JSON failures become fixed `unavailable` errors.

Optional stats HTTP non-success still returns recent activities with null totals. The two concurrent bearer GETs and every successful result projection are unchanged.

## Invariants and failure cases

- App Check, Auth, connection/secret reads, and token selection/refresh remain before provider data access.
- With a fresh token, every tested data failure makes exactly two bearer GETs, no refresh POST, no Firestore write, and no console call.
- Failed activities and optional-stats response bodies are never read.
- Provider status, body, URL, access token, exception, cause, and details do not enter the handler error, console, or Firestore.
- Activities HTTP failure remains fixed `internal`; fetch and JSON failures are fixed `unavailable`.
- Optional stats HTTP failure preserves the existing partial-success result and unread body.
- An expired-token path may still complete the pre-existing #229 refresh write before a later data-read failure; this PR does not change or misstate that behavior.
- Tests use only synthetic fixtures, mocked fetch, mocked Admin SDK, and the repository network guard.

## Red/green proof

Before the implementation change, the focused suite had 16 passing tests and exactly 5 intended failures:

1. Activities HTTP status was exposed.
2. Activities transport error escaped raw.
3. Statistics transport error escaped raw.
4. Activities JSON error escaped raw.
5. Statistics JSON error escaped raw.

The optional-statistics HTTP compatibility test already passed before the change.

After the change on exact main `a7eb4ceea3676e3572fa76d5232703def15392ee`:

- `npm --prefix functions run test:run -- strava.test.js --runInBand`: 21/21 passed.
- `npm --prefix functions run lint`: passed.
- `npm --prefix functions run test:run -- --runInBand`: 1,488 passed; 47 existing conditional/emulator tests skipped.
- `git diff --check`: passed.
- Three independent exact-diff reviews passed: security/framework logging, deterministic test scope, and old/new compatibility.

Commands ran with Node 20.20.2. No real Firebase project or Strava endpoint was used.

## Compatibility and residual risk

No schema, API success shape, migration, or production-data action changes. Active #232 owns disjoint commerce/tests/named C4A documentation paths and remains immutable.

Still open under #88: transaction/version-safe concurrent refresh; token/scope/account and decoded-response-shape validation; bounded one-use callback state/code; native App Check handoff; disconnect/revoke and durable redacted audit; remaining Firestore/disconnect error surfaces; encryption/IAM; provider capacity/configuration; Firebase deployment; and live proof.
