### PR TITLE
WEB-INTEGRITY-001A: bind Event-detail state to the active slug

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -669,6 +669,41 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public event-detail lookup lifecycle — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep a public event page tied to the event named in its current address when a visitor moves between event pages, even if an older lookup finishes later.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#264](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/264) must be merged for source review. Calling the repair live also requires a protected website publication and an exact revision check on the affected `runmprc.com/events/...` pages. This source change does not choose the canonical event source, schema, importer, or publication workflow reserved to #121; deploy Firebase; change database permissions; contact an outside provider; change event records; use production data; or prove live behavior. It leaves the separate commerce-result work in #249 unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the public event-detail lifecycle repair marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #264 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only made-up event names, mocked event lookups, and a mocked database reference.
+4. Confirm moving from a failed made-up event to a successful one clears the old alert and shows the current event.
+5. Confirm moving from a missing made-up event to a successful one clears the old not-found result and shows the current event.
+6. Confirm an older rejection that finishes after the current event cannot replace that event with an alert.
+7. Confirm an older success that finishes after the current event cannot replace its title, registration link, or event-view measurement.
+8. Confirm the current event keeps its own title, registration link, and one event-view measurement.
+9. Confirm the fixed failure sentence and missing-event result from #262 still work for the current event.
+10. Record source change, tests, merge, preview, website publication, the exact `runmprc.com` event pages, Firebase, provider, event-record, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** each changed event address starts a fresh loading state, clears the preceding event and alert, and accepts a result only from its own active lookup. A completed older lookup cannot replace the current event, registration link, alert, or measurement. The current event retains the existing success, missing-event, and fixed failure displays. This source slice does not approve #121 event-source decisions or change #249 commerce-result work.
+
+**Stop conditions:** any real member, registration, event record, private location, discount, payment, waiver, or contact data; a request to force a production race between lookups; a production Firebase or provider change; a stale title, registration link, alert, or event-view measurement after the address changes; an attempt to decide #121 work or edit #249 work in this slice; or a claim that source, tests, merge, preview, or a green workflow proves the repair is live.
+
+**Success proof:** for source completion, record the exact #264 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic lifecycle tests, relevant full checks, and independent integrity review. For live availability, separately record the approved website publication, published revision, and a dated check that navigation between two approved public `runmprc.com` event pages keeps the address, title, and registration link aligned. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, and production-data actions as **not performed** for this frontend-only change. A synthetic timing test proves source behavior; it does not prove production behavior.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on the affected `runmprc.com` event pages. Do not undo by changing an event, member account, registration, database record, permission, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if a stale page exposed a wrong event, private detail, registration destination, or measurement. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -14,6 +14,7 @@ import {
   listMemberEvents,
   listPublicEvents,
 } from './services/events/eventsService';
+import { track } from './services/analytics/analytics';
 import { getProductBySlug, listActiveProducts } from './services/shop/shopService';
 import App from './App';
 
@@ -46,6 +47,11 @@ jest.mock('./services/events/eventsService', () => {
   };
 });
 
