### PR TITLE
WEB-PRIVACY-001C: redact public Events-list failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -563,6 +563,40 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public Events-list load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give any public Events visitor one plain next step when the event list cannot load, without showing a database, provider, account, endpoint, or technical error.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#258](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/258) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com/events`. This source change does not choose the canonical event source, deploy Firebase, change database permissions, contact an outside provider, change event records, use production data, or prove live behavior.
+
+Officer review steps after the source merge:
+
+1. Keep the public Events-list failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #258 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up event, mocked event subscription, and mocked database reference.
+4. Confirm a made-up subscription rejection announces `Error: We could not load events right now. Please try again later.` as an alert.
+5. Confirm the loading sentence stops and the genuine empty-events sentence does not appear for that failure.
+6. Confirm no made-up database, provider, account, endpoint, or technical detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a genuinely empty made-up event list and a successful made-up public event still use their existing displays, and that the anonymous page does not select the member event list.
+9. Record website publication, `runmprc.com/events`, Firebase, provider, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for an Events-list subscription rejection. It announces that result as an alert and does not inspect, display, or log the rejected value. Loading ends, while successful and genuinely empty public event results remain unchanged. This source slice does not approve an event source, schema, importer, or publication workflow; those owner decisions remain under #121.
+
+**Stop conditions:** any real member, registration, event record, private location, discount, payment, waiver, or contact data; a request for a database or provider error, account detail, private endpoint, or screenshot containing private values; a production Firebase or provider change; a raw detail on the page or in the console; an attempt to force a production failure; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #258 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated `runmprc.com/events` revision check without forcing an error or opening private event data. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, and production-data actions as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging check proves it.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com/events`. Do not undo by changing an event, member account, registration, database record, permission, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, provider, account, endpoint, or technical detail appeared. Do not copy the detail into an issue, message, screenshot, email, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -9,6 +9,7 @@ import {
 } from '@testing-library/react';
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
+import { listMemberEvents, listPublicEvents } from './services/events/eventsService';
 import { getProductBySlug, listActiveProducts } from './services/shop/shopService';
 import App from './App';
 
@@ -31,6 +32,15 @@ jest.mock('./services/shop/shopService', () => {
   };
 });
 
