### PR TITLE
WEB-PRIVACY-001H: redact event-registration submit failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -816,6 +816,51 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Public event-registration submission failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give a public event-registration visitor one plain instruction when the website cannot confirm a submission, without adding any failure-supplied runner, contact, Firebase, Stripe, provider, endpoint, token-shaped, or technical detail to the page or analytics.
+
+**Approver:** events lead plus platform/security owner. Add the treasurer before any live paid-registration review.
+
+**Prerequisites:** issue [#274](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/274) must be merged for source review. Use only a made-up event, made-up runner and contact values, a made-up waiver, and a mocked rejected submission. Calling the sentence live also requires a protected website publication and an exact revision check on the affected `runmprc.com/events/.../register` page without entering data, accepting a waiver, submitting, or starting checkout. This source change does not prove whether a rejected request reached Firebase or Stripe, make a repeat safe, contact a provider, deploy Firebase, use production data, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Made-up registration form"] --> B["Mocked submission request"]
+    B -- "Rejected" --> C["Fixed inline alert; event and form remain"]
+    B -- "Resolved" --> D["Existing free or paid success path"]
+```
+
+In words: a mocked rejection keeps the made-up event, form, answers, and waiver selection on the page and shows one fixed inline alert; the existing successful free-registration and paid-checkout paths are unchanged.
+
+Officer review steps after the source merge:
+
+1. Keep the submission-failure sentence marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #274 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up public event, made-up runner and emergency-contact fields, a made-up waiver, and a mocked checkout Function rejection.
+4. Confirm the rejection shows exactly `We could not confirm your registration. Please wait before trying again.`
+5. Confirm the complete sentence is announced as one urgent screen-reader alert.
+6. Confirm the made-up event, route, form values, and waiver selection remain visible, no navigation or redirect occurs, and the existing busy state ends.
+7. Confirm no contact value supplied only by the rejection, Firebase, Stripe, provider, endpoint, token-shaped, or technical detail appears on the page, in five browser console methods, or in analytics. The made-up runner and contact values remain only in their existing form inputs and mocked request.
+8. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
+9. Confirm the mocked request still receives the same Firebase app and made-up event, runner, custom-field, signup-type, waiver, and price-tier projection exactly once.
+10. Confirm the existing submit-attempt analytics marker remains and the registration-error marker contains only the made-up public event slug, with no rejected value or property.
+11. Record source change, tests, merge, preview, website publication, the exact `runmprc.com` registration page, Firebase, Stripe/provider, registration/checkout, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source discards the complete rejected value and uses one fixed inline instruction that does not claim registration definitely failed. The event and entered values remain visible, the existing busy state ends, and successful free-registration navigation and paid-checkout redirect stay unchanged. The button becomes available again as it did before, but this source slice does not prove a repeat is safe; follow the displayed wait instruction until PAY-002/PAY-003 provide durable idempotency, result persistence, and reconciliation.
+
+**Stop conditions:** any real member, runner, registration, private event record, name, email, phone, birth date, emergency contact, waiver, payment, Session, or provider data used to exercise the synthetic failure review; entry or submission of a real form; acceptance of a real waiver; a real registration or checkout attempt; a request for a raw error, private endpoint, token, provider ID, or screenshot containing private values; an attempt to force a production failure; a Firebase, Stripe, provider, event-record, or analytics change; an unapproved retry; or a claim that source, tests, merge, preview, or a green workflow proves the sentence is live or a repeat is safe. A later approved revision check may open the already-public event page read-only but must not enter data, accept a waiver, submit, start checkout, or force a failure.
+
+**Success proof:** for source completion, record the exact #274 issue, reviewed pull request, merged commit, eight preserved old-source tests plus two intended old-source failures, ten green synthetic registration route tests, relevant full checks, and independent privacy/accessibility review. For live availability, separately record the approved website publication, published revision, and a dated read-only `runmprc.com` registration-page revision check without entering data, accepting a waiver, submitting, or forcing an error. Record Firebase deployment, Stripe/provider configuration or calls, event-record and production-data actions, registrations, payments, and checkout attempts as **not performed** for this frontend-only change. The failure path remains synthetic-test evidence unless an approved isolated staging plan later proves it with test-mode providers and reconciliation.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision on the affected `runmprc.com` registration page. Do not undo by changing an event, registration, member account, database record, payment, waiver, permission, Firebase setting, analytics setting, or Stripe/provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the treasurer and use the private incident path if a live request may have reached registration or checkout. Add the privacy owner if any failure-supplied runner/contact value or any Firebase, Stripe, provider, endpoint, token-shaped, or technical detail appeared outside the retained made-up form inputs and mocked request. Do not copy the detail into an issue, message, screenshot, email, or AI tool.
+
+No system-topology diagram changes for this source slice; the state-flow diagram above records the page's failure-display change, while data movement, permissions, account ownership, and deployment topology remain unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -10,11 +10,12 @@ import {
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
 import {
+  createCheckoutSession,
   getEventBySlug,
   listMemberEvents,
   listPublicEvents,
 } from './services/events/eventsService';
-import { track } from './services/analytics/analytics';
+import { events as analyticsEvents, track } from './services/analytics/analytics';
 import {
   createMerchCheckout,
   getProductBySlug,
@@ -46,6 +47,7 @@ jest.mock('./services/events/eventsService', () => {
   const actual = jest.requireActual('./services/events/eventsService');
   return {
     ...actual,
+    createCheckoutSession: jest.fn(),
     getEventBySlug: jest.fn(),
     listMemberEvents: jest.fn(),
     listPublicEvents: jest.fn(),
@@ -76,6 +78,7 @@ beforeEach(() => {
   createMerchCheckout.mockReset();
   getProductBySlug.mockReset();
   listActiveProducts.mockReset();
+  createCheckoutSession.mockReset();
   getEventBySlug.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
@@ -171,6 +174,7 @@ const EVENTS_LOAD_FAILURE = 'Error: We could not load events right now. Please t
 const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const EVENT_REGISTER_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
+const EVENT_REGISTER_SUBMIT_FAILURE = 'We could not confirm your registration. Please wait before trying again.';
 const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
@@ -949,6 +953,173 @@ describe('public Event-registration load failure boundary', () => {
     expect(screen.queryByText('$99.00')).not.toBeInTheDocument();
     expect(window.location.pathname).toBe('/events/current-event/register');
     expect(track).not.toHaveBeenCalled();
+  });
+});
+
+describe('public Event-registration submit failure boundary', () => {
+  const syntheticEvent = {
+    id: 'synthetic-event',
+    slug: 'synthetic-event',
+    title: 'Synthetic Registration Event',
+    description: 'A made-up event used only for this test.',
+    startAt: { toDate: () => new Date('2030-01-12T16:00:00Z') },
+    location: 'Made-up Park',
+    capacity: null,
+    registeredCount: 0,
+    status: 'open',
+    visibility: 'public',
+    pricing: { memberCents: 1000, nonMemberCents: 1500 },
+    customFields: [],
+    volunteerFields: [],
+    volunteerEnabled: false,
+    waiverText: 'Made-up waiver text.',
+  };
+
+  beforeEach(() => {
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: true,
+    });
+    getEventBySlug.mockResolvedValue(syntheticEvent);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function fillRequiredRegistrationFields() {
+    fireEvent.change(screen.getByRole('textbox', { name: 'First name *' }), {
+      target: { value: 'Synthetic' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Last name *' }), {
+      target: { value: 'Runner' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email *' }), {
+      target: { value: 'runner@example.test' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /accept the waiver/i }));
+  }
+
+  test('replaces rejected submission details with one fixed accessible result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    createCheckoutSession.mockRejectedValueOnce(Object.assign(
+      new Error('registration-provider-private-canary private-leak@example.test'),
+      {
+        code: 'functions/registration-provider-private-canary',
+        endpoint: 'https://provider.example.test/?token=registration-secret-canary',
+      },
+    ));
+
+    renderPublicEventRegister();
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Synthetic Registration Event',
+    })).toBeInTheDocument();
+    fillRequiredRegistrationFields();
+    fireEvent.change(screen.getAllByRole('textbox', { name: 'Phone' })[0], {
+      target: { value: '+1 555 010 2740' },
+    });
+    fireEvent.change(screen.getByLabelText('Date of birth'), {
+      target: { value: '1990-01-02' },
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Shirt size' }), {
+      target: { value: 'M' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), {
+      target: { value: 'Synthetic Contact' },
+    });
+    fireEvent.change(screen.getAllByRole('textbox', { name: 'Phone' })[1], {
+      target: { value: '+1 555 010 2741' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to payment — $15.00' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(EVENT_REGISTER_SUBMIT_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /registration-provider-private-canary|private-leak@example\.test|provider\.example|registration-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /registration-provider-private-canary|private-leak@example\.test|provider\.example|registration-secret-canary/i,
+    );
+    expect(createCheckoutSession).toHaveBeenCalledWith(firebaseApp, {
+      eventId: 'synthetic-event',
+      runner: {
+        firstName: 'Synthetic',
+        lastName: 'Runner',
+        email: 'runner@example.test',
+        phone: '+1 555 010 2740',
+        dob: '1990-01-02',
+        shirtSize: 'M',
+        emergencyContactName: 'Synthetic Contact',
+        emergencyContactPhone: '+1 555 010 2741',
+      },
+      customFields: {},
+      signupType: 'participant',
+      acceptedWaiver: true,
+      priceTier: 'nonMember',
+    });
+    expect(createCheckoutSession).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenNthCalledWith(1, analyticsEvents.registrationSubmitAttempt, {
+      slug: 'synthetic-event', tier: 'nonMember', signup_type: 'participant',
+    });
+    expect(track).toHaveBeenNthCalledWith(2, analyticsEvents.registrationError, {
+      slug: 'synthetic-event',
+    });
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('heading', {
+      level: 1,
+      name: 'Register for Synthetic Registration Event',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'First name *' })).toHaveValue('Synthetic');
+    expect(screen.getByRole('textbox', { name: 'Last name *' })).toHaveValue('Runner');
+    expect(screen.getByRole('textbox', { name: 'Email *' })).toHaveValue('runner@example.test');
+    expect(screen.getByRole('checkbox', { name: /accept the waiver/i })).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Continue to payment — $15.00' })).toBeEnabled();
+    expect(window.location.pathname).toBe('/events/synthetic-event/register');
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile submission rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('registration-message-getter-canary');
+    });
+    createCheckoutSession.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderPublicEventRegister();
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Register for Synthetic Registration Event',
+    })).toBeInTheDocument();
+    fillRequiredRegistrationFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to payment — $15.00' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(EVENT_REGISTER_SUBMIT_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('registration-message-getter-canary');
+    expect(JSON.stringify(track.mock.calls)).not.toContain('registration-message-getter-canary');
+    expect(createCheckoutSession).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenNthCalledWith(2, analyticsEvents.registrationError, {
+      slug: 'synthetic-event',
+    });
+    expect(screen.getByRole('heading', {
+      level: 1,
+      name: 'Register for Synthetic Registration Event',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Email *' })).toHaveValue('runner@example.test');
+    expect(screen.getByRole('checkbox', { name: /accept the waiver/i })).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Continue to payment — $15.00' })).toBeEnabled();
+    expect(window.location.pathname).toBe('/events/synthetic-event/register');
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });
 

--- a/src/pages/events/EventRegister.tsx
+++ b/src/pages/events/EventRegister.tsx
@@ -15,8 +15,8 @@ import buildRaceCheckoutRequest, {
   customValuesAfterSignupTypeChange,
 } from './raceCheckoutRequest';
 
+const SUBMIT_FAILURE = 'We could not confirm your registration. Please wait before trying again.';
 type PriceTier = 'member' | 'nonMember' | 'earlyBird';
-
 interface RunnerFormState {
   firstName: string;
   lastName: string;
@@ -152,7 +152,7 @@ function EventRegister() {
   }, [event, effectiveTier]);
 
   if (loading) return <div className="container mx-auto p-6">Loading...</div>;
-  if (error || !event) {
+  if (!event) {
     return (
       <div className="container mx-auto p-6">
         <p role={error === EVENT_LOAD_FAILURE ? 'alert' : undefined} aria-live={error === EVENT_LOAD_FAILURE ? 'assertive' : undefined} aria-atomic={error === EVENT_LOAD_FAILURE ? true : undefined} className="text-red-500">{error || 'Event not found.'}</p>
@@ -220,11 +220,11 @@ function EventRegister() {
         return;
       }
       setError('Unexpected response from checkout service.');
-    } catch (err: any) {
+    } catch {
       track(analyticsEvents.registrationError, {
-        slug: event?.slug, message: err?.message?.slice(0, 100),
+        slug: event.slug,
       });
-      setError(err?.message || 'Registration failed.');
+      setError(SUBMIT_FAILURE);
     } finally {
       setSubmitting(false);
     }
@@ -455,7 +455,7 @@ function EventRegister() {
             </fieldset>
           )}
 
-          {error && <p className="text-red-600 text-sm">{error}</p>}
+          {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-red-600 text-sm">{error}</p>}
 
           <button
             type="submit"


### PR DESCRIPTION
## Outcome

The public event-registration page now replaces a rejected submission value with one fixed, accessible instruction: `We could not confirm your registration. Please wait before trying again.` The complete rejection is discarded without inspection, logging, storage, rendering, or analytics detail, while the event, entered form values, waiver selection, exact request, and existing busy-state release remain intact.

Closes #274

## Scope and invariant

- Change only the EventRegister submit rejection boundary, load-versus-inline error gate, and existing inline alert attributes.
- Keep the registration-error analytics marker with only the already-public event slug; remove all caught detail.
- Keep event loading/missing/lifecycle, runner/custom/waiver fields, request projection, fixed unexpected-response branch, free-registration navigation, paid-checkout redirect, price, availability, membership, and payment behavior unchanged.
- Prove both an ordinary private rejection and a hostile value with a throwing `message` getter cannot escape.
- Preserve the exact request once, retain the made-up event/form/waiver/route, release the existing busy state, and emit no five-method console output.
- Add one separately named source-only officer review procedure with synthetic-only and no-live-action limits.

The outcome is intentionally ambiguous: a browser rejection does not prove registration or checkout failed. The button becomes available as it did before, but this slice does not make a repeat safe or provide durable idempotency, result persistence, or reconciliation.

## Verification

- Old-source regression proof: all 8 existing EventRegister load/lifecycle tests passed; both new submit privacy tests failed as intended through raw DOM/analytics exposure and hostile getter access.
- Fixed focused EventRegister route tests: 10/10 passed.
- Complete `src/App.test.jsx` route suite: 42/42 passed.
- Full frontend Jest: 297/297 passed.
- TypeScript `tsc --noEmit`: passed.
- Frontend lint baseline: unchanged at 106 files, 123 reviewed errors, 7 reviewed warnings; EventRegister remains 491 lines with all 19 legacy lint locations unchanged.
- SPA/workflow/release/artifact safety: 53/53 passed.
- Diagnostic production build: passed without regenerating the sitemap.
- Functions lint: passed.
- Full Functions unit suite: 1,627 passed; 64 skipped.
- Commerce command-journal emulator: 63/63 passed on demo project `demo-pay002b2-test`.
- Firestore Rules emulator: 378/378 passed on demo project `demo-rules-test`.
- `git diff --check`: passed.
- Final exact diff SHA-256: `ee2237a53ff758e02a2b7a5ad51fffbf7741272d89a74c90774c24d0aad270d6`.
- Three independent read-only reviews approved privacy/security/reliability, UX/accessibility/test quality, and officer documentation/scope with no remaining findings.

## Compatibility and migration

No schema, request, success result, navigation, redirect, role, permission, Function, Rules, provider, price, capacity, payment, analytics implementation, or data migration. The successful free and paid branches are byte-untouched. The fixed unexpected-resolved-response branch is also unchanged.

Residual work remains explicit: a pending submission is not yet bound to the route that started it, returned URLs are not validated by this slice, and browser rejection remains an unknown backend/provider outcome. Durable idempotency, result persistence, and reconciliation remain future commerce work.

Officer impact: Officers gain a source-only, synthetic review procedure for the fixed public registration-submission failure instruction. It is marked NOT AVAILABLE YET and authorizes no real data entry, waiver acceptance, submission, registration, or checkout attempt.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — added `Public event-registration submission failure privacy — SOURCE ONLY, NOT LIVE`.

Deployment evidence: Source and synthetic local tests only. No website publication, `runmprc.com` revision verification, Firebase deployment, Stripe/provider configuration or call, registration/checkout attempt, event/order/payment action, production-data access, or live behavior verification occurred.
