### PR TITLE
WEB-INTEGRITY-001B: bind event-registration state to the current slug

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -739,6 +739,41 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public event-registration lookup lifecycle — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep a public event-registration page tied to the event named in its current address when a visitor moves between registration pages, even if an older event lookup finishes later.
+
+**Approver:** events lead plus platform/security owner.
+
+**Prerequisites:** issue [#268](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/268) must be merged for source review. Calling the repair live also requires a protected website publication and an exact revision check on the affected `runmprc.com/events/.../register` pages without entering runner data, accepting a waiver, submitting, or starting checkout. This source change preserves #266 error privacy; it does not choose the canonical event source, schema, importer, or publication workflow reserved to #121; reset runner answers, custom answers, signup type, or waiver state when the address changes; bind a pending submission to its starting address; change registration, price, analytics, or checkout behavior; deploy Firebase; change database permissions; contact Stripe or another provider; change event records; use production data; or prove live behavior. It leaves the separate commerce-result work in #249 unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the public event-registration lookup-lifecycle repair marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #268 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only made-up event names, mocked event lookups, a mocked database reference, and empty forms.
+4. Confirm moving from a failed made-up registration page to a successful one clears the old alert and shows the current event form and **Back to event** link.
+5. Confirm moving from a missing made-up event to a successful one clears the old not-found result and shows the current event form.
+6. Confirm an older rejection that finishes after the current registration event cannot replace that event with an alert.
+7. Confirm an older success that finishes after the current registration event cannot replace its heading, price, waiver text, form, or **Back to event** link.
+8. Confirm the fixed failure sentence and missing-event result from #266 still work for the current address.
+9. Confirm the review enters no runner, contact, birth-date, emergency-contact, waiver, registration, payment, or real event data and makes no form submission or checkout call.
+10. Record source change, tests, merge, preview, website publication, the exact `runmprc.com` registration pages, Firebase, provider, event-record, production-data, registration/payment, and live-behavior evidence as separate results.
+
+**Expected result:** each changed registration address starts a fresh loading state, clears the preceding event and load error, and accepts an event result only from its own active lookup. A completed older lookup cannot replace the current heading, price, waiver text, form, link, not-found result, or fixed failure alert. Current success, missing-event, and #266 failure displays remain unchanged. This source slice does not enter or reset form values, accept a waiver, submit a registration, start checkout, approve #121 event-source decisions, or change #249 commerce-result work.
+
+**Stop conditions:** any real member, runner, registration, event record, private location, discount, payment, waiver, emergency contact, birth date, phone, or email data; entry or submission of a form; acceptance of a waiver; a request to force a production race between lookups; a production Firebase or provider change; a stale heading, price, waiver, form, link, not-found result, or alert after the address changes; an attempt to expand into route-scoped form/waiver/submission state, decide #121 work, or edit #249 work in this slice; or a claim that source, tests, merge, preview, or a green workflow proves the repair is live.
+
+**Success proof:** for source completion, record the exact #268 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic lifecycle tests, relevant full checks, and independent integrity/privacy review. For live availability, separately record the approved website publication, published revision, and a dated read-only check that navigation between two approved public `runmprc.com` registration addresses keeps the address, event heading, and **Back to event** link aligned without entering data, accepting a waiver, submitting, or starting checkout. Record Firebase deployment, database-permission changes, provider configuration, event-record changes, production-data actions, registrations, and payments as **not performed** for this frontend-only change. A synthetic timing test proves source behavior; it does not prove production behavior.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on the affected `runmprc.com` registration pages. Do not undo by changing an event, member account, registration, database record, permission, source document, provider setting, waiver, or payment.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if a stale registration page exposed the wrong event, price, waiver, form, destination, runner detail, or technical detail. Do not copy private details into an issue, message, screenshot, email, or AI tool. Route-scoped form/waiver state and pending submission settlement remain separate specialist work.
+
+No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -685,6 +685,26 @@ describe('public Event-detail load failure boundary', () => {
 });
 
 describe('public Event-registration load failure boundary', () => {
+  function makeRegistrationEvent(slug, title, nonMemberCents = 1500) {
+    return {
+      id: slug,
+      slug,
+      title,
+      description: `A made-up ${title} used only for this test.`,
+      startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+      location: 'Made-up Park',
+      capacity: null,
+      registeredCount: 0,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents },
+      customFields: [],
+      volunteerFields: [],
+      volunteerEnabled: false,
+      waiverText: `Made-up waiver for ${title}.`,
+    };
+  }
+
   beforeEach(() => {
     useServiceLocator.mockReturnValue({
       services: { firebaseResources: { firestore } },
@@ -793,6 +813,134 @@ describe('public Event-registration load failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
     expect(getEventBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears a prior lookup failure when the current registration slug succeeds', async () => {
+    getEventBySlug
+      .mockRejectedValueOnce(new Error('prior-registration-failure-canary'))
+      .mockResolvedValueOnce(makeRegistrationEvent('current-event', 'Current Registration'));
+
+    renderPublicEventRegister();
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENT_REGISTER_LOAD_FAILURE);
+
+    window.history.pushState({}, '', '/events/current-event/register');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to event/ }))
+      .toHaveAttribute('href', '/events/current-event');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('prior-registration-failure-canary');
+    expect(getEventBySlug).toHaveBeenNthCalledWith(2, firestore, 'current-event');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('clears a prior not-found result when the current registration slug succeeds', async () => {
+    getEventBySlug
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeRegistrationEvent('current-event', 'Current Registration'));
+
+    renderPublicEventRegister();
+    expect(await screen.findByText('Event not found')).toBeInTheDocument();
+
+    window.history.pushState({}, '', '/events/current-event/register');
+    fireEvent(window, new PopStateEvent('popstate'));
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to event/ }))
+      .toHaveAttribute('href', '/events/current-event');
+    expect(screen.queryByText('Event not found')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(getEventBySlug).toHaveBeenNthCalledWith(2, firestore, 'current-event');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('ignores an older rejection after the current registration slug succeeds', async () => {
+    const olderLookup = {};
+    olderLookup.promise = new Promise((_resolve, reject) => {
+      olderLookup.reject = reject;
+    });
+    getEventBySlug
+      .mockImplementationOnce(() => olderLookup.promise)
+      .mockResolvedValueOnce(makeRegistrationEvent('current-event', 'Current Registration'));
+
+    renderPublicEventRegister();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+
+    window.history.pushState({}, '', '/events/current-event/register');
+    fireEvent(window, new PopStateEvent('popstate'));
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.reject(new Error('older-registration-rejection-canary'));
+      await olderLookup.promise.catch(() => undefined);
+    });
+
+    expect(screen.getByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to event/ }))
+      .toHaveAttribute('href', '/events/current-event');
+    expect(screen.getByText('$15.00')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('older-registration-rejection-canary');
+    expect(window.location.pathname).toBe('/events/current-event/register');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('ignores an older event after the current registration slug succeeds', async () => {
+    const olderLookup = {};
+    olderLookup.promise = new Promise((resolve) => {
+      olderLookup.resolve = resolve;
+    });
+    getEventBySlug
+      .mockImplementationOnce(() => olderLookup.promise)
+      .mockResolvedValueOnce(makeRegistrationEvent(
+        'current-event',
+        'Current Registration',
+        2500,
+      ));
+
+    renderPublicEventRegister();
+    expect(getEventBySlug).toHaveBeenCalledWith(firestore, 'synthetic-event');
+
+    window.history.pushState({}, '', '/events/current-event/register');
+    fireEvent(window, new PopStateEvent('popstate'));
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+    expect(screen.getByText('$25.00')).toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.resolve(makeRegistrationEvent('older-event', 'Older Registration', 9900));
+      await olderLookup.promise;
+    });
+
+    expect(screen.getByRole('heading', {
+      level: 1,
+      name: 'Register for Current Registration',
+    })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {
+      level: 1,
+      name: 'Register for Older Registration',
+    })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to event/ }))
+      .toHaveAttribute('href', '/events/current-event');
+    expect(screen.getByText('$25.00')).toBeInTheDocument();
+    expect(screen.queryByText('$99.00')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/events/current-event/register');
+    expect(track).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/events/EventRegister.tsx
+++ b/src/pages/events/EventRegister.tsx
@@ -121,17 +121,17 @@ function EventRegister() {
   }, [user]);
 
   useEffect(() => {
-    if (!isReady || !services || !slug) return;
-    setLoading(true);
+    if (!isReady || !services || !slug) return () => undefined;
+    let active = true; setLoading(true); setEvent(null); setError(null);
     getEventBySlug(services.firebaseResources.firestore, slug)
       .then((e) => {
-        setEvent(e);
-        setLoading(false);
+        if (!active) return;
+        setEvent(e); setLoading(false);
         if (!e) setError('Event not found');
       })
-      .catch(() => { setError(EVENT_LOAD_FAILURE); setLoading(false); });
+      .catch(() => { if (active) { setError(EVENT_LOAD_FAILURE); setLoading(false); } });
+    return () => { active = false; };
   }, [services, isReady, slug]);
