### PR TITLE
WEB-PRIVACY-001D: redact public Events-calendar failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -597,6 +597,43 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public Events-calendar load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a visitor to the public Events calendar one plain next step when calendar data cannot load, without showing a database, provider, account, endpoint, or technical error.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#260](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/260) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com/events/calendar`. This source change does not choose the canonical event source, schema, importer, or publication workflow reserved to #121; deploy Firebase; change database permissions; contact an outside provider; change event records; use production data; or prove live behavior. It also leaves the separate commerce-result work in #249 unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the public Events-calendar failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #260 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up event, mocked event subscription, and mocked database reference.
+4. Confirm a made-up subscription rejection shows exactly `We could not load events right now. Please try again later.` in one alert that assistive technology reads immediately as a complete sentence.
+5. Confirm the failed state replaces the loading sentence without displaying the calendar grid.
+6. Confirm no made-up database, provider, account, endpoint, or technical detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a genuinely empty made-up subscription still displays the normal empty calendar grid and controls.
+9. Confirm a successful made-up public event still appears in the calendar.
+10. Confirm the anonymous route selects only the public event list.
+11. Confirm the subscription's existing cleanup function is still returned.
+12. Record website publication, `runmprc.com/events/calendar`, Firebase, provider, event-record, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for an Events-calendar subscription rejection. It announces the complete sentence immediately as one alert and does not inspect, display, or log the rejected value. Loading ends and the failure does not display the calendar grid, while successful and genuinely empty subscriptions keep their existing displays. Public/member list selection and subscription cleanup remain unchanged. This source slice does not approve an event source, schema, importer, or publication workflow; those owner decisions remain under #121. It does not change the separate #249 commerce-result work.
+
+**Stop conditions:** any real member, registration, event record, private location, discount, payment, waiver, or contact data; a request for a database or provider error, account detail, private endpoint, or screenshot containing private values; a production Firebase or provider change; a raw detail on the page or in the console; an attempt to force a production failure; an attempt to decide #121's canonical event-source work or edit #249's commerce-result work in this slice; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #260 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated `runmprc.com/events/calendar` revision check without forcing an error or opening private event data. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, and production-data actions as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging check proves it.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com/events/calendar`. Do not undo by changing an event, member account, registration, database record, permission, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, provider, account, endpoint, or technical detail appeared. Do not copy the detail into an issue, message, screenshot, email, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -148,6 +148,7 @@ test('renders the Auth action route and removes its query and fragment before us
 const SHOP_LOAD_FAILURE = 'We could not load the shop right now. Please try again later.';
 const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
 const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please try again later.';
