### PR TITLE
WEB-PRIVACY-001E: redact public Event-detail failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -634,6 +634,41 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public event-detail load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a visitor to one public event page a plain next step when that event cannot load, without showing a database, provider, account, endpoint, or technical error.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#262](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/262) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on the affected `runmprc.com/events/...` page. This source change does not choose the canonical event source, schema, importer, or publication workflow reserved to #121; repair the separate stale or out-of-order event lookup lifecycle; deploy Firebase; change database permissions; contact an outside provider; change event records; use production data; or prove live behavior. It also leaves the separate commerce-result work in #249 unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the public event-detail failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #262 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up event, mocked event lookup, and mocked database reference.
+4. Confirm a made-up lookup rejection shows exactly `We could not load this event right now. Please try again later.` in one alert that assistive technology reads immediately as a complete sentence.
+5. Confirm the loading sentence stops and the **Back to events** link remains available.
+6. Confirm no made-up database, provider, account, endpoint, or technical detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a genuinely missing made-up event still shows the existing not-found result.
+9. Confirm a successful made-up event still shows its existing public details and registration link.
+10. Record website publication, the exact `runmprc.com` event page, Firebase, provider, event-record, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for a rejected event lookup. It announces the complete sentence immediately as one alert and does not inspect, display, or log the rejected value. Loading ends and the Back to events link remains, while missing and successful event results keep their existing displays. This source slice does not approve an event source, schema, importer, or publication workflow; those owner decisions remain under #121. It does not repair stale or out-of-order lookups or change the separate #249 commerce-result work.
+
+**Stop conditions:** any real member, registration, event record, private location, discount, payment, waiver, or contact data; a request for a database or provider error, account detail, private endpoint, or screenshot containing private values; a production Firebase or provider change; a raw detail on the page or in the console; an attempt to force a production failure; an attempt to decide #121 work, repair the separate lookup-lifecycle defect, or edit #249 work in this slice; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #262 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated check of the affected `runmprc.com` event page without forcing an error, starting registration, or opening private event data. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, and production-data actions as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging check proves it.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on the affected `runmprc.com` event page. Do not undo by changing an event, member account, registration, database record, permission, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, provider, account, endpoint, or technical detail appeared. Do not copy the detail into an issue, message, screenshot, email, or AI tool. A specialist still owns any stale or out-of-order lookup repair.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -9,7 +9,11 @@ import {
 } from '@testing-library/react';
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
-import { listMemberEvents, listPublicEvents } from './services/events/eventsService';
+import {
+  getEventBySlug,
+  listMemberEvents,
+  listPublicEvents,
+} from './services/events/eventsService';
 import { getProductBySlug, listActiveProducts } from './services/shop/shopService';
 import App from './App';
 