-
   const effectiveTier: PriceTier = useMemo(() => {
     if (!event) return 'nonMember';
     const now = Date.now();


### PR DESCRIPTION
## Outcome\n\nThe public event-registration page now accepts event-load results only from the current active slug lookup. Route changes and unmounts make older fulfillment, rejection, and not-found settlement inert, so an older event cannot replace the event/form/link under the current address.\n\n## Change\n\n- Clear obsolete event and load-error state when a valid lookup starts.\n- Deactivate the prior lookup when the effect cleans up.\n- Guard both fulfillment and rejection before any event/error/loading update.\n- Add four actual-App route-lifecycle regressions while preserving all four #266 cases.\n- Add the source-only officer verification, stop, proof, undo, and escalation procedure.\n\nRunner/contact/custom values, signup type, waiver state, submission, checkout, navigation, analytics, event services, Functions, Rules, #121 source decisions, and #249 commerce work are unchanged.\n\n## Verification\n\n- Old-source red proof: 4 existing privacy/preservation cases passed; all 4 new lifecycle cases failed for the intended defect.\n- Focused actual-App suite: 8/8 passed.\n- Full frontend: 12 suites / 293 tests passed.\n- TypeScript no-emit: passed.\n- Deterministic frontend lint: 106 files / 123 reviewed legacy errors / 7 warnings; EventRegister remains 491 lines with all 19 positions unchanged.\n- SPA/workflow/release/Firebase-readback/artifact safety: 53/53 passed.\n- Diagnostic production build and diff check: passed.\n- Three independent final-diff reviews approved integrity/privacy, frontend/testing/accessibility, and officer continuity/scope.\n- Exact three-file diff SHA-256: 1822aeb6720dc07b0f3ceaaf0bb80ae473ecee211971699a2f130997c0fa0af8.\n\n## Residual risk\n\nRoute-scoped runner/form/waiver state and pending checkout settlement are explicitly not fixed here. They need separately claimed review because they involve retention and side-effect decisions.\n\nOfficer impact: Public event-registration pages stay matched to the current address; an older lookup cannot replace the current event form or Back link.\nOfficer documentation: docs/officers/EVENTS_SHOP_MEMBERS.md\nDeployment evidence: Source, local tests, reviewed commit, and this pull request only. No protected release, production website or runmprc.com publication, Firebase deployment, provider configuration, event-record or production-data action, registration/payment action, or live verification occurred.\n\nCloses #268.