### PR TITLE
WEB-PRIVACY-001B: redact public product-load failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -528,6 +528,41 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public product-detail load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give any public Shop visitor one plain next step when a product page cannot load, without showing a database, provider, account, or technical error.
+
+**Approver:** communications lead plus platform/security owner.
+
+**Prerequisites:** issue [#256](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/256) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com/shop`. This source change does not deploy Firebase, change database permissions, contact an outside provider, start checkout, use production data, or prove live behavior.
+
+Officer review steps after the source merge:
+
+1. Keep the public product-page failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #256 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up product path, made-up product, and mocked database result.
+4. Confirm a made-up product lookup rejection shows `We could not load this product right now. Please try again later.`
+5. Confirm the loading sentence stops and the **Back to shop** link remains available.
+6. Confirm no made-up database, provider, account, endpoint, or technical detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a missing made-up product still shows the existing not-found result.
+9. Confirm a successful made-up product still shows its title, price, and form without starting checkout.
+10. Record website publication, `runmprc.com/shop`, Firebase, provider, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for a rejected product lookup. It does not inspect, display, or log the rejected value. The failure is announced as an alert, the Back to shop link remains, and missing or successful product results stay distinct.
+
+**Stop conditions:** any real member, customer, order, or private product data; a request for a database or provider error, account detail, private endpoint, or screenshot containing private values; a checkout attempt; a production Firebase or provider change; a raw detail on the page or in the console; an attempt to force a production failure; or a claim that source, tests, merge, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #256 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated `runmprc.com/shop` revision check without forcing an error or starting checkout. Record Firebase deployment, database-permission changes, provider configuration, and production-data actions as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging check proves it.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com/shop`. Do not undo by changing a product, order, member account, database record, permission, or provider setting.
+
+**Escalation:** communications lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, provider, account, endpoint, or technical detail appeared. Do not copy the detail into an issue, message, screenshot, email, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,10 +1,15 @@
 /* eslint-env jest */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
-import { listActiveProducts } from './services/shop/shopService';
+import { getProductBySlug, listActiveProducts } from './services/shop/shopService';
 import App from './App';
 
 jest.mock('./services/ServiceLocatorProvider', () => function TestServiceLocatorProvider({
@@ -21,6 +26,7 @@ jest.mock('./services/shop/shopService', () => {
   const actual = jest.requireActual('./services/shop/shopService');
   return {
     ...actual,
+    getProductBySlug: jest.fn(),
     listActiveProducts: jest.fn(),
   };
 });
@@ -41,6 +47,7 @@ jest.mock('./services/hooks/useAuth', () => ({
 beforeEach(() => {
   useServiceLocator.mockReset();
   useServiceLocator.mockReturnValue({ services: null, isReady: false });
+  getProductBySlug.mockReset();
   listActiveProducts.mockReset();
 });
 
@@ -127,10 +134,16 @@ test('renders the Auth action route and removes its query and fragment before us
 });
 
 const SHOP_LOAD_FAILURE = 'We could not load the shop right now. Please try again later.';
+const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
   window.history.pushState({}, '', '/shop');
+  return render(<App />);
+}
+
+function renderPublicProduct() {
+  window.history.pushState({}, '', '/shop/synthetic-product');
   return render(<App />);
 }
 
@@ -225,5 +238,179 @@ describe('public Shop catalog failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(listActiveProducts).toHaveBeenCalledWith(firestore);
     expect(listActiveProducts).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('public Shop product-load failure boundary', () => {
+  beforeEach(() => {
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    getProductBySlug.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected product details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    getProductBySlug.mockRejectedValueOnce(Object.assign(
+      new Error('product-provider-private-canary member@example.test'),
+      {
+        code: 'firestore/product-provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=product-secret-canary',
+      },
+    ));
+
+    renderPublicProduct();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(PRODUCT_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /product-provider-private-canary|member@example\.test|provider\.example|product-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Product not found')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to shop/ })).toHaveAttribute('href', '/shop');
+    expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
+    expect(getProductBySlug).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile product rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('product-message-getter-canary');
+    });
+    getProductBySlug.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderPublicProduct();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(PRODUCT_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('product-message-getter-canary');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('announces a rejected slug after a product was already loaded', async () => {
+    getProductBySlug
+      .mockResolvedValueOnce({
+        id: 'synthetic-product',
+        slug: 'synthetic-product',
+        title: 'Synthetic Product',
+        description: 'A made-up product used only for this test.',
+        imageUrl: '',
+        priceCents: 3000,
+        status: 'active',
+        sizes: [],
+        colors: [],
+      })
+      .mockRejectedValueOnce(new Error('product-transition-private-canary'));
+
+    renderPublicProduct();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .toBeInTheDocument();
+
+    window.history.pushState({}, '', '/shop/rejected-product');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(PRODUCT_LOAD_FAILURE);
+    expect(screen.queryByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('product-transition-private-canary');
+    expect(getProductBySlug).toHaveBeenNthCalledWith(1, firestore, 'synthetic-product');
+    expect(getProductBySlug).toHaveBeenNthCalledWith(2, firestore, 'rejected-product');
+    expect(getProductBySlug).toHaveBeenCalledTimes(2);
+  });
+
+  test('ignores an older lookup rejection after the current slug loads', async () => {
+    const firstLookup = {};
+    firstLookup.promise = new Promise((resolve, reject) => {
+      firstLookup.resolve = resolve;
+      firstLookup.reject = reject;
+    });
+    getProductBySlug
+      .mockImplementationOnce(() => firstLookup.promise)
+      .mockResolvedValueOnce({
+        id: 'current-product',
+        slug: 'current-product',
+        title: 'Current Product',
+        description: 'A made-up current product used only for this test.',
+        imageUrl: '',
+        priceCents: 4000,
+        status: 'active',
+        sizes: [],
+        colors: [],
+      });
+
+    renderPublicProduct();
+    expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
+
+    window.history.pushState({}, '', '/shop/current-product');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Current Product' }))
+      .toBeInTheDocument();
+
+    await act(async () => {
+      firstLookup.reject(new Error('stale-product-private-canary'));
+      await firstLookup.promise.catch(() => undefined);
+    });
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Current Product' }))
+      .toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('stale-product-private-canary');
+    expect(getProductBySlug).toHaveBeenNthCalledWith(2, firestore, 'current-product');
+    expect(getProductBySlug).toHaveBeenCalledTimes(2);
+  });
+
+  test('preserves the existing missing-product result', async () => {
+    renderPublicProduct();
+
+    expect(await screen.findByText('Product not found')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to shop/ })).toHaveAttribute('href', '/shop');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
+    expect(getProductBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the existing successful product projection and form', async () => {
+    getProductBySlug.mockResolvedValueOnce({
+      id: 'synthetic-product',
+      slug: 'synthetic-product',
+      title: 'Synthetic Product',
+      description: 'A made-up product used only for this test.',
+      imageUrl: '',
+      priceCents: 3000,
+      status: 'active',
+      sizes: [],
+      colors: [],
+    });
+
+    renderPublicProduct();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('$30.00')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('First name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Last name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
+    expect(getProductBySlug).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/shop/ProductDetail.tsx
+++ b/src/pages/shop/ProductDetail.tsx
@@ -30,15 +30,15 @@ function ProductDetail() {
   const [color, setColor] = useState('');
 
   useEffect(() => {
-    if (!isReady || !services || !slug) return;
-    setLoading(true);
+    if (!isReady || !services || !slug) return () => undefined;
+    let active = true; setLoading(true); setProduct(null); setError(null);
     getProductBySlug(services.firebaseResources.firestore, slug)
       .then((p) => {
-        setProduct(p);
-        setLoading(false);
+        if (!active) return;
+        setProduct(p); setLoading(false);
         if (!p) setError('Product not found');
       })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .catch(() => { if (active) { setError('We could not load this product right now. Please try again later.'); setLoading(false); } }); return () => { active = false; };
   }, [services, isReady, slug]);
 
   useEffect(() => {
@@ -50,7 +50,7 @@ function ProductDetail() {
   if (error || !product) {
     return (
       <div className="container mx-auto p-6">
-        <p className="text-red-500">{error || 'Product not found.'}</p>
+        <p role={!product && error ? 'alert' : undefined} aria-live={!product && error ? 'assertive' : undefined} aria-atomic={!product && error ? true : undefined} className="text-red-500">{error || 'Product not found.'}</p>
         <Link to="/shop" className="text-blue-600 hover:underline">← Back to shop</Link>
       </div>
     );


### PR DESCRIPTION
Closes #256

## Outcome

The public `/shop/:slug` route now treats a rejected product read as untrusted. It discards the rejection and shows exactly `We could not load this product right now. Please try again later.` in an assertive atomic alert.

Loading ends on failure. The lookup effect clears stale page state and ignores results from older slugs, so an out-of-order request cannot replace or declassify the current route result. Genuine missing products, successful product displays, and checkout behavior remain unchanged.

## Safety invariant

- never bind, inspect, coerce, render, store, or log a rejected product-lookup value
- show only the fixed source-owned sentence to an anonymous visitor
- do not retain a previous product or error across a new slug lookup
- ignore fulfillment or rejection from an inactive older lookup
- preserve successful, genuine-not-found, and checkout behavior
- tests use only made-up values and mocks with no Firebase or provider network access

## Verification

Old-source red proof:
- 10 passed / 2 intended failures
- the raw private canary reached the public page
- a hostile `message` getter executed and left the page loading

Final local proof on Node 20:
- focused actual-App product route: 14/14
- full frontend: 12 suites / 269 tests
- TypeScript no-emit: passed
- lint safety: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- SPA navigation: 11/11
- workflow, release, Firebase-readback, and artifact safety: 42/42
- diagnostic production build: passed
- `git diff --check`: passed
- exact three-path diff SHA-256: `909de1e935297db09ca0d3e13fc26b7587e81e6ffaeadbaa46e049d1e42597c3`
- independent security/privacy, frontend/lifecycle/accessibility, and officer/scope reviews: PASS

## Scope

Only:
- `src/pages/shop/ProductDetail.tsx`
- `src/App.test.jsx`
- the separately named #256 section in `docs/officers/EVENTS_SHOP_MEMBERS.md`

Open commerce #249/#246 paths are disjoint and untouched. The checkout handler is byte-identical to the claimed base.

Officer impact: Visitors and officers receive one plain retry-later instruction without database, provider, account, endpoint, or technical detail. Older in-flight product reads cannot replace the current page result.
Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, section `Public product-detail load failure privacy — SOURCE ONLY, NOT LIVE`.
Deployment evidence: None yet. This pull request changes source, tests, and documentation only. No release workflow, production website, `runmprc.com`, Firebase, database permissions, provider configuration, production data, migration, checkout, or live-behavior action occurred.

## Residual risk

This source slice does not publish the website, deploy or verify Firebase, change product permissions, configure a provider, or prove live behavior. Those require a separately approved protected release and exact revision checks.
