### PR TITLE
WEB-PRIVACY-001I: redact Admin Products list-load failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -958,6 +958,53 @@ Before an officer click guide may be added, a claimed issue must prove all of th
 
 Until that issue closes, request event/product changes through [Request a change](./REQUEST_A_CHANGE.md). Use a reviewed pull request or a specialist-run, test-only demonstration; do not enter real members, registrations, products, prices, or payment details.
 
+### Admin product-list load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give an officer one plain instruction when the Admin Products list cannot load, without showing a Firebase, database, provider, account, endpoint, token-shaped, or technical detail and without falsely saying that the catalog is empty.
+
+**Approver:** shop lead plus platform/security and privacy owners. Add the treasurer before any future live commerce-admin review.
+
+**Prerequisites:** issue [#277](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/277) must be merged for source review. Use only a mocked admin identity, mocked database reference, made-up product, and mocked rejected list lookup. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply: this slice does not approve the screen, role, permissions, backup, preview, rollback, product editing, publication, checkout, or production use. It does not deploy Firebase, change database permissions or product records, contact Stripe or another provider, use production data, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Made-up Admin Products route"] --> B["Mocked product-list lookup"]
+    B -- "Fulfilled empty" --> C["Existing No products yet state"]
+    B -- "Fulfilled with products" --> D["Existing product table"]
+    B -- "Rejected" --> E["Fixed alert; no empty state or table"]
+```
+
+In words: only a successful mocked lookup may show the existing empty catalog or product table. A mocked rejection shows one fixed alert while keeping the Products heading and navigation; it does not turn an unknown result into an empty catalog.
+
+Officer review steps after the source merge:
+
+1. Keep the Admin product-list failure sentence and the complete Admin Products screen marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #277 issue, reviewed pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up admin identity, mocked database reference, made-up product, and mocked lookup. Do not use a real officer account or product record.
+4. Confirm a mocked rejection shows exactly `We could not load products right now. Please try again later.`
+5. Confirm assistive technology receives the complete sentence immediately as one alert.
+6. Confirm no made-up rejection-only email, database, Firebase, provider, account, endpoint, token-shaped, or technical detail appears on the page, in analytics, or in five browser console methods.
+7. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
+8. Confirm the rejected lookup ends loading and shows neither **No products yet** nor a product table.
+9. Confirm the **Products** heading and existing **Orders** and **New product** links remain available without following either link.
+10. Confirm the mocked lookup receives the same mocked database reference exactly once.
+11. Confirm a successful mocked empty list still shows **No products yet**, and a successful made-up product still shows its existing title, price, status, and edit link.
+12. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, product-record, production-data, admin-screen approval, and live-behavior evidence as separate results.
+
+**Expected result:** the reviewed source discards the complete rejected value without binding or inspecting it and shows one fixed accessible retry-later sentence. A failure is not treated as an empty or populated catalog. The Products heading and navigation remain, while genuine successful empty and populated results keep their existing displays. This does not authorize an officer to open or use the Admin Products screen live.
+
+**Stop conditions:** any real officer, member, product, price, inventory, order, checkout, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; the false empty state or a product table after rejection; an attempted product/admin write; a Firebase, Rules, provider, or permission change; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or Admin screen is live.
+
+**Success proof:** for source completion, record the exact #277 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic actual-route tests, relevant full checks, and independent privacy, accessibility, and officer-continuity reviews. The safe review path stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, database-permission changes, provider configuration, product-record changes, production-data actions, and live behavior as **not performed** for this frontend-only slice unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After any later approved publication, use the same protected website release path and verify the replacement revision. Do not undo by changing or deleting a product, order, payment, officer account, permission, database record, source document, or provider setting.
+
+**Escalation:** shop lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, Firebase, provider, account, product, order, payment, endpoint, token-shaped, or technical detail appeared. Add the treasurer if a commerce or payment state might be involved. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
+
 ## Stop conditions
 
 Stop if staging is not isolated, the owner/policy is missing, a test uses real people or money, Firebase deployment skipped, rollback is untested, or the requested action directly edits payment/member state.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -16,10 +16,12 @@ import {
   listPublicEvents,
 } from './services/events/eventsService';
 import { events as analyticsEvents, track } from './services/analytics/analytics';
+import { useAuth } from './services/hooks/useAuth';
 import {
   createMerchCheckout,
   getProductBySlug,
   listActiveProducts,
+  listAllProducts,
 } from './services/shop/shopService';
 import App from './App';
 
@@ -40,6 +42,7 @@ jest.mock('./services/shop/shopService', () => {
     createMerchCheckout: jest.fn(),
     getProductBySlug: jest.fn(),
     listActiveProducts: jest.fn(),
+    listAllProducts: jest.fn(),
   };
 });
 
@@ -60,7 +63,7 @@ jest.mock('./services/analytics/analytics', () => {
 });
 
 jest.mock('./services/hooks/useAuth', () => ({
-  useAuth: () => ({
+  useAuth: jest.fn(() => ({
     user: null,
     isLoading: false,
     isAuthenticated: false,
@@ -69,7 +72,7 @@ jest.mock('./services/hooks/useAuth', () => ({
     signIn: jest.fn(),
     signOut: jest.fn(),
     register: jest.fn(),
-  }),
+  })),
 }));
 
 beforeEach(() => {
@@ -78,11 +81,23 @@ beforeEach(() => {
   createMerchCheckout.mockReset();
   getProductBySlug.mockReset();
   listActiveProducts.mockReset();
+  listAllProducts.mockReset();
   createCheckoutSession.mockReset();
   getEventBySlug.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
   track.mockReset();
+  useAuth.mockReset();
+  useAuth.mockReturnValue({
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+    isMember: false,
+    isAdmin: false,
+    signIn: jest.fn(),
+    signOut: jest.fn(),
+    register: jest.fn(),
+  });
 });
 
 afterEach(() => {
@@ -175,6 +190,7 @@ const EVENTS_CALENDAR_LOAD_FAILURE = 'We could not load events right now. Please
 const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const EVENT_REGISTER_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const EVENT_REGISTER_SUBMIT_FAILURE = 'We could not confirm your registration. Please wait before trying again.';
+const ADMIN_PRODUCTS_LOAD_FAILURE = 'We could not load products right now. Please try again later.';
 const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
@@ -205,6 +221,11 @@ function renderPublicEventDetail() {
 
 function renderPublicEventRegister() {
   window.history.pushState({}, '', '/events/synthetic-event/register');
+  return render(<App />);
+}
+
+function renderAdminProducts() {
+  window.history.pushState({}, '', '/admin/products');
   return render(<App />);
 }
 
@@ -1505,5 +1526,135 @@ describe('public Shop product-load failure boundary', () => {
     expect(screen.getByRole('button', { name: 'Buy — $30.00' })).toBeEnabled();
     expect(track).not.toHaveBeenCalled();
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});
+
+describe('Admin Products list-load failure boundary', () => {
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    listAllProducts.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected list details with one fixed accessible unknown outcome', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listAllProducts.mockRejectedValueOnce(Object.assign(
+      new Error('admin-products-private-canary officer@example.test'),
+      {
+        code: 'firestore/admin-products-private-canary',
+        endpoint: 'https://provider.example.test/?token=admin-products-secret-canary',
+      },
+    ));
+
+    renderAdminProducts();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_PRODUCTS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /admin-products-private-canary|officer@example\.test|provider\.example|admin-products-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /admin-products-private-canary|officer@example\.test|provider\.example|admin-products-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create one' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Products' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Orders' })).toHaveAttribute('href', '/admin/orders');
+    expect(screen.getByRole('link', { name: '+ New product' }))
+      .toHaveAttribute('href', '/admin/products/new');
+    expect(listAllProducts).toHaveBeenCalledWith(firestore);
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/admin/products');
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile list rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('admin-products-message-getter-canary');
+    });
+    listAllProducts.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderAdminProducts();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(ADMIN_PRODUCTS_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('admin-products-message-getter-canary');
+    expect(JSON.stringify(track.mock.calls)).not.toContain('admin-products-message-getter-canary');
+    expect(screen.queryByRole('link', { name: 'Create one' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Products' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Orders' })).toHaveAttribute('href', '/admin/orders');
+    expect(screen.getByRole('link', { name: '+ New product' }))
+      .toHaveAttribute('href', '/admin/products/new');
+    expect(listAllProducts).toHaveBeenCalledWith(firestore);
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/admin/products');
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the existing successful empty-catalog result', async () => {
+    renderAdminProducts();
+
+    const emptyStateLink = await screen.findByRole('link', { name: 'Create one' });
+    expect(emptyStateLink).toHaveAttribute('href', '/admin/products/new');
+    expect(emptyStateLink.parentElement).toHaveTextContent('No products yet. Create one.');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllProducts).toHaveBeenCalledWith(firestore);
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the existing successful product projection', async () => {
+    listAllProducts.mockResolvedValueOnce([{
+      id: 'synthetic-product',
+      slug: 'synthetic-club-shirt',
+      title: 'Synthetic Club Shirt',
+      description: 'A made-up product used only for this test.',
+      imageUrl: '',
+      priceCents: 2500,
+      status: 'active',
+      sizes: [],
+      colors: [],
+    }]);
+
+    renderAdminProducts();
+
+    expect(await screen.findByRole('link', { name: 'Synthetic Club Shirt' }))
+      .toHaveAttribute('href', '/admin/products/synthetic-club-shirt/edit');
+    expect(screen.getByText('$25.00')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Edit' }))
+      .toHaveAttribute('href', '/admin/products/synthetic-club-shirt/edit');
+    expect(screen.queryByRole('link', { name: 'Create one' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllProducts).toHaveBeenCalledWith(firestore);
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/admin/shop/AdminProducts.tsx
+++ b/src/pages/admin/shop/AdminProducts.tsx
@@ -6,6 +6,8 @@ import { useServiceLocator } from '../../../services/ServiceLocatorContext';
 import { Product } from '../../../types/shop';
 import { listAllProducts, formatPrice } from '../../../services/shop/shopService';
 
+const LOAD_FAILURE = 'We could not load products right now. Please try again later.';
+
 function StatusPill({ status }: { status: string }) {
   const m: Record<string, string> = {
     draft: 'bg-gray-200 text-gray-700',
@@ -26,7 +28,7 @@ function Inner() {
     if (!isReady || !services) return;
     listAllProducts(services.firebaseResources.firestore)
       .then((ps) => { setProducts(ps); setLoading(false); })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .catch(() => { setError(LOAD_FAILURE); setLoading(false); });
   }, [services, isReady]);
 
   return (
@@ -49,9 +51,13 @@ function Inner() {
         </div>
 
         {loading && <p>Loading...</p>}
-        {error && <p className="text-red-500">{error}</p>}
+        {error && (
+          <p className="text-red-500" role="alert" aria-live="assertive" aria-atomic="true">
+            {error}
+          </p>
+        )}
 
-        {!loading && products.length === 0 && (
+        {!error && !loading && products.length === 0 && (
           <p className="text-gray-600">
             No products yet.
             {' '}
@@ -59,7 +65,7 @@ function Inner() {
             .
           </p>
         )}
-        {!loading && products.length > 0 && (
+        {!error && !loading && products.length > 0 && (
           <table className="w-full border-collapse">
             <thead>
               <tr className="border-b bg-gray-50">


### PR DESCRIPTION
## Outcome

The officer-only Admin Products page now discards a failed product-list lookup without binding or inspecting it. It shows one fixed accessible recovery sentence and no longer turns an unknown failure into `No products yet` or a stale product table.

The Products heading and existing Orders/New product links remain available. Successful empty and populated list behavior is unchanged.

Closes #277.

## Exact scope

- `src/pages/admin/shop/AdminProducts.tsx`: fixed failure sentence, unbound catch, assertive atomic alert, and success-only empty/table gates.
- `src/App.test.jsx`: actual `/admin/products` route tests using a synthetic admin and mocked Firestore reference; ordinary/private-canary and hostile-getter failures; exact request, route, navigation, console/analytics silence, and both success states.
- `docs/officers/EVENTS_SHOP_MEMBERS.md`: separately named source-only officer procedure under the existing unapproved Admin-screen boundary.

No service, Function, Firestore Rule, Auth/App Check boundary, product/price/inventory/business state, checkout/payment, package, lint ledger, workflow, root architecture/security/commerce document, provider configuration, deployment, migration, or production data changed.

## Red / green proof

Old source with the focused tests:

- 2 existing success states passed.
- Ordinary rejection failed because raw private/provider canaries were rendered with no alert and `No products yet` also appeared.
- Hostile rejection failed because its throwing `message` getter executed and the page never reached the expected alert.

Final source:

- Focused Admin Products boundary: 4/4.
- Full `src/App.test.jsx`: 46/46.
- Full frontend: 301/301.
- TypeScript: passed.
- Frontend lint ledger: unchanged at 106 files / 123 reviewed errors / 7 warnings.
- SPA callback plus workflow/release/Firebase-readback/artifact safety: 53/53.
- Diagnostic production build: passed without sitemap regeneration.
- Functions lint: passed.
- Functions tests: 1,627 active passed / 64 skipped.
- Firestore Rules emulator: 378/378.
- Real commerce concurrency emulator: 63/63.
- `git diff --check`: passed.

Three independent final reviews approved the exact diff with no P0–P3 findings: security/privacy/reliability; UX/accessibility/testing; and officer continuity/scope/collision.

Reviewed head after preserving merged #275: `47b94198d241a3d71180ac7674a4be9e1e1689ab`

Reviewed exact-diff SHA-256: `644aa9b343ac1e231e3efb4d029e121b8beeb82489ec5199a08fc59e79c19b50`

## Residual risk

- This slice does not approve the Admin Products screen for officer use. The broader permission, backup, preview, audit, rollback, and no-code commerce-control prerequisites remain open.
- A provider result remains unknown on rejection. This read-only list lookup makes no product or payment transition, but source tests do not prove live Firebase/provider behavior.
- Other admin raw-error boundaries remain separate tickets and are not silently included here.

Officer impact: Officers who cannot load the product list receive one plain retry-later instruction instead of technical/provider detail or a false empty catalog. The Admin screen remains NOT AVAILABLE YET.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`

Deployment evidence: Local source and synthetic tests passed. A PR-only preview may be created by GitHub/Netlify after publication. No release workflow, website publication, exact `runmprc.com` verification, Firebase deployment, Rules change, provider configuration, product-record action, production-data action, or live behavior is claimed by this PR.
