### PR TITLE
WEB-UX-002: restore visible keyboard focus

### DIFF
--- a/docs/officers/PUBLISH_AND_CHECK.md
+++ b/docs/officers/PUBLISH_AND_CHECK.md
@@ -159,6 +159,34 @@ Do not use this section until #133 records that both GitHub environments are pro
 9. Use made-up data only. Do not inspect or change a real member record.
 10. Complete the delivery record.
 
+### Check keyboard focus after an approved website publication — NOT AVAILABLE YET
+
+**Purpose:** prove that a person using a keyboard can see which public link, button, or navigation control is active.
+
+**Approver:** the named release observer, with the platform owner or accessibility reviewer available if the check fails.
+
+**Prerequisites:** protected website publication must be available; the exact approved commit must be live and identified by the host; the public site must be safe to open without signing in; and the observer must use a normal computer with a keyboard. Publication is still **NOT AVAILABLE YET** under #133/#136, so do not record live proof from this procedure until those prerequisites are met.
+
+1. Open the public website in a private browser window.
+2. Confirm the host identifies the exact approved commit.
+3. Stay signed out. Do not submit a form or enter member, payment, or private data.
+4. Press `Tab` once. Confirm the skip link appears with a visible yellow-and-dark focus ring.
+5. Continue pressing `Tab` through the public navigation and one public page action.
+6. Open the public Events page and repeat the keyboard check without registering.
+7. Open the public Shop page and repeat the keyboard check without starting checkout.
+8. Press `Shift` and `Tab` together to confirm the focus ring remains visible when moving backward.
+9. Record the exact commit, public pages, browser, date, time, and one redacted public screenshot.
+
+**Expected result:** every focused public link, button, and navigation control has a clearly visible yellow-and-dark ring; the ring is not clipped; focus moves in a sensible order; and keyboard movement does not open, submit, or change anything by itself. A mouse-only click does not need to show the same ring.
+
+**Stop conditions:** stop if the exact live commit is unknown, the ring is missing or hard to distinguish, the ring is clipped, focus moves to an invisible control, focus becomes trapped, the page changes without activation, or the check asks for sign-in or real data.
+
+**Success proof:** keep the exact commit and host readback, the named public pages, browser, check time, and one redacted screenshot that contains no member or payment data.
+
+**Undo:** do not edit live CSS or provider files by hand. Open a small tracked issue and reviewed pull request to revert or safely correct the focus rule, then use the same protected publication path. Record the exact undo commit.
+
+**Escalation:** platform owner first, then the accessibility reviewer or backup release officer. Treat an unexpected live publication as a hosting incident.
+
 ## Expected result
 
 Merge, release approval, Firebase deployment, backend verification, Pages publication, Netlify publication, `runmprc.com`, and provider verification are recorded as separate states. A backend failure or missing authority leaves the website unpublished.

--- a/src/headerClearance.test.js
+++ b/src/headerClearance.test.js
@@ -15,6 +15,61 @@ const getRule = (stylesheet, selector) => {
   return match?.[1] ?? '';
 };
 