+jest.mock('./services/analytics/analytics', () => {
+  const actual = jest.requireActual('./services/analytics/analytics');
+  return { ...actual, track: jest.fn() };
+});
+
 jest.mock('./services/hooks/useAuth', () => ({
   useAuth: () => ({
     user: null,
@@ -67,6 +73,7 @@ beforeEach(() => {
   getEventBySlug.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
+  track.mockReset();
 });
 
 afterEach(() => {
@@ -443,6 +450,23 @@ describe('public Events-calendar failure boundary', () => {
 });
 
 describe('public Event-detail load failure boundary', () => {
+  function makeEvent(slug, title) {
+    return {
+      id: slug,
+      slug,
+      title,
+      description: `A made-up ${title} used only for this test.`,
+      startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+      location: 'Made-up Park',
+      capacity: null,
+      registeredCount: 0,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+      resultsUrl: null,
+    };
+  }
+
   beforeEach(() => {
     useServiceLocator.mockReturnValue({
       services: { firebaseResources: { firestore } },
@@ -543,6 +567,114 @@ describe('public Event-detail load failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
     expect(getEventBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears a prior lookup failure when the current slug succeeds', async () => {
+    getEventBySlug
+      .mockRejectedValueOnce(new Error('prior-event-failure-canary'))
+      .mockResolvedValueOnce(makeEvent('current-event', 'Current Event'));
+
+    renderPublicEventDetail();
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENT_DETAIL_LOAD_FAILURE);
+
+    window.history.pushState({}, '', '/events/current-event');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' }))
+      .toHaveAttribute('href', '/events/current-event/register');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('prior-event-failure-canary');
+    expect(getEventBySlug).toHaveBeenNthCalledWith(2, firestore, 'current-event');
+  });
+
+  test('clears a prior not-found result when the current slug succeeds', async () => {
+    getEventBySlug
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeEvent('current-event', 'Current Event'));
+
+    renderPublicEventDetail();
+    expect(await screen.findByText('Event not found')).toBeInTheDocument();
+
+    window.history.pushState({}, '', '/events/current-event');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' }))
+      .toHaveAttribute('href', '/events/current-event/register');
+    expect(screen.queryByText('Event not found')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenNthCalledWith(2, firestore, 'current-event');
+  });
+
+  test('ignores an older rejection after the current slug succeeds', async () => {
+    const olderLookup = {};
+    olderLookup.promise = new Promise((_resolve, reject) => {
+      olderLookup.reject = reject;
+    });
+    getEventBySlug
+      .mockImplementationOnce(() => olderLookup.promise)
+      .mockResolvedValueOnce(makeEvent('current-event', 'Current Event'));
+
+    renderPublicEventDetail();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+
+    window.history.pushState({}, '', '/events/current-event');
+    fireEvent(window, new PopStateEvent('popstate'));
+    expect(await screen.findByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.reject(new Error('older-event-rejection-canary'));
+      await olderLookup.promise.catch(() => undefined);
+    });
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' }))
+      .toHaveAttribute('href', '/events/current-event/register');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('older-event-rejection-canary');
+    expect(window.location.pathname).toBe('/events/current-event');
+  });
+
+  test('ignores an older event and analytics after the current slug succeeds', async () => {
+    const olderLookup = {};
+    olderLookup.promise = new Promise((resolve) => {
+      olderLookup.resolve = resolve;
+    });
+    getEventBySlug
+      .mockImplementationOnce(() => olderLookup.promise)
+      .mockResolvedValueOnce(makeEvent('current-event', 'Current Event'));
+
+    renderPublicEventDetail();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+
+    window.history.pushState({}, '', '/events/current-event');
+    fireEvent(window, new PopStateEvent('popstate'));
+    expect(await screen.findByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith('event_view', {
+      slug: 'current-event',
+      title: 'Current Event',
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      olderLookup.resolve(makeEvent('older-event', 'Older Event'));
+      await olderLookup.promise;
+    });
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Current Event' }))
+      .toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1, name: 'Older Event' }))
+      .not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' }))
+      .toHaveAttribute('href', '/events/current-event/register');
+    expect(window.location.pathname).toBe('/events/current-event');
+    expect(track).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pages/events/EventDetail.tsx
+++ b/src/pages/events/EventDetail.tsx
@@ -32,16 +32,16 @@ function EventDetail() {
   const cancelled = searchParams.get('cancelled') === '1';
 
   useEffect(() => {
-    if (!isReady || !services || !slug) return;
-    setLoading(true);
+    if (!isReady || !services || !slug) return () => undefined;
+    let active = true; setLoading(true); setEvent(null); setError(null);
     getEventBySlug(services.firebaseResources.firestore, slug)
       .then((e) => {
-        setEvent(e);
-        setLoading(false);
+        if (!active) return;
+        setEvent(e); setLoading(false);
         if (!e) setError('Event not found');
         else track(analyticsEvents.eventView, { slug: e.slug, title: e.title });
       })
-      .catch(() => { setError('We could not load this event right now. Please try again later.'); setLoading(false); });
+      .catch(() => { if (active) { setError('We could not load this event right now. Please try again later.'); setLoading(false); } }); return () => { active = false; };
   }, [services, isReady, slug]);
 
   if (loading) return <div className="container mx-auto p-6">Loading...</div>;


### PR DESCRIPTION
## Outcome

Public `/events/:slug` state now belongs only to the current active slug lookup. Moving between event pages clears obsolete state, and an older fulfillment or rejection cannot replace the current title, registration link, alert, loading result, or event-view analytics.

Closes #264.

## Scope

- clears obsolete event and error state when the active slug changes
- deactivates the prior lookup on route change or unmount and ignores every later settlement from it
- preserves EventDetail at 235 physical lines and keeps the four reviewed lint locations fixed
- adds actual-App router tests for prior rejection, prior not-found, stale rejection, stale fulfillment, Register-link binding, and analytics suppression
- adds one separately named source-only/not-live officer procedure
- leaves #121 event-authority decisions and #249/#246 C4C1 work outside this change

## Verification

- old-source red proof: 4/4 original tests passed and 4/4 new lifecycle tests failed for the intended defects
- focused final Event-detail route: 8/8
- full frontend: 12 suites / 285 tests
- TypeScript no-emit: pass
- frontend lint ledger: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- SPA/workflow/release/Firebase-readback/artifact safety: 53/53
- diagnostic production build: pass
- `git diff --check`: pass
- EventDetail physical lines: 235; reviewed lint locations remain 75/218/220/222
- independent security/integrity, frontend/lifecycle, and officer/scope reviews: APPROVE, no findings
- exact three-file diff SHA-256: `f470e6235fe664df52095bdb89343ce0f952d17b88f85b33a27a5cfdf2c04369`

## Risk and compatibility

The repair ignores inactive promise settlement; it does not cancel or change Firestore requests. Current not-found, fixed #262 failure alert, successful details/prices/results/SEO, capacity/member/status registration rules, current-event analytics, and Back to events behavior remain covered. No schema, service, Rules, Function, permission, provider, event-record, production-data, migration, registration, or payment change.

Officer impact: Public event pages stay matched to the current URL, and an older request cannot offer the wrong event registration link or replace the current result.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, named `Public event-detail lookup lifecycle — SOURCE ONLY, NOT LIVE` section.

Deployment evidence: Source/branch/PR only. No protected release, production website or `runmprc.com` publication, Firebase deployment, provider configuration, event-record action, production-data action, migration, registration/payment action, or live verification occurred.
