### PR TITLE
OAUTH-001C1E: validate Strava exchange success before writes

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -1,6 +1,8 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const { Timestamp } = require('firebase-admin/firestore');
+const { URL: NodeURL } = require('node:url');
+const { types: { isProxy } } = require('node:util');
 const { requireAppCheck } = require('./stripeHelpers');
 
 const STRAVA_TOKEN_URL = 'https://www.strava.com/api/v3/oauth/token';
@@ -9,8 +11,27 @@ const STRAVA_ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities'
 const STRAVA_STATS_URL = (id) => `https://www.strava.com/api/v3/athletes/${id}/stats`;
 const STRAVA_AUTHORIZATION_ERROR_MESSAGE = 'Strava authorization could not be completed.';
 const STRAVA_AUTHORIZATION_CODE_MAX_LENGTH = 1_024;
+const STRAVA_TOKEN_MAX_LENGTH = 2_048;
+const STRAVA_SCOPE_MAX_LENGTH = 1_024;
+const STRAVA_PROFILE_TEXT_MAX_LENGTH = 1_024;
+const STRAVA_PROFILE_URL_MAX_LENGTH = 2_048;
 const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.';
 const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
+const VISIBLE_ASCII_PATTERN = /^[\x21-\x7e]+$/;
+const OAUTH_SCOPE_PATTERN = /^[\x21\x23-\x5b\x5d-\x7e]+(?: [\x21\x23-\x5b\x5d-\x7e]+)*$/;
+const PROFILE_WHITESPACE_OR_BACKSLASH_PATTERN = /[\s\\]/u;
+const HTTPS_PREFIX_PATTERN = /^https:\/\//iu;
+const objectFreeze = Object.freeze;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const objectPrototype = Object.prototype;
+const numberIsSafeInteger = Number.isSafeInteger;
+const reflectApply = Reflect.apply;
+const regexpTest = RegExp.prototype.test;
+const stringCharCodeAt = String.prototype.charCodeAt;
+const INVALID_SELECTED_VALUE = Symbol('invalid-selected-value');
+const MISSING_SELECTED_VALUE = Symbol('missing-selected-value');
 
 function stravaAuthorizationError(code) {
   return new functions.https.HttpsError(code, STRAVA_AUTHORIZATION_ERROR_MESSAGE);
@@ -22,6 +43,183 @@ function stravaRefreshError(code) {
 
 function stravaDataError(code) {
   return new functions.https.HttpsError(code, STRAVA_DATA_ERROR_MESSAGE);
+}
+
+function patternMatches(pattern, value) {
+  return reflectApply(regexpTest, pattern, [value]);
+}
+
+function isPlainJsonRecord(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) return false;
+  try {
+    return objectGetPrototypeOf(value) === objectPrototype;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function selectedOwnDataValue(record, key, required) {
+  let descriptor;
+  try {
+    descriptor = objectGetOwnPropertyDescriptor(record, key);
+  } catch (_error) {
+    return INVALID_SELECTED_VALUE;
+  }
+  if (!descriptor) return required ? INVALID_SELECTED_VALUE : MISSING_SELECTED_VALUE;
+  if (!reflectApply(objectHasOwnProperty, descriptor, ['value'])) {
+    return INVALID_SELECTED_VALUE;
+  }
+  return descriptor.value;
+}
+
+function isBoundedVisibleAscii(value, maxLength) {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= maxLength
+    && patternMatches(VISIBLE_ASCII_PATTERN, value);
+}
+
+function isPositiveSafeInteger(value) {
+  return typeof value === 'number' && numberIsSafeInteger(value) && value > 0;
+}
+
+function hasLoneSurrogate(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = reflectApply(stringCharCodeAt, value, [index]);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return true;
+      const nextCodeUnit = reflectApply(stringCharCodeAt, value, [index + 1]);
+      if (nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) return true;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasControlCharacter(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = reflectApply(stringCharCodeAt, value, [index]);
+    if (codeUnit <= 0x1f || (codeUnit >= 0x7f && codeUnit <= 0x9f)) return true;
+  }
+  return false;
+}
+
+function isBoundedProfileText(value, maxLength) {
+  return typeof value === 'string'
+    && value.length <= maxLength
+    && !hasLoneSurrogate(value)
+    && !hasControlCharacter(value);
+}
+
+function optionalProfileText(record, key) {
+  const value = selectedOwnDataValue(record, key, false);
+  if (value === MISSING_SELECTED_VALUE || value === null || value === '') return null;
+  if (!isBoundedProfileText(value, STRAVA_PROFILE_TEXT_MAX_LENGTH)) {
+    return INVALID_SELECTED_VALUE;
+  }
+  return value;
+}
+
+function optionalScope(record) {
+  const value = selectedOwnDataValue(record, 'scope', false);
+  if (value === MISSING_SELECTED_VALUE || value === null || value === '') return null;
+  if (
+    typeof value !== 'string'
+    || value.length > STRAVA_SCOPE_MAX_LENGTH
+    || !patternMatches(OAUTH_SCOPE_PATTERN, value)
+  ) {
+    return INVALID_SELECTED_VALUE;
+  }
+  return value;
+}
+
+function isCredentialFreeHttpsUrl(value) {
+  if (
+    !isBoundedProfileText(value, STRAVA_PROFILE_URL_MAX_LENGTH)
+    || value.length === 0
+    || patternMatches(PROFILE_WHITESPACE_OR_BACKSLASH_PATTERN, value)
+    || !patternMatches(HTTPS_PREFIX_PATTERN, value)
+  ) {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new NodeURL(value);
+  } catch (_error) {
+    return false;
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.hostname.length === 0
+    || parsed.username.length !== 0
+    || parsed.password.length !== 0
+  ) {
+    return false;
+  }
+
+  const authorityStart = 'https://'.length;
+  const authorityEndCandidate = value.slice(authorityStart).search(/[/?#]/u);
+  const authorityEnd = authorityEndCandidate === -1
+    ? value.length
+    : authorityStart + authorityEndCandidate;
+  return !value.slice(authorityStart, authorityEnd).includes('@');
+}
+
+function optionalProfileUrl(record) {
+  const value = selectedOwnDataValue(record, 'profile', false);
+  if (value === MISSING_SELECTED_VALUE || value === null || value === '') return null;
+  return isCredentialFreeHttpsUrl(value) ? value : INVALID_SELECTED_VALUE;
+}
+
+function snapshotAuthorizationExchangeResponse(response) {
+  if (!isPlainJsonRecord(response)) return null;
+
+  const accessToken = selectedOwnDataValue(response, 'access_token', true);
+  const refreshToken = selectedOwnDataValue(response, 'refresh_token', true);
+  const expiresAt = selectedOwnDataValue(response, 'expires_at', true);
+  const scope = optionalScope(response);
+  const athleteRecord = selectedOwnDataValue(response, 'athlete', true);
+  if (
+    !isBoundedVisibleAscii(accessToken, STRAVA_TOKEN_MAX_LENGTH)
+    || !isBoundedVisibleAscii(refreshToken, STRAVA_TOKEN_MAX_LENGTH)
+    || !isPositiveSafeInteger(expiresAt)
+    || scope === INVALID_SELECTED_VALUE
+    || !isPlainJsonRecord(athleteRecord)
+  ) {
+    return null;
+  }
+
+  const athleteId = selectedOwnDataValue(athleteRecord, 'id', true);
+  const firstName = optionalProfileText(athleteRecord, 'firstname');
+  const lastName = optionalProfileText(athleteRecord, 'lastname');
+  const username = optionalProfileText(athleteRecord, 'username');
+  const profileUrl = optionalProfileUrl(athleteRecord);
+  if (
+    !isPositiveSafeInteger(athleteId)
+    || firstName === INVALID_SELECTED_VALUE
+    || lastName === INVALID_SELECTED_VALUE
+    || username === INVALID_SELECTED_VALUE
+    || profileUrl === INVALID_SELECTED_VALUE
+  ) {
+    return null;
+  }
+
+  return objectFreeze({
+    accessToken,
+    refreshToken,
+    expiresAt,
+    scope,
+    athlete: objectFreeze({
+      id: athleteId,
+      firstName,
+      lastName,
+      username,
+      profileUrl,
+    }),
+  });
 }
 
 function getStravaCreds() {
@@ -68,11 +266,17 @@ async function exchangeCode(code) {
   if (!resp || resp.ok !== true) {
     throw stravaAuthorizationError('invalid-argument');
   }
+  let response;
   try {
-    return await resp.json();
+    response = await resp.json();
   } catch (_error) {
     throw stravaAuthorizationError('unavailable');
   }
+  const exchange = snapshotAuthorizationExchangeResponse(response);
+  if (!exchange) {
+    throw stravaAuthorizationError('internal');
+  }
+  return exchange;
 }
 
 async function refreshToken(refresh) {
@@ -141,29 +345,28 @@ exports.stravaExchangeCode = functions
     }
     const { uid } = context.auth;
 
-    const tokenResp = await exchangeCode(code);
-    const athlete = tokenResp.athlete || {};
+    const exchange = await exchangeCode(code);
 
     await secretDocRef(uid).set({
-      access_token: tokenResp.access_token,
-      refresh_token: tokenResp.refresh_token,
-      expires_at: tokenResp.expires_at,
-      scope: tokenResp.scope || null,
+      access_token: exchange.accessToken,
+      refresh_token: exchange.refreshToken,
+      expires_at: exchange.expiresAt,
+      scope: exchange.scope,
       updatedAt: Timestamp.now(),
     }, { merge: true });
 
     await connectionDocRef(uid).set({
       provider: 'strava',
-      athleteId: athlete.id || null,
-      firstName: athlete.firstname || null,
-      lastName: athlete.lastname || null,
-      username: athlete.username || null,
-      profileUrl: athlete.profile || null,
+      athleteId: exchange.athlete.id,
+      firstName: exchange.athlete.firstName,
+      lastName: exchange.athlete.lastName,
+      username: exchange.athlete.username,
+      profileUrl: exchange.athlete.profileUrl,
       connectedAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
     }, { merge: true });
 
-    return { ok: true, athleteId: athlete.id || null };
+    return { ok: true, athleteId: exchange.athlete.id };
   });
 
 exports.stravaFetchStats = functions

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -74,7 +74,7 @@ jest.mock('firebase-admin/firestore', () => {
   let tick = 1_800_000_000;
   return {
     Timestamp: {
-      now: () => ({ _seconds: tick += 1 }),
+      now: jest.fn(() => ({ _seconds: tick += 1 })),
     },
   };
 });
@@ -85,6 +85,7 @@ jest.mock('./stripeHelpers', () => ({
 
 const admin = require('firebase-admin');
 const functions = require('firebase-functions');
+const { Timestamp } = require('firebase-admin/firestore');
 const { requireAppCheck } = require('./stripeHelpers');
 const { stravaDisconnect, stravaExchangeCode, stravaFetchStats } = require('./strava');
 
@@ -99,6 +100,10 @@ const CONTEXT = Object.freeze({
 });
 const CODE = 'synthetic_authorization_code';
 const MAX_AUTHORIZATION_CODE_LENGTH = 1_024;
+const MAX_TOKEN_LENGTH = 2_048;
+const MAX_SCOPE_LENGTH = 1_024;
+const MAX_PROFILE_TEXT_LENGTH = 1_024;
+const MAX_PROFILE_URL_LENGTH = 2_048;
 const CONNECTION_PATH = 'members/synthetic-member-000001/connections/strava';
 const SECRET_PATH = 'members/synthetic-member-000001/secrets/strava';
 
@@ -131,6 +136,7 @@ describe('Strava authorization exchange failure boundary', () => {
     admin.__clearDocuments();
     admin.__clearReads();
     admin.__clearWrites();
+    Timestamp.now.mockClear();
     requireAppCheck.mockReset();
     fetchMock = jest.fn();
     global.fetch = fetchMock;
@@ -149,26 +155,53 @@ describe('Strava authorization exchange failure boundary', () => {
     expect(admin.__getDeletes()).toEqual([]);
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getWrites()).toEqual([]);
+    expect(Timestamp.now).not.toHaveBeenCalled();
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   }
 
-  function mockSuccessfulExchange() {
+  function validExchangeResponse() {
+    return {
+      access_token: 'access_token_test',
+      refresh_token: 'refresh_token_test',
+      expires_at: 1_900_000_000,
+      scope: 'read',
+      athlete: {
+        id: 123456,
+        firstname: 'Synthetic',
+        lastname: 'Athlete',
+        username: 'synthetic-athlete',
+        profile: 'https://images.example.test/synthetic-athlete.png',
+      },
+    };
+  }
+
+  function mockExchangeResponse(response) {
+    const json = jest.fn().mockResolvedValue(response);
     fetchMock.mockResolvedValue({
       ok: true,
-      json: jest.fn().mockResolvedValue({
-        access_token: 'access_token_test',
-        refresh_token: 'refresh_token_test',
-        expires_at: 1_900_000_000,
-        scope: 'read',
-        athlete: {
-          id: 123456,
-          firstname: 'Synthetic',
-          lastname: 'Athlete',
-          username: 'synthetic-athlete',
-          profile: 'https://images.example.test/synthetic-athlete.png',
-        },
-      }),
+      json,
     });
+    return json;
+  }
+
+  function mockSuccessfulExchange() {
+    return mockExchangeResponse(validExchangeResponse());
+  }
+
+  async function expectInvalidSuccessfulResponse(response) {
+    const json = mockExchangeResponse(response);
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+
+    expect(publicError(error)).toEqual({
+      code: 'internal',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledTimes(1);
+    expectNoSideEffects();
   }
 
   test('runs App Check before Auth, provider exchange, or Firestore', async () => {
@@ -364,8 +397,461 @@ describe('Strava authorization exchange failure boundary', () => {
     expectNoSideEffects();
   });
 
+  describe('successful provider response validation', () => {
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a primitive', true],
+      ['an array', []],
+      ['a null-prototype record', Object.create(null)],
+      ['a custom-prototype record', Object.create({ inherited: true })],
+    ])('rejects %s root before timestamps, Firestore, or logs', async (_case, response) => {
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test('rejects a transparent root Proxy before validator-controlled reflection', async () => {
+      const observedGetKeys = [];
+      const secondThenFailure = new Error(
+        'second-then-canary access_token=provider-secret-canary',
+      );
+      const reflectionTraps = {
+        getOwnPropertyDescriptor: jest.fn(() => {
+          throw new Error('root descriptor trap must not run');
+        }),
+        getPrototypeOf: jest.fn(() => {
+          throw new Error('root prototype trap must not run');
+        }),
+        ownKeys: jest.fn(() => {
+          throw new Error('root ownKeys trap must not run');
+        }),
+      };
+      const response = new Proxy(validExchangeResponse(), {
+        get: (_target, key) => {
+          observedGetKeys.push(key);
+          if (key !== 'then') {
+            throw new Error(`unexpected root Proxy read: ${String(key)}`);
+          }
+          if (observedGetKeys.length > 1) throw secondThenFailure;
+          return undefined;
+        },
+        ...reflectionTraps,
+      });
+
+      await expectInvalidSuccessfulResponse(response);
+
+      expect(observedGetKeys).toEqual(['then']);
+      Object.values(reflectionTraps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    });
+
+    test('keeps a throwing root then trap inside the existing unavailable JSON boundary', async () => {
+      const thenFailure = new Error('root-then-canary access_token=provider-secret-canary');
+      const response = new Proxy(validExchangeResponse(), {
+        get: (_target, key) => {
+          if (key === 'then') throw thenFailure;
+          throw new Error('unexpected root Proxy read');
+        },
+      });
+      mockExchangeResponse(response);
+
+      const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+
+      expect(publicError(error)).toEqual({
+        code: 'unavailable',
+        message: FIXED_AUTHORIZATION_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify(publicError(error))).not.toMatch(/root-then-canary|provider-secret/i);
+      expectNoSideEffects();
+    });
+
+    test.each([
+      ['access_token', undefined, true],
+      ['access_token', null, false],
+      ['access_token', '', false],
+      ['access_token', 'token\ncanary', false],
+      ['access_token', 'tökén', false],
+      ['access_token', 'x'.repeat(MAX_TOKEN_LENGTH + 1), false],
+      ['access_token', Object('boxed-token'), false],
+      ['refresh_token', undefined, true],
+      ['refresh_token', null, false],
+      ['refresh_token', '', false],
+      ['refresh_token', 'token\rcanary', false],
+      ['refresh_token', 'tökén', false],
+      ['refresh_token', 'x'.repeat(MAX_TOKEN_LENGTH + 1), false],
+      ['refresh_token', { token: 'structured' }, false],
+    ])('rejects invalid required %s value without coercion or writes', async (
+      field,
+      value,
+      remove,
+    ) => {
+      const response = validExchangeResponse();
+      if (remove) delete response[field];
+      else response[field] = value;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test.each([
+      ['expires_at', undefined, true],
+      ['expires_at', null, false],
+      ['expires_at', '1900000000', false],
+      ['expires_at', 0, false],
+      ['expires_at', -1, false],
+      ['expires_at', 1.5, false],
+      ['expires_at', Number.MAX_SAFE_INTEGER + 1, false],
+      ['athlete.id', undefined, true],
+      ['athlete.id', null, false],
+      ['athlete.id', '123456', false],
+      ['athlete.id', 0, false],
+      ['athlete.id', -1, false],
+      ['athlete.id', 1.5, false],
+      ['athlete.id', Number.MAX_SAFE_INTEGER + 1, false],
+    ])('rejects invalid positive-safe-integer %s without writes', async (
+      field,
+      value,
+      remove,
+    ) => {
+      const response = validExchangeResponse();
+      const target = field === 'athlete.id' ? response.athlete : response;
+      const key = field === 'athlete.id' ? 'id' : field;
+      if (remove) delete target[key];
+      else target[key] = value;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test.each([
+      ['missing', undefined, true],
+      ['null', null, false],
+      ['exact empty', '', false],
+    ])('preserves %s scope as unknown null without inferring permission', async (
+      _case,
+      scope,
+      remove,
+    ) => {
+      const response = validExchangeResponse();
+      if (remove) delete response.scope;
+      else response.scope = scope;
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()[0].data.scope).toBeNull();
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test.each([
+      ['a number', 1],
+      ['leading whitespace', ' read'],
+      ['trailing whitespace', 'read '],
+      ['repeated separators', 'read  activity:read'],
+      ['a quote', 'read"activity:read'],
+      ['a backslash', 'read\\activity:read'],
+      ['a control', 'read\nactivity:read'],
+      ['an oversized value', 'r'.repeat(MAX_SCOPE_LENGTH + 1)],
+    ])('rejects present scope with %s without making an entitlement decision', async (
+      _case,
+      scope,
+    ) => {
+      const response = validExchangeResponse();
+      response.scope = scope;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test.each([
+      ['a null athlete', null],
+      ['an array athlete', []],
+      ['a custom-prototype athlete', Object.create({ inherited: true })],
+    ])('rejects %s before nested field access', async (_case, athlete) => {
+      const response = validExchangeResponse();
+      response.athlete = athlete;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test('rejects a nested athlete Proxy without invoking any trap', async () => {
+      const traps = ['get', 'getOwnPropertyDescriptor', 'getPrototypeOf', 'ownKeys']
+        .reduce((result, name) => ({
+          ...result,
+          [name]: jest.fn(() => {
+            throw new Error(`nested athlete ${name} trap must not run`);
+          }),
+        }), {});
+      const response = validExchangeResponse();
+      response.athlete = new Proxy(response.athlete, traps);
+
+      await expectInvalidSuccessfulResponse(response);
+
+      Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    });
+
+    test.each([
+      ['firstname', 1],
+      ['firstname', 'line\nbreak'],
+      ['lastname', '\ud800'],
+      ['username', 'x'.repeat(MAX_PROFILE_TEXT_LENGTH + 1)],
+      ['username', Object('boxed-username')],
+    ])('rejects invalid optional %s without coercion or partial writes', async (field, value) => {
+      const response = validExchangeResponse();
+      response.athlete[field] = value;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test.each([
+      ['a relative path', '/profile.png'],
+      ['plain HTTP', 'http://images.example.test/profile.png'],
+      ['credentials', 'https://user:pass@images.example.test/profile.png'],
+      ['raw whitespace', 'https://images.example.test/profile image.png'],
+      ['a backslash', 'https://images.example.test/profile\\image.png'],
+      ['a malformed URL', 'https://'],
+      ['an oversized URL', `https://images.example.test/${'x'.repeat(MAX_PROFILE_URL_LENGTH)}`],
+    ])('rejects profile URL with %s before writes', async (_case, profile) => {
+      const response = validExchangeResponse();
+      response.athlete.profile = profile;
+
+      await expectInvalidSuccessfulResponse(response);
+    });
+
+    test.each([
+      ['access_token', 'root', 'access_token'],
+      ['refresh_token', 'root', 'refresh_token'],
+      ['expires_at', 'root', 'expires_at'],
+      ['scope', 'root', 'scope'],
+      ['athlete', 'root', 'athlete'],
+      ['athlete.id', 'athlete', 'id'],
+      ['athlete.firstname', 'athlete', 'firstname'],
+      ['athlete.lastname', 'athlete', 'lastname'],
+      ['athlete.username', 'athlete', 'username'],
+      ['athlete.profile', 'athlete', 'profile'],
+    ])('does not invoke a selected %s accessor', async (_path, targetName, key) => {
+      const response = validExchangeResponse();
+      const target = targetName === 'root' ? response : response.athlete;
+      const selectedGetter = jest.fn(() => target[key]);
+      Object.defineProperty(target, key, {
+        configurable: true,
+        enumerable: true,
+        get: selectedGetter,
+      });
+
+      await expectInvalidSuccessfulResponse(response);
+
+      expect(selectedGetter).not.toHaveBeenCalled();
+    });
+
+    test('does not consult an inherited required-field getter', async () => {
+      const inheritedGetter = jest.fn(() => 'access_token_test');
+      const response = validExchangeResponse();
+      delete response.access_token;
+      Object.defineProperty(Object.prototype, 'access_token', {
+        configurable: true,
+        get: inheritedGetter,
+      });
+
+      try {
+        await expectInvalidSuccessfulResponse(response);
+      } finally {
+        delete Object.prototype.access_token;
+      }
+
+      expect(inheritedGetter).not.toHaveBeenCalled();
+    });
+
+    test('ignores an inherited optional-field value', async () => {
+      const response = validExchangeResponse();
+      delete response.athlete.firstname;
+      Object.defineProperty(Object.prototype, 'firstname', {
+        configurable: true,
+        value: 'Inherited',
+      });
+
+      try {
+        mockExchangeResponse(response);
+        const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+        expect(result).toEqual({ ok: true, athleteId: 123456 });
+        expect(admin.__getWrites()[1].data.firstName).toBeNull();
+        expect(Timestamp.now).toHaveBeenCalledTimes(3);
+        consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+      } finally {
+        delete Object.prototype.firstname;
+      }
+    });
+
+    test('does not invoke selected token coercion hooks', async () => {
+      const coercionHooks = {
+        toString: jest.fn(() => 'access_token_test'),
+        valueOf: jest.fn(() => 'access_token_test'),
+        [Symbol.toPrimitive]: jest.fn(() => 'access_token_test'),
+      };
+      const response = validExchangeResponse();
+      response.access_token = coercionHooks;
+
+      await expectInvalidSuccessfulResponse(response);
+
+      expect(coercionHooks.toString).not.toHaveBeenCalled();
+      expect(coercionHooks.valueOf).not.toHaveBeenCalled();
+      expect(coercionHooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      ['firstname', 'firstName', 'missing', undefined, true],
+      ['firstname', 'firstName', 'null', null, false],
+      ['firstname', 'firstName', 'exact empty', '', false],
+      ['lastname', 'lastName', 'missing', undefined, true],
+      ['lastname', 'lastName', 'null', null, false],
+      ['lastname', 'lastName', 'exact empty', '', false],
+      ['username', 'username', 'missing', undefined, true],
+      ['username', 'username', 'null', null, false],
+      ['username', 'username', 'exact empty', '', false],
+      ['profile', 'profileUrl', 'missing', undefined, true],
+      ['profile', 'profileUrl', 'null', null, false],
+      ['profile', 'profileUrl', 'exact empty', '', false],
+    ])('projects optional athlete.%s to %s as null when %s', async (
+      providerField,
+      documentField,
+      _case,
+      value,
+      remove,
+    ) => {
+      const response = validExchangeResponse();
+      if (remove) delete response.athlete[providerField];
+      else response.athlete[providerField] = value;
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()[1].data[documentField]).toBeNull();
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test('preserves valid Unicode profile text, scope bytes, and HTTPS URL exactly', async () => {
+      const response = validExchangeResponse();
+      response.scope = 'future:Read,Variant read activity:read activity:read';
+      response.athlete.firstname = 'Zoë 🏃🏽‍♀️';
+      response.athlete.lastname = '李';
+      response.athlete.username = 'e\u0301 runner';
+      response.athlete.profile = 'https://例え.example/athlete/%E2%98%83?size=large#profile';
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()[0].data.scope).toBe(response.scope);
+      expect(admin.__getWrites()[1].data).toMatchObject({
+        firstName: response.athlete.firstname,
+        lastName: response.athlete.lastname,
+        username: response.athlete.username,
+        profileUrl: response.athlete.profile,
+      });
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test('accepts exact technical string bounds without normalization', async () => {
+      const response = validExchangeResponse();
+      const profilePrefix = 'https://images.example.test/';
+      response.access_token = 'a'.repeat(MAX_TOKEN_LENGTH);
+      response.refresh_token = 'b'.repeat(MAX_TOKEN_LENGTH);
+      response.scope = 'r'.repeat(MAX_SCOPE_LENGTH);
+      response.athlete.firstname = 'Z'.repeat(MAX_PROFILE_TEXT_LENGTH);
+      response.athlete.profile = profilePrefix
+        + 'p'.repeat(MAX_PROFILE_URL_LENGTH - profilePrefix.length);
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()[0].data).toMatchObject({
+        access_token: response.access_token,
+        refresh_token: response.refresh_token,
+        scope: response.scope,
+      });
+      expect(admin.__getWrites()[1].data).toMatchObject({
+        firstName: response.athlete.firstname,
+        profileUrl: response.athlete.profile,
+      });
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test('accepts frozen JSON-shaped selected data descriptors', async () => {
+      const response = validExchangeResponse();
+      Object.freeze(response.athlete);
+      Object.freeze(response);
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()).toHaveLength(2);
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test('accepts non-enumerable selected own data descriptors', async () => {
+      const response = validExchangeResponse();
+      Object.defineProperty(response, 'access_token', {
+        configurable: false,
+        enumerable: false,
+        value: response.access_token,
+        writable: false,
+      });
+      Object.defineProperty(response.athlete, 'firstname', {
+        configurable: false,
+        enumerable: false,
+        value: response.athlete.firstname,
+        writable: false,
+      });
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(admin.__getWrites()[0].data.access_token).toBe('access_token_test');
+      expect(admin.__getWrites()[1].data.firstName).toBe('Synthetic');
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+
+    test('ignores unknown hostile fields without enumeration or access', async () => {
+      const unknownGetter = jest.fn(() => {
+        throw new Error('unknown-field-canary access_token=provider-secret-canary');
+      });
+      const unknownSymbolGetter = jest.fn(() => {
+        throw new Error('unknown-symbol-canary refresh_token=provider-secret-canary');
+      });
+      const response = validExchangeResponse();
+      Object.defineProperty(response, 'provider_debug', {
+        configurable: true,
+        enumerable: true,
+        get: unknownGetter,
+      });
+      Object.defineProperty(response.athlete, Symbol('unknown'), {
+        configurable: true,
+        enumerable: true,
+        get: unknownSymbolGetter,
+      });
+      mockExchangeResponse(response);
+
+      const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(unknownGetter).not.toHaveBeenCalled();
+      expect(unknownSymbolGetter).not.toHaveBeenCalled();
+      expect(admin.__getWrites()).toHaveLength(2);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+  });
+
   test('preserves the successful server-only exchange, writes, and minimal result', async () => {
-    mockSuccessfulExchange();
+    const json = mockSuccessfulExchange();
 
     const result = await stravaExchangeCode({ code: CODE }, CONTEXT);
 
@@ -385,6 +871,7 @@ describe('Strava authorization exchange failure boundary', () => {
         }),
       },
     );
+    expect(json).toHaveBeenCalledTimes(1);
     expect(admin.__getWrites()).toEqual([
       {
         path: 'members/synthetic-member-000001/secrets/strava',
@@ -412,6 +899,9 @@ describe('Strava authorization exchange failure boundary', () => {
         options: { merge: true },
       },
     ]);
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(Timestamp.now).toHaveBeenCalledTimes(3);
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Closes #281

Parent tracker: #88

Officer impact: None — this is a fail-closed server-side validation guard in the existing source-only Strava prototype. It changes no available page or officer task.

Officer documentation: None — no current procedure changes. Strava deployment and live setup remain NOT AVAILABLE.

Deployment evidence: Source, tests, and commit only at submission. No Firebase deployment, Strava provider configuration, website publication, production-data action, migration, or live-behavior verification occurred. Hosted PR CI is pending.

## Outcome

- Validate and snapshot a successful Strava authorization-exchange response before either Firestore write or timestamp creation.
- Read only ten selected own data descriptors, reject accessors/proxies/coercion objects, ignore unknown fields without enumeration, and copy only bounded primitives into a frozen projection.
- Preserve missing/null/exact-empty scope and optional athlete fields as `null`; validate present scope syntax, profile text, HTTPS profile URL, positive safe-integer expiry, and athlete ID.
- Convert an invalid parsed HTTP-200 provider shape to the existing fixed authorization message with `internal`, zero Firestore activity, zero timestamps, and zero logs.
- Preserve the provider request, valid two-write order and fields, three timestamps, and minimal `{ ok, athleteId }` result.

## Boundary and failure cases

- App Check, Auth, authorization-code validation, provider non-success handling, transport/JSON failures, refresh, stats, and disconnect behavior are unchanged.
- The parsed provider root is validated inside `exchangeCode` before its async return, preventing a second Promise-assimilation access to an untrusted Proxy.
- A root Proxy may receive the one unavoidable promise `then` lookup; tests fail on a second or any other property access. Nested Proxy and validator-reflection traps stay untouched.
- Scope entitlement, account/athlete uniqueness, replay/state/TTL, the existing nontransactional two-write boundary, refresh-response validation, provider setup, and deployment remain excluded follow-up work.

## Verification

- Node 20 focused Strava tests: 134/134 passed.
- Node 20 full Functions tests: 1,733 passed; 64 intentionally skipped; 27/29 suites active and passed.
- Functions ESLint: passed.
- Frontend tests: 301/301 passed.
- Frontend lint ledger: unchanged at 106 files / 123 errors / 7 warnings.
- SPA/workflow/release/Firebase-readback/artifact checks: 53/53 passed.
- Commerce journal real Firestore emulator: 63/63 passed.
- Firestore Rules emulator: 378/378 passed.
- Diagnostic production build: passed without regenerating the sitemap.
- `git diff --check`: passed; exact scope is only `functions/strava.js` and `functions/strava.test.js`.
- Two independent exact-diff rereviews approved with no remaining findings.

Reviewed head: `3967d1a89da847b17e5d8d4592fcb9838157a5c4`

Reviewed diff SHA-256: `d29b942020b1668b6b4cc5c722c9c6903bb5be2645cbd2785c4e77e439b498b0`

## Compatibility and migration

No data migration is performed. Existing valid documented responses remain compatible, including omitted scope. Deliberate fail-closed residuals are recorded on #281: an athlete ID beyond JavaScript safe-integer precision and a profile URL outside the bounded credential-free HTTPS contract require a future reviewed schema/policy change rather than silent coercion.