+const normalizeSelector = (selector) => selector
+  .replace(/\s+/g, ' ')
+  .replace(/\s*,\s*/g, ',')
+  .trim();
+
+const getStylesheetRules = (stylesheet) => [...stylesheet
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/@tailwind[^;]*;/g, '')
+  .matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+  .map(([, selector, declarations]) => ({
+    selector: normalizeSelector(selector),
+    declarations,
+  }));
+
+const getDeclarations = (rule) => rule
+  .split(';')
+  .map((declaration) => declaration.trim())
+  .filter(Boolean)
+  .flatMap((declaration) => {
+    const colon = declaration.indexOf(':');
+    if (colon < 0) return [];
+    return [{
+      property: declaration.slice(0, colon).trim(),
+      value: declaration.slice(colon + 1).trim(),
+    }];
+  });
+
+const getDeclarationValues = (rule, property) => getDeclarations(rule)
+  .filter((declaration) => declaration.property === property)
+  .map((declaration) => declaration.value);
+
+const getShorthandTokens = (value) => (
+  value.match(/(?:[^\s()]|\([^)]*\))+/g) ?? []
+);
+
+const suppressesOutline = ({ property, value }) => {
+  const normalizedValue = value.replace(/\s*!important\s*$/i, '').trim();
+
+  if (property === 'outline') {
+    return getShorthandTokens(normalizedValue).some((token) => (
+      /^(?:0(?:\.0+)?(?:[a-z%]+)?|none|transparent)$/i.test(token)
+    ));
+  }
+  if (property === 'outline-width') {
+    return /^0(?:\.0+)?(?:[a-z%]+)?$/i.test(normalizedValue);
+  }
+  if (property === 'outline-style') {
+    return /^none$/i.test(normalizedValue);
+  }
+  if (property === 'outline-color') {
+    return /^transparent$/i.test(normalizedValue);
+  }
+  return false;
+};
+
 describe('persistent navigation clearance', () => {
   const globalStyles = readStylesheet('index.css');
   const navbarStyles = readStylesheet('components', 'navbar.css');
@@ -39,5 +94,102 @@ describe('persistent navigation clearance', () => {
   test('does not add legacy hero offsets on top of the shared clearance', () => {
     expect(getRule(globalStyles, '.header')).toMatch(/margin-top:\s*0\s*;/);
     expect(getRule(homeStyles, '.main__header')).toMatch(/margin-top:\s*0\s*;/);
+  });
+});
+
+describe('global keyboard focus visibility', () => {
+  const globalStyles = readStylesheet('index.css');
+  const stylesheetRules = getStylesheetRules(globalStyles);
+  const approvedFocusSelector = [
+    ':focus-visible',
+    '.hover\\:shadow-md:hover:focus-visible',
+  ].join(',');
+
+  test('does not suppress outlines in the universal reset', () => {
+    const resetRules = stylesheetRules.filter(
+      ({ selector }) => selector === '*,*::before,*::after',
+    );
+
+    expect(resetRules).toHaveLength(1);
+    const resetProperties = getDeclarations(resetRules[0].declarations)
+      .map((declaration) => declaration.property);
+    expect(resetProperties).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^outline(?:-|$)/i)]),
+    );
+  });
+
+  test('provides a bounded two-tone focus-visible indicator', () => {
+    const globalFocusRules = stylesheetRules.filter(({ selector }) => (
+      selector.includes(':focus-visible')
+    ));
+    expect(globalFocusRules).toHaveLength(1);
+    expect(globalFocusRules[0].selector).toBe(approvedFocusSelector);
+
+    const focusVisibleRule = globalFocusRules[0].declarations;
+    const outlines = getDeclarationValues(focusVisibleRule, 'outline');
+    const outlineOffsets = getDeclarationValues(focusVisibleRule, 'outline-offset');
+    const shadows = getDeclarationValues(focusVisibleRule, 'box-shadow');
+    expect(outlines).toHaveLength(1);
+    expect(outlineOffsets).toHaveLength(1);
+    expect(shadows).toHaveLength(1);
+
+    const outline = outlines[0].match(
+      /^(\d+(?:\.\d+)?)px\s+solid\s+var\(--color-secondary\)$/,
+    );
+    const outlineOffset = outlineOffsets[0].match(
+      /^(\d+(?:\.\d+)?)px$/,
+    );
+    const shadow = shadows[0].match(
+      /^0\s+0\s+0\s+(\d+(?:\.\d+)?)px\s+var\(--color-gray-600\)$/,
+    );
+
+    expect(outline).not.toBeNull();
+    expect(Number(outline?.[1])).toBeGreaterThan(0);
+    expect(Number(outline?.[1])).toBeLessThanOrEqual(4);
+    expect(outlineOffset).not.toBeNull();
+    expect(Number(outlineOffset?.[1])).toBeGreaterThan(0);
+    expect(Number(outlineOffset?.[1])).toBeLessThanOrEqual(4);
+    expect(shadow).not.toBeNull();
+    expect(Number(shadow?.[1])).toBeGreaterThan(0);
+    expect(Number(shadow?.[1])).toBeLessThanOrEqual(8);
+  });
+
+  test('has no competing outline suppression in the global stylesheet', () => {
+    const suppressingRules = stylesheetRules
+      .filter(({ declarations }) => getDeclarations(declarations).some(suppressesOutline))
+      .map(({ selector }) => selector);
+
+    expect(suppressingRules).toEqual([]);
+  });
+
+  test('keeps the focused skip-link indicator inside the viewport', () => {
+    const focusRule = stylesheetRules.find(
+      ({ selector }) => selector === approvedFocusSelector,
+    );
+    const skipFocusRules = stylesheetRules.filter(
+      ({ selector }) => selector === '.skip-to-content:focus',
+    );
+    expect(focusRule).toBeDefined();
+    expect(skipFocusRules).toHaveLength(1);
+
+    const outlineWidth = getDeclarationValues(focusRule.declarations, 'outline')[0]
+      .match(/^(\d+(?:\.\d+)?)px\s/)?.[1];
+    const outlineOffset = getDeclarationValues(
+      focusRule.declarations,
+      'outline-offset',
+    )[0].match(/^(\d+(?:\.\d+)?)px$/)?.[1];
+    const shadowSpread = getDeclarationValues(focusRule.declarations, 'box-shadow')[0]
+      .match(/^0\s+0\s+0\s+(\d+(?:\.\d+)?)px\s/)?.[1];
+    const decorationExtent = Math.max(
+      Number(outlineWidth) + Number(outlineOffset),
+      Number(shadowSpread),
+    );
+
+    ['left', 'top'].forEach((property) => {
+      const values = getDeclarationValues(skipFocusRules[0].declarations, property);
+      expect(values).toHaveLength(1);
+      const inset = values[0].match(/^(\d+(?:\.\d+)?)px$/)?.[1];
+      expect(Number(inset)).toBeGreaterThanOrEqual(decorationExtent);
+    });
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,8 @@
 }
 
 .skip-to-content:focus {
-  left: 0;
+  left: 8px;
+  top: 8px;
 }
 
 *,
@@ -23,7 +24,6 @@
   margin: 0;
   padding: 0;
   border: 0;
-  outline: 0;
   list-style: none;
   text-decoration: none;
   box-sizing: border-box;
@@ -54,6 +54,13 @@
   --site-nav-height: 5.5rem;
 
   --transition: all 500ms ease; /* make sure all transition have a constant effect*/
+}
+
+:focus-visible,
+.hover\:shadow-md:hover:focus-visible {
+  outline: 3px solid var(--color-secondary);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 6px var(--color-gray-600);
 }
 
 /******************** GENERAL STYLES ********************/


