### PR TITLE
OAUTH-001A2B: redact Strava activity-load browser failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -423,6 +423,40 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Strava activity failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a signed-in member one plain next step when My Account cannot load Strava activity, without showing a provider or technical error.
+
+**Approver:** membership lead plus platform/security owner.
+
+**Prerequisites:** issue [#250](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/250) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com`. This source change does not deploy Firebase, contact Strava, change provider settings, use production data, or prove live behavior.
+
+Officer review steps after the source merge:
+
+1. Keep the activity-failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #250 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up connection, made-up activity, and mocked service results.
+4. Confirm a made-up stats rejection shows `We could not load your Strava activity right now. Please try again later.`
+5. Confirm the connected athlete remains visible and the loading sentence stops.
+6. Confirm no made-up provider detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a successful made-up result still shows the existing activity and totals.
+9. Record website publication, `runmprc.com`, Firebase, Strava, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for a stats-load rejection. It does not inspect, display, or log the rejected value. Existing connection display and successful activity projection stay in place. Disconnect failures are separate work and are not made safe by this source slice.
+
+**Stop conditions:** any real member or Strava account; a request for a token, provider error, private account detail, or screenshot containing private values; a real provider call; a production Firebase or Strava change; a raw detail on the page or in the console; or a claim that source, tests, merge, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #250 issue, reviewed pull request, merged commit, intended old-source failure, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated `runmprc.com` check using no real account. Record Firebase deployment, Strava/provider configuration, and production-data actions as **not performed** for this frontend-only change.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com`. Do not undo by changing a member account, Firebase record, or Strava setting.
+
+**Escalation:** membership lead plus platform/security owner. Add the privacy owner and use the private incident path if any provider or technical detail appeared. Do not copy the detail into an issue, message, screenshot, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -18,7 +18,9 @@ import {
   updateMyProfile,
 } from '../../services/account/accountService';
 import {
+  getStravaConnection,
   stravaExchangeCode,
+  stravaFetchStats,
   verifyStravaState,
 } from '../../services/strava/stravaService';
 import { AccountContent } from './Account';
@@ -32,10 +34,16 @@ jest.mock('../../services/hooks/useAuth', () => ({
   useAuth: jest.fn(),
 }));
 
-jest.mock('../../services/strava/stravaService', () => ({
-  stravaExchangeCode: jest.fn(),
-  verifyStravaState: jest.fn(),
-}));
+jest.mock('../../services/strava/stravaService', () => {
+  const actual = jest.requireActual('../../services/strava/stravaService');
+  return {
+    ...actual,
+    getStravaConnection: jest.fn(),
+    stravaExchangeCode: jest.fn(),
+    stravaFetchStats: jest.fn(),
+    verifyStravaState: jest.fn(),
+  };
+});
 
 jest.mock('../../services/account/accountService', () => {
   const actual = jest.requireActual('../../services/account/accountService');
@@ -55,6 +63,8 @@ jest.mock('../../components/SEO', () => function SEO() {
 jest.mock('./StravaSection', () => function StravaSection() {
   return <div data-testid="strava-section" />;
 });
+
+const ActualStravaSection = jest.requireActual('./StravaSection').default;
 
 const USER = {
   uid: 'synthetic-user',
@@ -78,6 +88,46 @@ const app = { name: 'synthetic-app' };
 const firestore = { name: 'synthetic-firestore' };
 const signOut = jest.fn();
 const resendVerificationEmail = jest.fn();
+
+const STRAVA_CONNECTION = {
+  provider: 'strava' as const,
+  athleteId: 123456,
+  firstName: 'Synthetic',
+  lastName: 'Athlete',
+  username: 'synthetic-athlete',
+  profileUrl: null,
+  connectedAt: null,
+  updatedAt: null,
+};
+
+const STRAVA_STATS = {
+  connected: true as const,
+  athlete: {
+    id: 123456,
+    firstName: 'Synthetic',
+    lastName: 'Athlete',
+    username: 'synthetic-athlete',
+    profileUrl: null,
+  },
+  recentActivities: [{
+    id: 987654,
+    name: 'Synthetic Morning Run',
+    type: 'Run',
+    distanceMeters: 8046.72,
+    movingTimeSeconds: 2700,
+    startDate: '2026-07-13T14:00:00Z',
+  }],
+  yearToDate: {
+    runMeters: 16093.44,
+    runCount: 2,
+    rideMeters: 0,
+    rideCount: 0,
+  },
+  allTime: {
+    runMeters: 32186.88,
+    runCount: 4,
+  },
+};
 
 function accountView(user = USER) {
   return (
@@ -477,6 +527,106 @@ describe('Account profile recovery', () => {
     const css = readFileSync(join(__dirname, 'Account.css'), 'utf8');
     expect(css).toMatch(/\.verification-resend__button\s*\{[\s\S]*min-height:\s*3rem;/);
     expect(css).toMatch(/\.verification-resend__button:focus-visible\s*\{[\s\S]*outline:/);
+  });
+});
+
+const STRAVA_ACTIVITY_FAILURE = 'We could not load your Strava activity right now. Please try again later.';
+
+function renderActualStravaSection() {
+  return render(<ActualStravaSection uid={USER.uid} />);
+}
+
+describe('Strava activity browser failure boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useServiceLocator as jest.Mock).mockReturnValue({
+      services: { firebaseResources: { app, firestore } },
+      isReady: true,
+    });
+    (getStravaConnection as jest.Mock).mockResolvedValue(STRAVA_CONNECTION);
+    (stravaFetchStats as jest.Mock).mockResolvedValue(STRAVA_STATS);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('waits for the connection before requesting stats once', async () => {
+    let resolveConnection: ((connection: typeof STRAVA_CONNECTION) => void) | undefined;
+    (getStravaConnection as jest.Mock).mockReturnValueOnce(
+      new Promise<typeof STRAVA_CONNECTION>((resolve) => {
+        resolveConnection = resolve;
+      }),
+    );
+
+    renderActualStravaSection();
+
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledWith(firestore, USER.uid));
+    expect(stravaFetchStats).not.toHaveBeenCalled();
+
+    await act(async () => resolveConnection?.(STRAVA_CONNECTION));
+
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledWith(app));
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+
+  test('replaces rejected stats details with one fixed actionable alert', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method as any).mockImplementation(() => undefined));
+    (stravaFetchStats as jest.Mock).mockRejectedValueOnce(Object.assign(
+      new Error('provider-private-canary member@example.test'),
+      {
+        code: 'functions/provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=secret-canary',
+      },
+    ));
+
+    renderActualStravaSection();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(STRAVA_ACTIVITY_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).toHaveTextContent('Synthetic Athlete');
+    expect(document.body).not.toHaveTextContent(
+      /provider-private-canary|member@example\.test|provider\.example|secret-canary/i,
+    );
+    expect(screen.queryByText('Loading recent activity...')).not.toBeInTheDocument();
+    expect(getStravaConnection).toHaveBeenCalledWith(firestore, USER.uid);
+    expect(stravaFetchStats).toHaveBeenCalledWith(app);
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the successful activity projection', async () => {
+    renderActualStravaSection();
+
+    expect(await screen.findByText('Synthetic Morning Run')).toBeInTheDocument();
+    expect(screen.getByText('Runs this year')).toBeInTheDocument();
+    expect(screen.getByText('All-time runs')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(stravaFetchStats).toHaveBeenCalledWith(app);
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not inspect a hostile stats rejection', async () => {
+    const messageGetter = jest.fn(() => {
+      throw new Error('message-getter-canary');
+    });
+    (stravaFetchStats as jest.Mock).mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderActualStravaSection();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(STRAVA_ACTIVITY_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('message-getter-canary');
+    expect(screen.queryByText('Loading recent activity...')).not.toBeInTheDocument();
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pages/account/StravaSection.tsx
+++ b/src/pages/account/StravaSection.tsx
@@ -44,7 +44,7 @@ function Connected({
       </div>
 
       {loading && <p className="text-sm text-gray-600 mt-3">Loading recent activity...</p>}
-      {error && <p className="text-sm text-red-600 mt-3">{error}</p>}
+      {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-red-600 mt-3">{error}</p>}
 
       {stats?.yearToDate && (
         <div className="grid grid-cols-2 gap-3 mt-3">
@@ -143,7 +143,7 @@ function StravaSection({ uid }: { uid: string }) {
     setLoadingStats(true);
     stravaFetchStats(services.firebaseResources.app)
       .then((s) => { setStats(s); setLoadingStats(false); })
-      .catch((err) => { setError(err?.message || 'Failed to load Strava stats'); setLoadingStats(false); });
+      .catch(() => { setError('We could not load your Strava activity right now. Please try again later.'); setLoadingStats(false); });
   }, [services, conn]);
 
   function handleConnect() {


### PR DESCRIPTION
## Outcome

My Account now treats a rejected Strava stats value as opaque and shows one fixed retry-later alert. It no longer reads or renders the rejection's `message`, and successful activity display remains unchanged.

Closes #250. Canonical parent #88 remains open.

## Privacy and behavior invariant

- The connection resolves before exactly one stats request.
- A rejection is not read, retained, coerced, stringified, or logged.
- Failure ends loading and shows only: `We could not load your Strava activity right now. Please try again later.`
- The sentence is an atomic assertive alert; the connected athlete remains visible.
- A successful synthetic result still renders recent activity and totals.

## Proof

- Intended old-source red: focused suite was 28 pass / 1 intended failure. The old page rendered `provider-private-canary member@example.test` and had no fixed alert.
- Focused Account suite: 31/31 PASS, including deferred connection ordering, ordinary canary redaction, hostile throwing `message` getter non-inspection, five-console silence, loading completion, connected identity, and successful projection.
- Full frontend: 12 suites / 254 tests PASS.
- Frontend lint: unchanged deterministic baseline, 106 files / 123 reviewed errors / 7 warnings.
- TypeScript no-emit check, SPA 11/11, workflow/release/artifact 42/42, production diagnostic build, and `git diff --check`: PASS.
- Independent final reviews: privacy/security PASS; adversarial frontend/accessibility PASS after its deferred-ordering finding was fixed; scope/officer/deployment truth PASS.
- Final pre-commit diff SHA-256: `e773c132171e09b6318d5d94135befcf080e3610fa9d22b254876d9fd0d702c7`.

All Firebase and Strava behavior in tests is mocked. No provider or production network path ran.

## Residual risk and migration

Migration impact: none. No stored data, schema, permission, or provider behavior changes.

Explicitly excluded and still unsafe: the existing browser disconnect catch can render a raw rejection message. It remains a separately claimable OAUTH-001B browser child. Connection-load recovery, server/provider response validation, callback/state/code/App Check, tokens/scopes/account binding, refresh concurrency, revoke/audit, IAM/encryption, provider setup, deployment, and live verification remain under #88.

## Officer handoff

Officer impact: members receive one plain retry-later sentence instead of technical/provider detail. Keep it marked source-only until the exact website revision is published and verified.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — added the separately named `Strava activity failure privacy — SOURCE ONLY, NOT LIVE` recognition/evidence section.

Deployment evidence: Source changed and local tests passed. Website publication: not performed. `runmprc.com`: not verified because no website publication occurred. Firebase deployment: not performed. Strava/provider configuration: not changed or verified. Production data/migration: none. Live behavior: not claimed.
