### PR TITLE
WEB-PRIVACY-001J: redact Admin Events list failures

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -1005,6 +1005,53 @@ Officer review steps after the source merge:
 
 No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
 
+### Admin event-list load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give an officer one plain instruction when the Admin Events list cannot load, without showing a Firebase, database, provider, account, endpoint, token-shaped, or technical detail and without falsely saying that the event list is empty.
+
+**Approver:** events lead plus platform/security and privacy owners. Add the treasurer before any future live commerce-admin review.
+
+**Prerequisites:** issue [#290](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/290) must be merged for source review. Use only a mocked admin identity, mocked database reference, made-up event, and mocked rejected list lookup. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply: this slice does not approve the screen, role, permissions, backup, preview, rollback, event editing, publication, registration, payment, or production use. It does not choose the event source reserved to #121, deploy Firebase, change Rules, permissions, or event records, contact Stripe or another provider, use production data, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Made-up Admin Events route"] --> B["Mocked event-list lookup"]
+    B -- "Fulfilled empty" --> C["Existing No events yet state"]
+    B -- "Fulfilled with events" --> D["Existing events table"]
+    B -- "Rejected" --> E["Fixed alert; no empty state or table"]
+```
+
+In words: only a successful mocked lookup may show the existing empty event list or events table. A mocked rejection shows one fixed alert while keeping the Events heading and New event navigation; it does not turn an unknown result into an empty or current event list.
+
+Officer review steps after the source merge:
+
+1. Keep this failure sentence and the complete Admin Events screen marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #290 issue, reviewed pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up admin identity, mocked database reference, made-up event, and mocked lookup.
+4. Confirm a mocked rejection shows exactly `We could not load events right now. Please try again later.`
+5. Confirm assistive technology receives the complete sentence immediately as one alert.
+6. Confirm no rejection-only database, Firebase, provider, account, endpoint, token-shaped, or technical detail appears on the page, in analytics, or in the browser console.
+7. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
+8. Confirm the rejected lookup ends loading and shows neither **No events yet.** nor an events table.
+9. Confirm the **Events** heading and **+ New event** link remain without following the link.
+10. Confirm the mocked lookup receives the same mocked database reference exactly once.
+11. Confirm a successful mocked empty list still shows **No events yet.**, and a successful made-up event keeps its existing table display.
+12. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, event-record, production-data, Admin-screen approval, and live behavior as separate results.
+
+**Expected result:** the reviewed source discards the complete rejected value without binding or inspecting it and shows one fixed accessible retry-later sentence. A failure is not treated as an empty or populated event list. The Events heading and New event navigation remain, while genuine successful empty and populated results keep their existing displays. This does not authorize an officer to open or use the Admin Events screen live.
+
+**Stop conditions:** any real officer, member, event, registration, location, discount, waiver, price, capacity, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; the false empty state or an events table after rejection; an attempted event/admin write; a Firebase, Rules, provider, permission, or event-source change; an attempt to decide #121 work; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or Admin screen is live.
+
+**Success proof:** for source completion, record the exact #290 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic actual-route tests, relevant full checks, and independent privacy, accessibility, and officer-continuity reviews. The safe review path stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, Rules or permission changes, provider configuration, event-record changes, production-data actions, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After any later approved publication, use the same protected website release path and verify the replacement revision. Do not undo by changing or deleting an event, registration, payment, officer account, permission, database record, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, Firebase, provider, account, event, registration, endpoint, token-shaped, or technical detail appeared. Add the treasurer if commerce or payment state might be involved. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
+
 ## Stop conditions
 
 Stop if staging is not isolated, the owner/policy is missing, a test uses real people or money, Firebase deployment skipped, rollback is untested, or the requested action directly edits payment/member state.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -15,6 +15,7 @@ import {
   listMemberEvents,
   listPublicEvents,
 } from './services/events/eventsService';
+import { listAllEvents } from './services/events/adminService';
 import { events as analyticsEvents, track } from './services/analytics/analytics';
 import { useAuth } from './services/hooks/useAuth';
 import {
@@ -57,6 +58,14 @@ jest.mock('./services/events/eventsService', () => {
   };
 });
 
+jest.mock('./services/events/adminService', () => {
+  const actual = jest.requireActual('./services/events/adminService');
+  return {
+    ...actual,
+    listAllEvents: jest.fn(),
+  };
+});
+
 jest.mock('./services/analytics/analytics', () => {
   const actual = jest.requireActual('./services/analytics/analytics');
   return { ...actual, track: jest.fn() };
@@ -86,6 +95,7 @@ beforeEach(() => {
   getEventBySlug.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
+  listAllEvents.mockReset();
   track.mockReset();
   useAuth.mockReset();
   useAuth.mockReturnValue({
@@ -191,6 +201,7 @@ const EVENT_DETAIL_LOAD_FAILURE = 'We could not load this event right now. Pleas
 const EVENT_REGISTER_LOAD_FAILURE = 'We could not load this event right now. Please try again later.';
 const EVENT_REGISTER_SUBMIT_FAILURE = 'We could not confirm your registration. Please wait before trying again.';
 const ADMIN_PRODUCTS_LOAD_FAILURE = 'We could not load products right now. Please try again later.';
+const ADMIN_EVENTS_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
@@ -226,6 +237,11 @@ function renderPublicEventRegister() {
 
 function renderAdminProducts() {
   window.history.pushState({}, '', '/admin/products');
+  return render(<App />);
+}
+
+function renderAdminEvents() {
+  window.history.pushState({}, '', '/admin/events');
   return render(<App />);
 }
 
@@ -1656,5 +1672,264 @@ describe('Admin Products list-load failure boundary', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(listAllProducts).toHaveBeenCalledWith(firestore);
     expect(listAllProducts).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Admin Events list-load failure boundary', () => {
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    listAllEvents.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces rejected list details with one fixed accessible unknown outcome', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listAllEvents.mockRejectedValueOnce(Object.assign(
+      new Error('admin-events-private-canary officer@example.test'),
+      {
+        code: 'firestore/admin-events-private-canary',
+        endpoint: 'https://provider.example.test/?token=admin-events-secret-canary',
+      },
+    ));
+
+    renderAdminEvents();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_EVENTS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /admin-events-private-canary|officer@example\.test|provider\.example|admin-events-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /admin-events-private-canary|officer@example\.test|provider\.example|admin-events-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create the first one' }))
+      .not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('No events yet.');
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Events' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '+ New event' }))
+      .toHaveAttribute('href', '/admin/events/new');
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/admin/events');
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile list rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('admin-events-message-getter-canary');
+    });
+    listAllEvents.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderAdminEvents();
+
+    expect((await screen.findByRole('alert')).textContent).toBe(ADMIN_EVENTS_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('admin-events-message-getter-canary');
+    expect(JSON.stringify(track.mock.calls)).not.toContain('admin-events-message-getter-canary');
+    expect(screen.queryByRole('link', { name: 'Create the first one' }))
+      .not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('No events yet.');
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Events' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '+ New event' }))
+      .toHaveAttribute('href', '/admin/events/new');
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/admin/events');
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves the existing successful empty-events result', async () => {
+    renderAdminEvents();
+
+    const emptyStateLink = await screen.findByRole('link', {
+      name: 'Create the first one',
+    });
+    expect(emptyStateLink).toHaveAttribute('href', '/admin/events/new');
+    expect(emptyStateLink.parentElement).toHaveTextContent(
+      'No events yet. Create the first one.',
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the existing successful event projection', async () => {
+    listAllEvents.mockResolvedValueOnce([{
+      id: 'synthetic-event',
+      slug: 'synthetic-club-run',
+      title: 'Synthetic Club Run',
+      startAt: { toDate: () => new Date(2030, 0, 12, 12, 0) },
+      capacity: 20,
+      registeredCount: 7,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+    }]);
+
+    renderAdminEvents();
+
+    expect(await screen.findByRole('link', { name: 'Synthetic Club Run' }))
+      .toHaveAttribute('href', '/admin/events/synthetic-club-run/edit');
+    expect(screen.getByText(/Jan 12, 2030/)).toBeInTheDocument();
+    expect(screen.getByText('$10.00 / $15.00')).toBeInTheDocument();
+    expect(screen.getByText('7 / 20')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(screen.getByText('public')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Signups' }))
+      .toHaveAttribute('href', '/admin/events/synthetic-club-run/registrations');
+    expect(screen.getByRole('link', { name: 'Edit' }))
+      .toHaveAttribute('href', '/admin/events/synthetic-club-run/edit');
+    expect(screen.queryByRole('link', { name: 'Create the first one' }))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('hides a previously loaded table when a later lookup fails', async () => {
+    listAllEvents.mockResolvedValueOnce([{
+      id: 'synthetic-event',
+      slug: 'synthetic-club-run',
+      title: 'Synthetic Club Run',
+      startAt: { toDate: () => new Date(2030, 0, 12, 12, 0) },
+      capacity: 20,
+      registeredCount: 7,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+    }]);
+    const view = renderAdminEvents();
+    expect(await screen.findByRole('table')).toBeInTheDocument();
+
+    const retryFirestore = { name: 'synthetic-firestore-retry' };
+    listAllEvents.mockRejectedValueOnce(
+      new Error('admin-events-stale-private-canary'),
+    );
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: retryFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    expect((await screen.findByRole('alert')).textContent).toBe(ADMIN_EVENTS_LOAD_FAILURE);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create the first one' }))
+      .not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('No events yet.');
+    expect(document.body).not.toHaveTextContent('admin-events-stale-private-canary');
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, retryFirestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(2);
+  });
+
+  test('shows a later successful empty result after an earlier failure', async () => {
+    listAllEvents.mockRejectedValueOnce(new Error('admin-events-first-failure-canary'));
+    const view = renderAdminEvents();
+    expect((await screen.findByRole('alert')).textContent).toBe(ADMIN_EVENTS_LOAD_FAILURE);
+
+    const retryFirestore = { name: 'synthetic-firestore-success-retry' };
+    listAllEvents.mockResolvedValueOnce([]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: retryFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    const emptyStateLink = await screen.findByRole('link', {
+      name: 'Create the first one',
+    });
+    expect(emptyStateLink.parentElement).toHaveTextContent(
+      'No events yet. Create the first one.',
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('admin-events-first-failure-canary');
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, retryFirestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(2);
+  });
+
+  test('ignores an older hostile rejection after a newer successful lookup', async () => {
+    let rejectOlderLookup;
+    listAllEvents.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectOlderLookup = reject;
+    }));
+    const view = renderAdminEvents();
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+
+    const currentFirestore = { name: 'synthetic-firestore-current' };
+    listAllEvents.mockResolvedValueOnce([{
+      id: 'synthetic-current-event',
+      slug: 'synthetic-current-run',
+      title: 'Synthetic Current Run',
+      startAt: { toDate: () => new Date(2030, 0, 12, 12, 0) },
+      capacity: null,
+      registeredCount: 2,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 0, nonMemberCents: 0 },
+    }]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect(await screen.findByRole('link', { name: 'Synthetic Current Run' }))
+      .toHaveAttribute('href', '/admin/events/synthetic-current-run/edit');
+
+    const messageGetter = jest.fn(() => {
+      throw new Error('admin-events-older-message-getter-canary');
+    });
+    await act(async () => {
+      rejectOlderLookup(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Synthetic Current Run' }))
+      .toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(
+      'admin-events-older-message-getter-canary',
+    );
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/admin/events/AdminEventsList.tsx
+++ b/src/pages/admin/events/AdminEventsList.tsx
@@ -7,6 +7,8 @@ import { Event } from '../../../types/events';
 import { listAllEvents } from '../../../services/events/adminService';
 import { formatEventDate, formatPrice } from '../../../services/events/eventsService';
 
+const LOAD_FAILURE = 'We could not load events right now. Please try again later.';
+
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
     draft: 'bg-gray-200 text-gray-700',
@@ -28,10 +30,23 @@ function Inner() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isReady || !services) return;
+    if (!isReady || !services) return undefined;
+    let active = true;
+    setLoading(true);
+    setError(null);
     listAllEvents(services.firebaseResources.firestore)
-      .then((evs) => { setEvents(evs); setLoading(false); })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .then((evs) => {
+        if (!active) return;
+        setEvents(evs);
+        setError(null);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!active) return;
+        setError(LOAD_FAILURE);
+        setLoading(false);
+      });
+    return () => { active = false; };
   }, [services, isReady]);
 
   return (
@@ -48,7 +63,11 @@ function Inner() {
           </Link>
         </div>
         {loading && <p>Loading...</p>}
-        {error && <p className="text-red-500">{error}</p>}
+        {error && (
+          <p className="text-red-500" role="alert" aria-live="assertive" aria-atomic="true">
+            {error}
+          </p>
+        )}
         {!loading && !error && events.length === 0 && (
           <p className="text-gray-600">
             No events yet.
@@ -59,7 +78,7 @@ function Inner() {
             .
           </p>
         )}
-        {!loading && events.length > 0 && (
+        {!error && !loading && events.length > 0 && (
           <table className="w-full border-collapse">
             <thead>
               <tr className="border-b bg-gray-50">


### PR DESCRIPTION
## Outcome

The Admin Events list now treats a rejected lookup as unknown. It discards the rejected value without inspecting it and shows one fixed accessible retry-later message instead of provider exception text.

Only the current fulfilled request may establish an empty list or event table. Each new current request clears stale failure state, and cleanup prevents an older fulfillment or rejection from overwriting a newer result.

Closes #290.

## Security and state invariant

- The rejection callback is unbound and does not read, coerce, log, analyze, persist, or render the rejected value.
- Failure text is fixed: `We could not load events right now. Please try again later.`
- The message is one assertive, atomic alert.
- Rejection ends loading and hides both `No events yet.` and every retained event table.
- A later current success clears a prior alert and restores the existing empty/populated display.
- An older deferred rejection cannot override a newer success or invoke a hostile getter.
- The Events heading, `+ New event` navigation, AdminGuard, exact `listAllEvents(firestore)` request, and successful projections remain unchanged.

This does not authorize the Admin screen, change services/Rules/data, decide the #121 event source, or approve a production workflow.

## Verification

Exact reviewed head: `6f90c0d367d9dda9f99eb9385555601182f28b5f`

Exact three-file diff SHA-256: `e1b8de7499d95c7bbd0cbfc6dca296b109c087a3da13e45565ba209060014769`

Red proof before the runtime fix:

- Raw provider text rendered without an alert.
- A hostile rejected value's throwing `message` getter executed.
- The two original successful empty/populated cases remained green.

Final proof:

- Node 20 focused actual-route tests: 7/7.
- Full frontend: 12 suites, 308/308.
- TypeScript no-emit: passed.
- Frontend lint ledger: 106 files / 123 reviewed legacy errors / 7 reviewed legacy warnings.
- SPA/workflow/release/readback/artifact safety: 53/53.
- Diagnostic production build: passed.
- Full Functions on refreshed main: 29 suites, 1,959 active passed; 64 existing emulator-gated tests skipped; lint passed.
- Local Rules: 378/378 and commerce emulator: 63/63 passed before the disjoint #287 base refresh. #287 exact-main CI passed both unchanged gates; this PR still requires exact-head hosted checks.
- Exact three-file scope, diff check, and #287 preservation audit: clean.
- Three independent exact-head privacy/security, test/compatibility, and officer-continuity reviews: approved.

The first review found and drove the current-request cleanup/ordering guard. The final tests prove failure-to-success recovery, stale-table hiding, and superseded hostile rejection suppression.

## Compatibility and migration

No schema, service, Rules, Function, package, provider, event-record, or migration change occurs. Existing fulfilled empty and populated displays remain unchanged.

## Officer impact

Officers will eventually see one safe retry-later message rather than internal provider detail or a misleading event list. The complete Admin Events screen remains **NOT AVAILABLE YET** pending its separate permission, backup, preview, rollback, release, and live-verification work.

## Officer documentation

Updated `docs/officers/EVENTS_SHOP_MEMBERS.md` with a separately named `Admin event-list load failure privacy — SOURCE ONLY, NOT LIVE` procedure, state diagram, plain-text alternative, approval, prerequisites, checks, proof, undo, stop, and escalation instructions.

## Deployment evidence

Source and synthetic tests are proven before this PR. No protected release, website publication, `runmprc.com` verification, Firebase deployment, Rules/provider configuration, event-record or production-data action, Admin-screen approval, or live behavior was performed or is claimed. Hosted PR CI and exact-main CI will be recorded separately.
