### PR TITLE
WEB-PRIVACY-001G: redact Shop checkout-start failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -563,6 +563,48 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public Shop checkout-start failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a public Shop visitor one plain instruction when the website cannot confirm that checkout started, without adding any failure-supplied contact value, database, Firebase, Stripe, provider, endpoint, or technical error to the page.
+
+**Approver:** communications lead plus platform/security owner. Add the treasurer before any live-commerce review.
+
+**Prerequisites:** issue [#272](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/272) must be merged for source review. Use only a made-up product, made-up buyer, and mocked rejected checkout request. Calling the sentence live also requires a protected website publication and an exact revision check on `runmprc.com/shop` without submitting a form or starting checkout. This source change does not prove whether a rejected request reached Firebase or Stripe, make a repeat safe, contact a provider, deploy Firebase, use production data, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Made-up Shop form"] --> B["Mocked checkout-start request"]
+    B -- "Rejected" --> C["Fixed inline alert; product and form remain"]
+    B -- "Resolved" --> D["Existing redirect behavior"]
+```
+
+In words: a mocked rejection keeps the made-up product and form on the page and shows one fixed inline alert; the successful redirect path is unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the checkout-start failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #272 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the test uses only a made-up active product, made-up buyer fields, and a mocked checkout Function rejection.
+4. Confirm the rejection shows exactly `We could not confirm checkout. Please wait before trying again.`
+5. Confirm the complete sentence is announced as one urgent screen-reader alert.
+6. Confirm the made-up product and form values remain visible, no redirect occurs, and the existing busy state ends.
+7. Confirm no contact value supplied only by the rejection, database, Firebase, Stripe, provider, endpoint, token-shaped, or technical detail appears on the page, in five browser console methods, or in analytics. The made-up buyer values remain only in their existing form inputs.
+8. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
+9. Confirm the mocked request still receives the same made-up product slug, buyer fields, optional size/color values, and Firebase app exactly once.
+10. Record website publication, `runmprc.com/shop`, Firebase, Stripe/provider, checkout, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source discards the complete rejected value and uses one fixed inline instruction that does not claim checkout definitely failed. The product and entered values remain visible, the existing busy state ends, and the successful redirect path is unchanged. The button becomes available again as it did before, but this source slice does not prove a repeat is safe; follow the displayed wait instruction until PAY-002/PAY-003 provide durable idempotency, result persistence, and reconciliation.
+
+**Stop conditions:** any real member, customer, order, product, name, email, phone, address, payment, Session, or provider data; a real form submission or checkout attempt; a request for a raw error, private endpoint, token, provider ID, or screenshot containing private values; an attempt to force a production failure; a Firebase, Stripe, or provider change; an unapproved retry; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live or a repeat is safe.
+
+**Success proof:** for source completion, record the exact #272 issue, reviewed pull request, merged commit, two intended old-source failures, green synthetic route tests, relevant full checks, and independent privacy/accessibility review. For live availability, separately record the approved website publication, published revision, and a dated read-only `runmprc.com/shop` revision check without submitting a form or forcing an error. Record Firebase deployment, Stripe/provider configuration or calls, production-data actions, orders, payments, and checkout attempts as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging plan later proves it with test-mode providers and reconciliation.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on `runmprc.com/shop`. Do not undo by changing a product, order, member account, database record, payment, permission, Firebase setting, or Stripe/provider setting.
+
+**Escalation:** communications lead plus platform/security owner. Add the treasurer and use the private incident path if a live request may have reached checkout. Add the privacy owner if any failure-supplied contact value or any provider, endpoint, token-shaped, or technical detail appeared outside the retained made-up form inputs. Do not copy the detail into an issue, message, screenshot, email, or AI tool.
+
 ## Public Events-list load failure privacy — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -15,7 +15,11 @@ import {
   listPublicEvents,
 } from './services/events/eventsService';
 import { track } from './services/analytics/analytics';
-import { getProductBySlug, listActiveProducts } from './services/shop/shopService';
+import {
+  createMerchCheckout,
+  getProductBySlug,
+  listActiveProducts,
+} from './services/shop/shopService';
 import App from './App';
 
 jest.mock('./services/ServiceLocatorProvider', () => function TestServiceLocatorProvider({
@@ -32,6 +36,7 @@ jest.mock('./services/shop/shopService', () => {
   const actual = jest.requireActual('./services/shop/shopService');
   return {
     ...actual,
+    createMerchCheckout: jest.fn(),
     getProductBySlug: jest.fn(),
     listActiveProducts: jest.fn(),
   };
@@ -68,6 +73,7 @@ jest.mock('./services/hooks/useAuth', () => ({
 beforeEach(() => {
   useServiceLocator.mockReset();
   useServiceLocator.mockReturnValue({ services: null, isReady: false });
+  createMerchCheckout.mockReset();
   getProductBySlug.mockReset();
   listActiveProducts.mockReset();
   getEventBySlug.mockReset();
@@ -160,10 +166,12 @@ test('renders the Auth action route and removes its query and fragment before us
 
 const SHOP_LOAD_FAILURE = 'We could not load the shop right now. Please try again later.';
 const PRODUCT_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
+const SHOP_CHECKOUT_FAILURE = 'We could not confirm checkout. Please wait before trying again.';
 const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please try again later.';
 const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const EVENT_REGISTER_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
+const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
 function renderPublicShop() {
@@ -1041,7 +1049,7 @@ describe('public Shop catalog failure boundary', () => {
 describe('public Shop product-load failure boundary', () => {
   beforeEach(() => {
     useServiceLocator.mockReturnValue({
-      services: { firebaseResources: { firestore } },
+      services: { firebaseResources: { app: firebaseApp, firestore } },
       isReady: true,
     });
     getProductBySlug.mockResolvedValue(null);
@@ -1209,5 +1217,122 @@ describe('public Shop product-load failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
     expect(getProductBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  test('replaces rejected checkout details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    getProductBySlug.mockResolvedValueOnce({
+      id: 'synthetic-product',
+      slug: 'synthetic-product',
+      title: 'Synthetic Product',
+      description: 'A made-up product used only for this test.',
+      imageUrl: '',
+      priceCents: 3000,
+      status: 'active',
+      sizes: [],
+      colors: [],
+    });
+    createMerchCheckout.mockRejectedValueOnce(Object.assign(
+      new Error('checkout-provider-private-canary private-leak@example.test'),
+      {
+        code: 'functions/checkout-provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=checkout-secret-canary',
+      },
+    ));
+
+    renderPublicProduct();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('First name'), {
+      target: { value: 'Synthetic' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Last name'), {
+      target: { value: 'Buyer' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'buyer@example.test' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Phone (optional)'), {
+      target: { value: '+1 555 010 2720' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Buy — $30.00' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(SHOP_CHECKOUT_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /checkout-provider-private-canary|private-leak@example\.test|provider\.example|checkout-secret-canary/i,
+    );
+    expect(createMerchCheckout).toHaveBeenCalledWith(firebaseApp, {
+      productSlug: 'synthetic-product',
+      buyer: {
+        firstName: 'Synthetic',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+        phone: '+1 555 010 2720',
+      },
+      size: undefined,
+      color: undefined,
+    });
+    expect(createMerchCheckout).toHaveBeenCalledTimes(1);
+    expect(screen.getByPlaceholderText('First name')).toHaveValue('Synthetic');
+    expect(screen.getByPlaceholderText('Last name')).toHaveValue('Buyer');
+    expect(screen.getByPlaceholderText('Email')).toHaveValue('buyer@example.test');
+    expect(screen.getByPlaceholderText('Phone (optional)')).toHaveValue('+1 555 010 2720');
+    expect(screen.getByRole('button', { name: 'Buy — $30.00' })).toBeEnabled();
+    expect(window.location.pathname).toBe('/shop/synthetic-product');
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile checkout rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('checkout-message-getter-canary');
+    });
+    getProductBySlug.mockResolvedValueOnce({
+      id: 'synthetic-product',
+      slug: 'synthetic-product',
+      title: 'Synthetic Product',
+      description: 'A made-up product used only for this test.',
+      imageUrl: '',
+      priceCents: 3000,
+      status: 'active',
+      sizes: [],
+      colors: [],
+    });
+    createMerchCheckout.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderPublicProduct();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('First name'), {
+      target: { value: 'Synthetic' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Last name'), {
+      target: { value: 'Buyer' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'buyer@example.test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Buy — $30.00' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(SHOP_CHECKOUT_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('checkout-message-getter-canary');
+    expect(createMerchCheckout).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { level: 1, name: 'Synthetic Product' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Buy — $30.00' })).toBeEnabled();
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });

--- a/src/pages/shop/ProductDetail.tsx
+++ b/src/pages/shop/ProductDetail.tsx
@@ -47,7 +47,7 @@ function ProductDetail() {
   }, [user]);
 
   if (loading) return <div className="container mx-auto p-6">Loading...</div>;
-  if (error || !product) {
+  if (!product) {
     return (
       <div className="container mx-auto p-6">
         <p role={!product && error ? 'alert' : undefined} aria-live={!product && error ? 'assertive' : undefined} aria-atomic={!product && error ? true : undefined} className="text-red-500">{error || 'Product not found.'}</p>
@@ -81,8 +81,8 @@ function ProductDetail() {
         },
       );
       window.location.href = result.url;
-    } catch (err: any) {
-      setError(err?.message || 'Checkout failed');
+    } catch {
+      setError('We could not confirm checkout. Please wait before trying again.');
       setSubmitting(false);
     }
   }
@@ -180,7 +180,7 @@ function ProductDetail() {
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
               />
-              {error && <p className="text-red-600 text-sm">{error}</p>}
+              {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-red-600 text-sm">{error}</p>}
               <button
                 type="submit"
                 disabled={!canBuy || submitting}


### PR DESCRIPTION
## Outcome

The public Shop product page now replaces a rejected checkout-start value with one fixed, accessible instruction: `We could not confirm checkout. Please wait before trying again.` The complete rejection is discarded without inspection, logging, analytics, storage, or rendering, while the product and entered form values remain visible.

Closes #272

## Scope and invariant

- Change only the ProductDetail checkout rejection boundary and its inline alert attributes.
- Keep product-load, missing-product, stale-request, request-payload, success-redirect, price, availability, and payment behavior unchanged.
- Prove both an ordinary private rejection and a hostile value with a throwing `message` getter cannot escape.
- Preserve the exact request once, retain the made-up form values and route, release the existing busy state, and emit no analytics or five-method console output.
- Add one separately named source-only officer review procedure with synthetic-only and no-live-action limits.

The outcome is intentionally ambiguous: a rejection does not prove checkout failed. The button becomes available as it did before, but this slice does not make a repeat safe or provide durable idempotency, result persistence, or reconciliation.

## Verification

- Old-source regression proof: 6 existing focused product tests passed; both new checkout privacy tests failed as intended through raw message rendering/getter access.
- Fixed focused product route tests: 8/8 passed.
- Full frontend Jest: 295/295 passed.
- TypeScript `tsc --noEmit`: passed.
- Frontend lint baseline: unchanged at 106 files, 123 reviewed errors, 7 reviewed warnings.
- SPA/workflow/release/artifact safety: 53/53 passed.
- Diagnostic production build: passed without regenerating the sitemap.
- Functions lint: passed.
- Full Functions unit suite: 1,554 passed; 64 skipped.
- Commerce command-journal emulator: 63/63 passed on demo project `demo-pay002b2-test`.
- Firestore Rules emulator: 378/378 passed on demo project `demo-rules-test`.
- `git diff --check`: passed.
- Final exact diff SHA-256: `88afde0eccc3a573d04d7a75d21fb58541416c8b579c1dfdcd3af84d3b9b46c9`.
- Three independent read-only reviews approved UX/accessibility, privacy/security/reliability, and officer documentation/scope with no actionable findings.

## Compatibility and migration

No schema, request, success result, redirect, role, permission, Function, Rules, provider, price, inventory, payment, or data migration. The failure result remains synthetic-test evidence only. A backup officer can review the written evidence, but platform/release specialists remain necessary for revision evidence and any later protected publication.

Officer impact: Officers gain a source-only, synthetic review procedure for the fixed Shop checkout-start failure instruction. It is marked NOT AVAILABLE YET and authorizes no live form submission or checkout attempt.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — added `Public Shop checkout-start failure privacy — SOURCE ONLY, NOT LIVE`.

Deployment evidence: Source and synthetic local tests only. No website publication, `runmprc.com` revision verification, Firebase deployment, Stripe/provider configuration or call, checkout attempt, order/payment action, production-data access, or live behavior verification occurred.
