### PR TITLE
OAUTH-001B2: redact ambiguous Strava disconnect browser failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -457,6 +457,43 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Strava disconnect failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a signed-in member one safe next step when My Account cannot confirm a Strava disconnect, without showing a provider or technical error or guessing whether the disconnect completed.
+
+**Approver:** membership lead plus platform/security owner.
+
+**Prerequisites:** issue [#252](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/252) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com`. This source change does not deploy Firebase, contact Strava, change provider settings, revoke access, use production data, or prove live behavior.
+
+Officer review steps after the source merge:
+
+1. Keep the disconnect-failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #252 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up connection, made-up activity, a mocked confirmation, and a mocked disconnect result.
+4. Confirm cancelling the browser question sends no disconnect request and shows no failure.
+5. Confirm a made-up rejected request shows `We could not confirm the Strava disconnect. Please refresh this page before trying again.`
+6. Confirm the connected athlete and activity remain visible because the actual result is not known.
+7. Confirm the Disconnect button becomes available again, but the instructions say to refresh before another attempt.
+8. Confirm a later activity-load failure cannot replace the disconnect refresh instruction.
+9. Confirm no made-up provider detail appears on the page or in browser console output.
+10. Confirm a hostile rejected value is not inspected.
+11. Confirm a successful made-up result still changes the page to `Connect Strava` and clears the old activity view.
+12. Record website publication, `runmprc.com`, Firebase, Strava, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed refresh-before-retry sentence for a rejected disconnect request. It does not inspect, display, or log the rejected value, and a later activity-load failure cannot replace that higher-priority instruction. It keeps the current connected view because the result is unknown, ends the busy state, and preserves the existing successful disconnect transition. This source slice does not prove that Strava access was revoked or that a retry is safe.
+
+**Stop conditions:** any real member or Strava account; a request for a token, provider error, private account detail, or screenshot containing private values; a real disconnect or provider call; a production Firebase or Strava change; a raw detail on the page or in the console; an immediate retry without first refreshing; or a claim that source, tests, merge, or a green workflow proves the sentence or disconnect behavior is live.
+
+**Success proof:** for source completion, record the exact #252 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated `runmprc.com` check using no real account. Record Firebase deployment, Strava/provider configuration, revoke actions, and production-data actions as **not performed** for this frontend-only change.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com`. Do not undo by disconnecting an account, changing a member record, editing Firebase, or changing a Strava setting.
+
+**Escalation:** membership lead plus platform/security owner. Add the privacy owner and use the private incident path if any provider or technical detail appeared. If a disconnect result is unclear after refresh, stop and escalate; do not repeat the request. Do not copy private detail into an issue, message, screenshot, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../services/account/accountService';
 import {
   getStravaConnection,
+  stravaDisconnect,
   stravaExchangeCode,
   stravaFetchStats,
   verifyStravaState,
@@ -39,6 +40,7 @@ jest.mock('../../services/strava/stravaService', () => {
   return {
     ...actual,
     getStravaConnection: jest.fn(),
+    stravaDisconnect: jest.fn(),
     stravaExchangeCode: jest.fn(),
     stravaFetchStats: jest.fn(),
     verifyStravaState: jest.fn(),
@@ -627,6 +629,141 @@ describe('Strava activity browser failure boundary', () => {
     expect(document.body).not.toHaveTextContent('message-getter-canary');
     expect(screen.queryByText('Loading recent activity...')).not.toBeInTheDocument();
     expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+});
+
+const STRAVA_DISCONNECT_FAILURE = 'We could not confirm the Strava disconnect. Please refresh this page before trying again.';
+
+describe('Strava disconnect browser failure boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useServiceLocator as jest.Mock).mockReturnValue({
+      services: { firebaseResources: { app, firestore } },
+      isReady: true,
+    });
+    (getStravaConnection as jest.Mock).mockResolvedValue(STRAVA_CONNECTION);
+    (stravaFetchStats as jest.Mock).mockResolvedValue(STRAVA_STATS);
+    (stravaDisconnect as jest.Mock).mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected disconnect details with one fixed refresh-before-retry alert', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method as any).mockImplementation(() => undefined));
+    let rejectDisconnect: ((reason?: unknown) => void) | undefined;
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (stravaDisconnect as jest.Mock).mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectDisconnect = reject;
+    }));
+    const privateFailure = Object.assign(
+      new Error('disconnect-private-canary member@example.test'),
+      {
+        code: 'functions/disconnect-private-canary',
+        endpoint: 'https://provider.example.test/?token=secret-canary',
+      },
+    );
+
+    renderActualStravaSection();
+    expect(await screen.findByText('Synthetic Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    const pendingButton = screen.getByRole('button', { name: 'Disconnecting...' });
+    expect(pendingButton).toBeDisabled();
+    fireEvent.click(pendingButton);
+    expect(stravaDisconnect).toHaveBeenCalledTimes(1);
+    await act(async () => { rejectDisconnect?.(privateFailure); });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(STRAVA_DISCONNECT_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).toHaveTextContent('Synthetic Athlete');
+    expect(document.body).toHaveTextContent('Synthetic Morning Run');
+    expect(document.body).not.toHaveTextContent(
+      /disconnect-private-canary|member@example\.test|provider\.example|secret-canary/i,
+    );
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeEnabled();
+    expect(stravaDisconnect).toHaveBeenCalledWith(app);
+    expect(stravaDisconnect).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect a hostile disconnect rejection', async () => {
+    const messageGetter = jest.fn(() => {
+      throw new Error('disconnect-message-getter-canary');
+    });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (stravaDisconnect as jest.Mock).mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderActualStravaSection();
+    expect(await screen.findByText('Synthetic Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(STRAVA_DISCONNECT_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('disconnect-message-getter-canary');
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeEnabled();
+  });
+
+  test('keeps the disconnect warning when a pending stats request later fails', async () => {
+    let rejectStats: ((reason?: unknown) => void) | undefined;
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (stravaFetchStats as jest.Mock).mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectStats = reject;
+    }));
+    (stravaDisconnect as jest.Mock).mockRejectedValueOnce(
+      new Error('disconnect-priority-canary'),
+    );
+
+    renderActualStravaSection();
+    expect(await screen.findByText('Loading recent activity...')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(STRAVA_DISCONNECT_FAILURE);
+    await act(async () => { rejectStats?.(new Error('stats-priority-canary')); });
+
+    expect(screen.getByRole('alert').textContent).toBe(STRAVA_DISCONNECT_FAILURE);
+    expect(document.body).not.toHaveTextContent(
+      /disconnect-priority-canary|stats-priority-canary/i,
+    );
+    expect(document.body).toHaveTextContent('Synthetic Athlete');
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeEnabled();
+    expect(stravaDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not request a disconnect when confirmation is cancelled', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderActualStravaSection();
+    expect(await screen.findByText('Synthetic Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    expect(stravaDisconnect).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeEnabled();
+  });
+
+  test('preserves the successful disconnect transition', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderActualStravaSection();
+    expect(await screen.findByText('Synthetic Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    expect(await screen.findByRole('button', { name: 'Connect Strava' })).toBeInTheDocument();
+    expect(screen.queryByText('Synthetic Athlete')).not.toBeInTheDocument();
+    expect(screen.queryByText('Synthetic Morning Run')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(stravaDisconnect).toHaveBeenCalledWith(app);
+    expect(stravaDisconnect).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pages/account/StravaSection.tsx
+++ b/src/pages/account/StravaSection.tsx
@@ -129,8 +129,8 @@ function StravaSection({ uid }: { uid: string }) {
   const [loadingConn, setLoadingConn] = useState(true);
   const [loadingStats, setLoadingStats] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [disconnecting, setDisconnecting] = useState(false);
-
   useEffect(() => {
     if (!services) return;
     getStravaConnection(services.firebaseResources.firestore, uid)
@@ -166,8 +166,8 @@ function StravaSection({ uid }: { uid: string }) {
       await stravaDisconnect(services.firebaseResources.app);
       setConn(null);
       setStats(null);
-    } catch (err: any) {
-      setError(err?.message || 'Failed to disconnect');
+    } catch {
+      setDisconnectError('We could not confirm the Strava disconnect. Please refresh this page before trying again.');
     } finally {
       setDisconnecting(false);
     }
@@ -183,7 +183,7 @@ function StravaSection({ uid }: { uid: string }) {
           conn={conn}
           stats={stats}
           loading={loadingStats}
-          error={error}
+          error={disconnectError || error}
           onDisconnect={handleDisconnect}
           disconnecting={disconnecting}
         />


### PR DESCRIPTION
Closes #252
Parent: #88

## Outcome

A rejected Strava disconnect request is now treated as an unknown outcome. My Account shows one fixed refresh-before-retry alert without inspecting, rendering, or logging the rejected value. It preserves the connected athlete and activity view until a refresh re-reads authoritative state.

A dedicated disconnect warning outranks a later activity-load failure, so concurrent failures cannot erase the safer instruction. Cancel and successful disconnect behavior remain unchanged.

## Safety invariant

- rejected provider, callable, SDK, and exception values are untrusted and never inspected
- rejection never claims that revoke or deletion succeeded or failed
- the connected view remains because the result is unknown
- the busy state ends, while a pending request disables repeat activation
- a later stats failure cannot replace the disconnect refresh instruction
- tests use only made-up values and mocks; no Firebase or Strava network access

## Verification

Red proof on old source:
- 33 passed / 2 intended failures
- raw private canary rendered
- hostile `message` getter executed and prevented a safe alert

Final local proof on Node 20:
- focused Account: 36/36
- full frontend: 12 suites / 259 tests
- TypeScript no-emit: passed
- lint safety: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- SPA navigation: 11/11
- workflow, release, Firebase-readback, and artifact safety: 42/42
- diagnostic production build: passed
- `git diff --check`: passed
- exact three-path diff SHA-256: `9ad38d66778169e150264eebce0a9934912b2f3e8c58b987bbeb2662a277f035`
- independent security, frontend/accessibility, and officer/scope reviews: final PASS

## Review-driven correction

Initial independent review found a race in which a pending stats rejection could overwrite the ambiguous-disconnect warning. The issue claim was amended before that area was edited. The final source uses a dedicated disconnect-error state and explicit precedence while leaving the #250 stats catch byte-for-byte unchanged. A deferred-stats regression test proves the correction.

## Scope

Only:
- `src/pages/account/StravaSection.tsx`
- `src/pages/account/Account.test.tsx`
- the separately named #252 section in `docs/officers/EVENTS_SHOP_MEMBERS.md`

Open commerce #249/#246 paths are disjoint and untouched.

Officer impact: Members and officers see one plain refresh-before-retry instruction when a disconnect result cannot be confirmed; the page does not expose technical/provider detail or guess the result.
Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, section `Strava disconnect failure privacy — SOURCE ONLY, NOT LIVE`.
Deployment evidence: None yet. This PR changes source/tests/docs only. No release workflow, website, `runmprc.com`, Firebase, Strava/provider, production-data, migration, revoke, or live-behavior action occurred.

## Residual risk

This slice does not make revoke/delete retry-safe, add durable lifecycle audit, confirm provider revocation, deploy Firebase or the website, or prove live behavior. Those remain under canonical #88.