### PR DESCRIPTION
## Outcome

Restores a visible, bounded keyboard-focus indicator across the public site and keeps the focused skip link inside the viewport. This is a source-only change; it is not published live.

Closes #291.

## What changed

- Remove the universal reset that suppressed every browser outline.
- Add one bounded yellow-and-dark `:focus-visible` indicator.
- Preserve that indicator when an existing Tailwind hover-shadow utility is also active.
- Inset the focused skip link enough to keep the complete decoration on-screen.
- Add adversarial CSS-contract tests for reset, cascade, declaration, selector, and clipping regressions.
- Add the source-only officer verification procedure for a future approved publication.

## Invariants and failure handling

- Keyboard focus remains visible without changing activation, routes, forms, permissions, or data.
- Pointer-only clicks are not forced to show the keyboard indicator.
- Indicator width, offset, and shadow spread are positive and bounded.
- Any competing global outline suppression or extra global `:focus-visible` rule fails the focused test.
- The skip-link inset must contain the larger of the outline or shadow decoration extent.

## Verification

- Focused header/focus suite: 6/6
- Full frontend: 12 suites, 312/312
- TypeScript no-emit: passed
- Frontend lint ledger: 106 files / 123 reviewed legacy errors / 7 reviewed legacy warnings
- SPA/workflow/release/readback/artifact safety: 53/53
- Diagnostic production build: passed
- Exact three-path diff and diff check: clean
- Accessibility/CSS, adversarial-test, and officer-continuity reviews: approved
- Local signed-out home-page keyboard review: skip-link decoration had 2px viewport clearance; navigation and public action indicators were visible; no forms, sign-in, Firebase, providers, or data were used

Exact reviewed head: `a87955d8ad60aceee321ee080e663f8efc9207cd`

Exact diff SHA-256: `56beadaf550c2a26e91a4d663bf5f024d19e191811a6d54a96e98407f3f57c40`

## Officer continuity

Officer impact: after an approved future publication, keyboard users will be able to see which public control is focused. No officer workflow, route, permission, or data behavior changes today.

Officer documentation: `docs/officers/PUBLISH_AND_CHECK.md`

Deployment evidence: source changed and local checks passed. No protected release, website publication, `runmprc.com` verification, Firebase/provider action, permission change, member/payment data action, or live behavior verification occurred. Website publication remains **NOT AVAILABLE YET** under #133/#136.
