### PR TITLE
WEB-PRIVACY-001F: redact public event-registration load failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -704,6 +704,41 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public event-registration page load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a visitor a plain next step when the public event-registration page cannot load its event, without showing a database, provider, account, endpoint, token-shaped, or technical error.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#266](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/266) must be merged for source review. Calling the sentence live also requires a protected website publication and an exact revision check on the affected `runmprc.com/events/.../register` page without entering or submitting runner data. This source change does not choose the canonical event source, schema, importer, or publication workflow reserved to #121; repair stale or out-of-order registration-page lookups; change registration, waiver, price, analytics, or checkout behavior; deploy Firebase; change database permissions; contact Stripe or another provider; change event records; use production data; or prove live behavior. It leaves the separate commerce-result work in #249 unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the public event-registration load-failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #266 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up event, mocked event lookup, mocked database reference, and an empty form.
+4. Confirm a made-up lookup rejection shows exactly `We could not load this event right now. Please try again later.` in one alert that assistive technology reads immediately as a complete sentence.
+5. Confirm the loading sentence stops and the **Back to events** link remains available.
+6. Confirm no made-up database, provider, account, endpoint, token-shaped, or technical detail appears on the page or in browser console output.
+7. Confirm a hostile rejected value is not inspected.
+8. Confirm a genuinely missing made-up event still shows the existing not-found result.
+9. Confirm a successful made-up event still shows the existing registration form and public price without entering data, accepting a waiver, submitting, or starting checkout.
+10. Record source change, tests, merge, preview, website publication, the exact `runmprc.com` registration page, Firebase, provider, event-record, production-data, registration/payment, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source uses one fixed retry-later sentence for a rejected event lookup on the registration page. It announces the complete sentence immediately as one alert and does not inspect, display, log, or send the rejected value to analytics. Loading ends and the Back to events link remains, while missing and successful event results keep their existing displays. This slice does not submit a registration, accept a waiver, start checkout, repair stale lookups, approve #121 event-source decisions, or change #249 commerce-result work.
+
+**Stop conditions:** any real member, runner, registration, event record, private location, discount, payment, waiver, emergency contact, birth date, phone, or email data; entry or submission of a form; acceptance of a waiver; a request to force a production failure; a Firebase or provider change; a raw detail on the page or in the console; an attempt to repair stale lookups, change submission/analytics/checkout, decide #121 work, or edit #249 work in this slice; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live.
+
+**Success proof:** for source completion, record the exact #266 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic tests, relevant full checks, and independent privacy review. For live availability, separately record the approved website publication, published revision, and a dated read-only check of the affected `runmprc.com` registration page without entering data, accepting a waiver, submitting, or forcing an error. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, production-data actions, registrations, and payments as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging check proves it.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on the affected `runmprc.com` registration page. Do not undo by changing an event, member account, registration, database record, permission, source document, provider setting, waiver, or payment.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, provider, account, endpoint, runner, waiver, registration, or technical detail appeared. Do not copy the detail into an issue, message, screenshot, email, or AI tool. A specialist still owns any stale or out-of-order lookup repair.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -163,6 +163,7 @@ const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please t
 const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please try again later.';
 const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