+const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
@@ -162,6 +163,11 @@ function renderPublicProduct() {
 
 function renderPublicEvents() {
   window.history.pushState({}, '', '/events');
+  return render(<App />);
+}
+
+function renderPublicEventCalendar() {
+  window.history.pushState({}, '', '/events/calendar');
   return render(<App />);
 }
 
@@ -284,6 +290,140 @@ describe('public Events-list failure boundary', () => {
       .toHaveAttribute('href', '/events/synthetic-club-run');
     expect(screen.getByText('Made-up Park', { exact: false })).toBeInTheDocument();
     expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe('public Events-calendar failure boundary', () => {
+  let unsubscribe;
+
+  beforeEach(() => {
+    unsubscribe = jest.fn();
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    listPublicEvents.mockImplementation((_db, onChange) => {
+      onChange([]);
+      return unsubscribe;
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected calendar details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listPublicEvents.mockImplementationOnce((_db, _onChange, onError) => {
+      onError(Object.assign(
+        new Error('calendar-provider-private-canary member@example.test'),
+        {
+          code: 'firestore/calendar-provider-private-canary',
+          endpoint: 'https://provider.example.test/?token=calendar-secret-canary',
+        },
+      ));
+      return unsubscribe;
+    });
+
+    renderPublicEventCalendar();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(EVENTS_CALENDAR_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /calendar-provider-private-canary|member@example\.test|provider\.example|calendar-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sun')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledWith(
+      firestore,
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile calendar rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('calendar-message-getter-canary');
+    });
+    listPublicEvents.mockImplementationOnce((_db, _onChange, onError) => {
+      onError(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      return unsubscribe;
+    });
+
+    renderPublicEventCalendar();
+
+    expect((await screen.findByRole('alert')).textContent)
+      .toBe(EVENTS_CALENDAR_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('calendar-message-getter-canary');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the empty calendar, public lister, and unsubscribe', async () => {
+    const { unmount } = renderPublicEventCalendar();
+
+    expect(await screen.findByText('Sun')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous month' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next month' })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listPublicEvents).toHaveBeenCalledWith(
+      firestore,
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(listPublicEvents).toHaveBeenCalledTimes(1);
+    expect(listMemberEvents).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves a successful public event in the current calendar month', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2030, 0, 15, 12));
+    const currentMonth = new Date();
+    listPublicEvents.mockImplementationOnce((_db, onChange) => {
+      onChange([{
+        id: 'synthetic-calendar-event',
+        slug: 'synthetic-calendar-run',
+        title: 'Synthetic Calendar Run',
+        startAt: {
+          toDate: () => new Date(
+            currentMonth.getFullYear(),
+            currentMonth.getMonth(),
+            12,
+            8,
+          ),
+        },
+        capacity: null,
+        registeredCount: 0,
+        status: 'open',
+        visibility: 'public',
+        pricing: { memberCents: 0, nonMemberCents: 0 },
+      }]);
+      return unsubscribe;
+    });
+
+    renderPublicEventCalendar();
+
+    expect(await screen.findByRole('link', { name: 'Synthetic Calendar Run' }))
+      .toHaveAttribute('href', '/events/synthetic-calendar-run');
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(listPublicEvents).toHaveBeenCalledTimes(1);
     expect(listMemberEvents).not.toHaveBeenCalled();

--- a/src/pages/events/EventCalendar.tsx
+++ b/src/pages/events/EventCalendar.tsx
@@ -87,7 +87,7 @@ function EventCalendar() {
     const unsub = lister(
       db,
       (evs) => { setEvents(evs); setLoading(false); },
-      (err) => { setError(err.message); setLoading(false); },
+      () => { setError('We could not load events right now. Please try again later.'); setLoading(false); },
     );
     return unsub;
   }, [services, isReady, isMember]);
@@ -154,7 +154,7 @@ function EventCalendar() {
         </div>
 
         {loading && <p className="text-gray-500">Loading...</p>}
-        {error && <p className="text-red-500">{error}</p>}
+        {error && <p className="text-red-500" role="alert" aria-live="assertive" aria-atomic="true">{error}</p>}
 
         {!loading && !error && (
           <div className="grid grid-cols-7 gap-px bg-gray-200 border border-gray-200 rounded overflow-hidden">


### PR DESCRIPTION
Closes #260

## Outcome

The public `/events/calendar` route now treats event-subscription rejections as untrusted. It discards the complete value and shows exactly `We could not load events right now. Please try again later.` in one assertive atomic alert.

Loading ends and the calendar grid stays hidden on failure. Genuine empty subscriptions, successful current-month event chips, anonymous public-lister selection, member-lister selection code, and returned unsubscribe behavior remain unchanged.

## Safety invariant

- never bind, inspect, coerce, render, store, or log a rejected event-subscription value
- show only the fixed source-owned sentence to an anonymous visitor
- do not render a failed subscription as a genuine empty calendar
- preserve public/member lister selection, successful results, normal empty grid, and unsubscribe behavior
- do not decide the canonical event source/schema/importer or change services, Rules, records, permissions, or commerce behavior
- tests use only made-up values and mocks with no Firebase or provider network access

## Verification

Old-source red proof on Node 20.19.5:
- 2 passed / 2 intended failures
- an ordinary rejection rendered the private canary publicly
- a hostile `message` getter executed and drove the route into its generic ErrorBoundary

Final local proof on Node 20.19.5:
- focused actual-App Events-calendar route: 4/4
- full frontend: 12 suites / 277 tests
- TypeScript no-emit: passed
- lint safety: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- the two pre-existing EventCalendar warnings remain exactly at 52:22 and 174:24
- SPA navigation plus workflow, release, Firebase-readback, and artifact safety: 53/53
- diagnostic production build: passed
- `git diff --check`: passed
- exact three-path diff SHA-256: `5530128ea61d880d514b278c879867249eacaba0802f002a5c2be80a82769e3a`
- independent security/privacy, frontend/accessibility, and officer/scope reviews: PASS

## Scope

Only:
- `src/pages/events/EventCalendar.tsx`
- additive EventCalendar route coverage in `src/App.test.jsx`
- the separately named #260 section in `docs/officers/EVENTS_SHOP_MEMBERS.md`

Blocked-owner #121 retains every canonical event source/schema/importer/publication decision. Open commerce #249/#246 paths and named C4C1 root-document hunks are disjoint and untouched. Event services, other event pages, Rules, Functions, indexes, lint baseline/tooling, workflows, packages, providers, deployments, records, and data are unchanged. No root architecture or operations document changed because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.

Officer impact: Public Events-calendar visitors receive one plain announced retry-later instruction without database, provider, account, endpoint, or technical detail.
Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, section `Public Events-calendar load failure privacy — SOURCE ONLY, NOT LIVE`.
Deployment evidence: None yet. This pull request changes source, tests, and documentation only. No release workflow, production website, `runmprc.com`, Firebase, database permissions, provider configuration, event record, production data, migration, or live-behavior action occurred.

## Residual risk

This source slice does not publish the website, deploy or verify Firebase, change event permissions/records, approve an event source, configure a provider, or prove live behavior. Those require separate owner decisions and an approved protected release with exact revision checks.