@@ -36,6 +40,7 @@ jest.mock('./services/events/eventsService', () => {
   const actual = jest.requireActual('./services/events/eventsService');
   return {
     ...actual,
+    getEventBySlug: jest.fn(),
     listMemberEvents: jest.fn(),
     listPublicEvents: jest.fn(),
   };
@@ -59,6 +64,7 @@ beforeEach(() => {
   useServiceLocator.mockReturnValue({ services: null, isReady: false });
   getProductBySlug.mockReset();
   listActiveProducts.mockReset();
+  getEventBySlug.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
 });
@@ -149,6 +155,7 @@ const SHOP_LOAD_FAILURE = 'We could not load the shop right now. Please try agai
 const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
 const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please try again later.';
 const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
+const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
@@ -168,6 +175,11 @@ function renderPublicEvents() {
 
 function renderPublicEventCalendar() {
   window.history.pushState({}, '', '/events/calendar');
+  return render(<App />);
+}
+
+function renderPublicEventDetail() {
+  window.history.pushState({}, '', '/events/synthetic-event');
   return render(<App />);
 }
 
@@ -427,6 +439,110 @@ describe('public Events-calendar failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(listPublicEvents).toHaveBeenCalledTimes(1);
     expect(listMemberEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe('public Event-detail load failure boundary', () => {
+  beforeEach(() => {
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    getEventBySlug.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected event details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    getEventBySlug.mockRejectedValueOnce(Object.assign(
+      new Error('event-detail-provider-private-canary member@example.test'),
+      {
+        code: 'firestore/event-detail-provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=event-detail-secret-canary',
+      },
+    ));
+
+    renderPublicEventDetail();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(EVENT_DETAIL_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /event-detail-provider-private-canary|member@example\.test|provider\.example|event-detail-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Event not found')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to events/ })).toHaveAttribute('href', '/events');
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile event-detail rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('event-detail-message-getter-canary');
+    });
+    getEventBySlug.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderPublicEventDetail();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENT_DETAIL_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('event-detail-message-getter-canary');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the existing missing-event result', async () => {
+    renderPublicEventDetail();
+
+    expect(await screen.findByText('Event not found')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to events/ })).toHaveAttribute('href', '/events');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the existing successful event projection and registration link', async () => {
+    getEventBySlug.mockResolvedValueOnce({
+      id: 'synthetic-event',
+      slug: 'synthetic-event',
+      title: 'Synthetic Club Event',
+      description: 'A made-up event used only for this test.',
+      startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+      location: 'Made-up Park',
+      capacity: null,
+      registeredCount: 0,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+      resultsUrl: null,
+    });
+
+    renderPublicEventDetail();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Club Event' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Made-up Park', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('$10.00')).toBeInTheDocument();
+    expect(screen.getByText('$15.00')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' }))
+      .toHaveAttribute('href', '/events/synthetic-event/register');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pages/events/EventDetail.tsx
+++ b/src/pages/events/EventDetail.tsx
@@ -41,14 +41,14 @@ function EventDetail() {
         if (!e) setError('Event not found');
         else track(analyticsEvents.eventView, { slug: e.slug, title: e.title });
       })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .catch(() => { setError('We could not load this event right now. Please try again later.'); setLoading(false); });
   }, [services, isReady, slug]);
 
   if (loading) return <div className="container mx-auto p-6">Loading...</div>;
   if (error || !event) {
     return (
       <div className="container mx-auto p-6">
-        <p className="text-red-500">{error || 'Event not found.'}</p>
+        <p role="alert" aria-live="assertive" aria-atomic="true" className="text-red-500">{error || 'Event not found.'}</p>
         <Link to="/events" className="text-blue-600 hover:underline">
           ← Back to events
         </Link>


### PR DESCRIPTION
## Outcome

Public `/events/:slug` lookup failures now discard the complete rejected value and show only `We could not load this event right now. Please try again later.` in one assertive atomic alert.

Closes #262.

## Scope

- replaces the current EventDetail rejection handler without binding or inspecting the rejected value
- preserves EventDetail at 235 physical lines and keeps the four reviewed lint locations fixed
- adds actual-App tests for ordinary private detail, a hostile throwing `message` getter, genuine not-found, and a successful public event/registration link
- adds one separately named source-only/not-live officer procedure
- leaves stale/out-of-order lookup lifecycle repair, #121 event-authority decisions, and #249 C4C1 work outside this change

## Verification

- old-source red proof: 2 pass / 2 intended failures
- focused final Event-detail route: 4/4
- full frontend: 12 suites / 281 tests
- TypeScript no-emit: pass
- frontend lint ledger: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- SPA/workflow/release/Firebase-readback/artifact safety: 53/53
- diagnostic production build: pass
- `git diff --check`: pass
- independent security/privacy, frontend/accessibility, and officer/scope reviews: PASS
- exact three-file diff SHA-256: `f84ed229ff366279c0325ce1dc629d9ce35a16d92828915818398b3eb4a4d43e`

## Risk and compatibility

No schema, service, Rules, Function, permission, provider, event-record, production-data, migration, registration, payment, or analytics implementation change. Missing and successful event results plus the Back to events link remain covered. The pre-existing stale/out-of-order lookup lifecycle defect is explicitly not repaired here.

Officer impact: Public event-detail visitors receive one plain retry-later instruction without database, provider, account, endpoint, or technical detail.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, named `Public event-detail load failure privacy — SOURCE ONLY, NOT LIVE` section.

Deployment evidence: Source/branch/PR only. No protected release, production website or `runmprc.com` publication, Firebase deployment, provider configuration, event-record action, production-data action, migration, or live verification occurred.