+jest.mock('./services/events/eventsService', () => {
+  const actual = jest.requireActual('./services/events/eventsService');
+  return {
+    ...actual,
+    listMemberEvents: jest.fn(),
+    listPublicEvents: jest.fn(),
+  };
+});
+
 jest.mock('./services/hooks/useAuth', () => ({
   useAuth: () => ({
     user: null,
@@ -49,6 +59,8 @@ beforeEach(() => {
   useServiceLocator.mockReturnValue({ services: null, isReady: false });
   getProductBySlug.mockReset();
   listActiveProducts.mockReset();
+  listMemberEvents.mockReset();
+  listPublicEvents.mockReset();
 });
 
 afterEach(() => {
@@ -135,6 +147,7 @@ test('renders the Auth action route and removes its query and fragment before us
 
 const SHOP_LOAD_FAILURE = 'We could not load the shop right now. Please try again later.';
 const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
+const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please try again later.';
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
@@ -146,6 +159,136 @@ function renderPublicProduct() {
   window.history.pushState({}, '', '/shop/synthetic-product');
   return render(<App />);
 }
+
+function renderPublicEvents() {
+  window.history.pushState({}, '', '/events');
+  return render(<App />);
+}
+
+describe('public Events-list failure boundary', () => {
+  let unsubscribe;
+
+  beforeEach(() => {
+    unsubscribe = jest.fn();
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    listPublicEvents.mockImplementation((_db, onChange) => {
+      onChange([]);
+      return unsubscribe;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected event details with one fixed result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listPublicEvents.mockImplementationOnce((_db, _onChange, onError) => {
+      onError(Object.assign(
+        new Error('events-provider-private-canary member@example.test'),
+        {
+          code: 'firestore/events-provider-private-canary',
+          endpoint: 'https://provider.example.test/?token=events-secret-canary',
+        },
+      ));
+      return unsubscribe;
+    });
+
+    renderPublicEvents();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(EVENTS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /events-provider-private-canary|member@example\.test|provider\.example|events-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading events...')).not.toBeInTheDocument();
+    expect(screen.queryByText('No events scheduled at this time.')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledWith(
+      firestore,
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile event rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('events-message-getter-canary');
+    });
+    listPublicEvents.mockImplementationOnce((_db, _onChange, onError) => {
+      onError(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      return unsubscribe;
+    });
+
+    renderPublicEvents();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENTS_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('events-message-getter-canary');
+    expect(screen.queryByText('Loading events...')).not.toBeInTheDocument();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the empty result, public lister, and unsubscribe', async () => {
+    const { unmount } = renderPublicEvents();
+
+    expect(await screen.findByText('No events scheduled at this time.'))
+      .toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledWith(
+      firestore,
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the successful public event projection', async () => {
+    listPublicEvents.mockImplementationOnce((_db, onChange) => {
+      onChange([{
+        id: 'synthetic-event',
+        slug: 'synthetic-club-run',
+        title: 'Synthetic Club Run',
+        startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+        location: 'Made-up Park',
+        capacity: null,
+        registeredCount: 0,
+        status: 'open',
+        visibility: 'public',
+        pricing: { memberCents: 0, nonMemberCents: 0 },
+        resultsUrl: null,
+      }]);
+      return unsubscribe;
+    });
+
+    renderPublicEvents();
+
+    expect(await screen.findByRole('link', { name: /Synthetic Club Run/ }))
+      .toHaveAttribute('href', '/events/synthetic-club-run');
+    expect(screen.getByText('Made-up Park', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+  });
+});
 
 describe('public Shop catalog failure boundary', () => {
   beforeEach(() => {

--- a/src/pages/events/Events.tsx
+++ b/src/pages/events/Events.tsx
@@ -25,7 +25,7 @@ const structuredData = {
   description: SEO_CONFIG.description,
   url: SEO_CONFIG.url,
 };
-
+function EventsSubscriptionAlertBox({ children }: { children: React.ReactNode }) { return <p className="text-red-500" role="alert" aria-live="assertive" aria-atomic="true">{children}</p>; }
 function PriceBadge({ event }: { event: Event }) {
   const { memberCents, nonMemberCents, earlyBirdCents } = event.pricing || {};
   if (!memberCents && !nonMemberCents && !earlyBirdCents) {
@@ -98,7 +98,7 @@ function Events() {
     const unsub = lister(
       db,
       (evs) => { setEvents(evs); setLoading(false); },
-      (err) => { setError(err.message); setLoading(false); },
+      () => { setError('We could not load events right now. Please try again later.'); setLoading(false); },
     );
     return unsub;
   }, [services, isReady, isMember]);
@@ -121,7 +121,7 @@ function Events() {
           </Link>
         </div>
         {loading && <p className="text-gray-500">Loading events...</p>}
-        {error && <p className="text-red-500">Error: {error}</p>}
+        {error && <EventsSubscriptionAlertBox>Error: {error}</EventsSubscriptionAlertBox>}
         {!loading && !error && events.length === 0 && (
           <p className="text-gray-500">No events scheduled at this time.</p>
         )}


### PR DESCRIPTION
Closes #258

## Outcome

The public `/events` route now treats an event-subscription rejection as untrusted. It discards the rejection and shows exactly `Error: We could not load events right now. Please try again later.` in an assertive atomic alert.

Loading ends on failure. Genuine empty event lists, successful public event displays, anonymous public-lister selection, member-lister selection, and subscription cleanup remain unchanged.

## Safety invariant

- never bind, inspect, coerce, render, store, or log a rejected event-subscription value
- show only the fixed source-owned sentence to an anonymous visitor
- do not misreport a failed subscription as a genuine empty event list
- preserve public/member lister selection, successful results, and unsubscribe behavior
- do not decide the canonical event source/schema or change services, Rules, records, or permissions
- tests use only made-up values and mocks with no Firebase or provider network access

## Verification

Old-source red proof on Node 20.19.5:
- 16 passed / 2 intended failures
- the raw private canary reached the public page
- a hostile `message` getter executed and drove the route into its generic error boundary

Final local proof on Node 20.19.5:
- focused actual-App Events route: 18/18
- full frontend: 12 suites / 273 tests
- TypeScript no-emit: passed
- lint safety: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- the two pre-existing Events paragraph findings remain exactly at line 124, columns 47 and 54
- SPA navigation: 11/11
- workflow, release, Firebase-readback, and artifact safety: 42/42
- diagnostic production build: passed
- `git diff --check`: passed
- exact three-path diff SHA-256: `64fc81cbf2bb26ac4a84c31ef82259b503dc628957245b9a261e34c9410b7e16`
- independent security/privacy, frontend/accessibility, and officer/scope reviews: PASS

## Scope

Only:
- `src/pages/events/Events.tsx`
- `src/App.test.jsx`
- the separately named #258 section in `docs/officers/EVENTS_SHOP_MEMBERS.md`

Blocked-owner #121 retains every canonical event source/schema/importer decision. Open commerce #249/#246 paths are disjoint and untouched. Event services, other event pages, Rules, Functions, lint baseline, workflows, packages, providers, deployments, and data are unchanged.

Officer impact: Public Events visitors receive one plain announced retry-later instruction without database, provider, account, endpoint, or technical detail.
Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, section `Public Events-list load failure privacy — SOURCE ONLY, NOT LIVE`.
Deployment evidence: None yet. This pull request changes source, tests, and documentation only. No release workflow, production website, `runmprc.com`, Firebase, database permissions, provider configuration, event record, production data, migration, or live-behavior action occurred.

## Residual risk

This source slice does not publish the website, deploy or verify Firebase, change event permissions/records, approve an event source, configure a provider, or prove live behavior. Those require separate owner decisions and an approved protected release with exact revision checks.