+const EVENT_REGISTER_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
@@ -187,6 +188,11 @@ function renderPublicEventCalendar() {
 
 function renderPublicEventDetail() {
   window.history.pushState({}, '', '/events/synthetic-event');
+  return render(<App />);
+}
+
+function renderPublicEventRegister() {
+  window.history.pushState({}, '', '/events/synthetic-event/register');
   return render(<App />);
 }
 
@@ -675,6 +681,118 @@ describe('public Event-detail load failure boundary', () => {
       .toHaveAttribute('href', '/events/current-event/register');
     expect(window.location.pathname).toBe('/events/current-event');
     expect(track).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('public Event-registration load failure boundary', () => {
+  beforeEach(() => {
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    getEventBySlug.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected event details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    getEventBySlug.mockRejectedValueOnce(Object.assign(
+      new Error('event-register-provider-private-canary member@example.test'),
+      {
+        code: 'firestore/event-register-provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=event-register-secret-canary',
+      },
+    ));
+
+    renderPublicEventRegister();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(EVENT_REGISTER_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /event-register-provider-private-canary|member@example\.test|provider\.example|event-register-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Event not found')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to events/ })).toHaveAttribute('href', '/events');
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile event-registration rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('event-register-message-getter-canary');
+    });
+    getEventBySlug.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderPublicEventRegister();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENT_REGISTER_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('event-register-message-getter-canary');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the existing missing-event result', async () => {
+    renderPublicEventRegister();
+
+    expect(await screen.findByText('Event not found')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to events/ })).toHaveAttribute('href', '/events');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the existing successful registration form and public price', async () => {
+    getEventBySlug.mockResolvedValueOnce({
+      id: 'synthetic-event',
+      slug: 'synthetic-event',
+      title: 'Synthetic Registration Event',
+      description: 'A made-up event used only for this test.',
+      startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+      location: 'Made-up Park',
+      capacity: null,
+      registeredCount: 0,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+      customFields: [],
+      volunteerFields: [],
+      volunteerEnabled: false,
+      waiverText: 'Made-up waiver text.',
+    });
+
+    renderPublicEventRegister();
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Synthetic Registration Event',
+    })).toBeInTheDocument();
+    expect(screen.getByText('Made-up Park', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('$15.00')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to event/ }))
+      .toHaveAttribute('href', '/events/synthetic-event');
+    expect(screen.getByRole('checkbox', { name: /accept the waiver/i })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+    expect(getEventBySlug).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/pages/events/EventRegister.tsx
+++ b/src/pages/events/EventRegister.tsx
@@ -38,7 +38,7 @@ const EMPTY_RUNNER: RunnerFormState = {
   emergencyContactName: '',
   emergencyContactPhone: '',
 };
-
+const EVENT_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 function CustomFieldInput({
   field, value, onChange,
 }: {
@@ -129,7 +129,7 @@ function EventRegister() {
         setLoading(false);
         if (!e) setError('Event not found');
       })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .catch(() => { setError(EVENT_LOAD_FAILURE); setLoading(false); });
   }, [services, isReady, slug]);
 
   const effectiveTier: PriceTier = useMemo(() => {
@@ -155,7 +155,7 @@ function EventRegister() {
   if (error || !event) {
     return (
       <div className="container mx-auto p-6">
-        <p className="text-red-500">{error || 'Event not found.'}</p>
+        <p role={error === EVENT_LOAD_FAILURE ? 'alert' : undefined} aria-live={error === EVENT_LOAD_FAILURE ? 'assertive' : undefined} aria-atomic={error === EVENT_LOAD_FAILURE ? true : undefined} className="text-red-500">{error || 'Event not found.'}</p>
         <Link to="/events" className="text-blue-600 hover:underline">
           ← Back to events
         </Link>


### PR DESCRIPTION
## Outcome

Anonymous `/events/:slug/register` event-load failures now discard the complete rejected value and show only `We could not load this event right now. Please try again later.` in one assertive atomic alert.

Closes #266.

## Scope

- replaces only the current EventRegister event-lookup rejection handler without binding or inspecting the rejected value
- applies live-region semantics only to the fixed lookup failure, preserving genuine not-found and later waiver/checkout error markup
- preserves EventRegister at 491 physical lines and keeps all 19 reviewed lint locations fixed
- adds actual-App route tests for ordinary private detail, a hostile throwing `message` getter, genuine not-found, and a successful made-up registration form/public price
- adds one separately named source-only/not-live officer procedure
- leaves submit/analytics/checkout, stale lookup lifecycle, #121 event-authority decisions, and #249 C4C1 work outside this change

## Verification

- old-source red proof: 2 preservation cases passed / 2 intended privacy cases failed; the raw canary appeared and the hostile getter was invoked
- focused final event-registration route: 4/4
- full frontend: 12 suites / 289 tests
- TypeScript no-emit: pass
- frontend lint ledger: unchanged at 106 files / 123 reviewed legacy errors / 7 warnings
- SPA/workflow/release/Firebase-readback/artifact safety: 53/53
- diagnostic production build: pass
- `git diff --check`: pass
- EventRegister physical lines: 491; reviewed lint locations remain 60/68/90/120/263/274/298/326/336/348/360/369/380/400/409/424/446/465/467
- independent review caught and corrected an overbroad alert-semantic change; final security/privacy, frontend/accessibility, and officer/scope re-reviews: APPROVE, no findings
- exact three-file diff SHA-256: `ffe4c133502586ca996bc5d7f62445b7d3a1804e311356b5fbe3c1eb234cdeb9`

## Risk and compatibility

No event service, schema, route, Rules, Function, permission, provider, event-record, production-data, migration, registration, waiver, analytics implementation, checkout, or payment change. Current loading, missing-event, successful form/public-price, Back-to-events, submission, and checkout behavior remain covered. The known stale/out-of-order registration-page lookup lifecycle remains explicitly separate.

Officer impact: Visitors to a public event-registration page receive one plain retry-later instruction without database, provider, account, endpoint, token-shaped, or technical detail.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`, named `Public event-registration page load failure privacy — SOURCE ONLY, NOT LIVE` section.

Deployment evidence: Source/branch/PR only. No protected release, production website or `runmprc.com` publication, Firebase deployment, provider configuration, event-record or production-data action, migration, registration/payment action, or live verification occurred.
