### PR TITLE
WEB-PRIVACY-001K — Make render failures private and truthful

### DIFF
--- a/docs/officers/EMERGENCY_AND_RECOVERY.md
+++ b/docs/officers/EMERGENCY_AND_RECOVERY.md
@@ -38,6 +38,55 @@
 
 Live commerce is not approved as of 2026-07-12. If the public site appears to accept a real payment, do not test it with a real card.
 
+### Unexpected “Something went wrong” page — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** leave a failed page safely, contact the right owner, and avoid copying private or technical error details.
+
+**Approver:** platform owner plus one backup. Add the privacy owner if private information may be involved. Add the treasurer if the failure followed a signup, checkout, order, payment, or refund action.
+
+**Prerequisites:** issue [#293](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/293) must be merged for source review. Calling the safer page live also requires a protected website publication and an exact revision check on `runmprc.com`. Source tests use only made-up failures. Do not force a production failure.
+
+**Seeing this page does not prove the club, a person, or an outside monitoring service was notified.** The source change does not configure monitoring, alert routing, provider delivery, or human response.
+
+```mermaid
+flowchart LR
+    Page["Something went wrong page"] --> Stop["Stop repeated actions"]
+    Stop --> Record["Record time and clean route"]
+    Record --> Contact["Contact the platform owner directly"]
+    Page -. "does not prove" .-> Notice["Monitoring or human notification"]
+```
+
+In words: stop repeated actions, record only safe public facts, and contact the platform owner directly. Never treat the page itself as proof that an alert reached anyone.
+
+Until the exact website proof exists, follow **First five minutes** above, but record only the clean route and omit everything after `?` or `#`. Contact the platform owner directly.
+
+Officer steps after the exact website proof exists:
+
+1. Stop using the affected page.
+2. Record the time.
+3. Record only the clean public route. Omit everything after `?` or `#`.
+4. Do not retry if the page followed a signup, checkout, order, payment, refund, Admin save, or any action that might have changed data.
+5. Otherwise, choose **Try again** once.
+6. If the page returns, choose **Go home**.
+7. Contact the platform owner directly.
+8. Add the privacy owner if private information appeared.
+9. Add the treasurer if money, an order, or a signup may be involved.
+10. Record who acknowledged the incident.
+11. Do not open developer tools or copy an error, stack, token, account detail, or private screenshot.
+12. Do not say anyone was notified until that person confirms receipt.
+
+**Expected result:** the page shows one fixed accessible recovery message, no thrown error detail, and the existing **Try again** and **Go home** choices. One safe retry can reset the page. The officer contacts the correct owner directly. The page does not prove that monitoring ran, a provider delivered an alert, or a person saw it.
+
+**Stop conditions:** any private detail, email, URL query, fragment, token-shaped value, provider detail, or technical error appears; the page followed a money, signup, order, or Admin action; one retry fails; anyone asks you to force a production error, inspect a real browser console, change monitoring settings, or copy the thrown value; the exact website revision is unverified; or anyone treats the page or a green workflow as notification proof.
+
+**Success proof:** record the exact #293 issue, reviewed pull request, merged commit, intended old-source exposure, green made-up privacy and recovery tests, relevant full checks, and accessibility review. Record website publication and the dated `runmprc.com` revision separately. A mocked reporting call proves only that source reached the existing reporting boundary. Monitoring configuration, provider delivery, alert routing, and human acknowledgement each require separate private evidence. Do not force a live failure to obtain proof.
+
+**Undo:** use one reviewed frontend revert or safe roll-forward through the protected website release. Verify the replacement revision on `runmprc.com`. Do not undo by disabling monitoring, changing a provider, editing production data, or repeatedly forcing the failure.
+
+**Escalation:** platform owner plus backup. Add the privacy owner for exposed information, the treasurer for money or signup uncertainty, and the security owner for a token, secret, account detail, or unauthorized action. Use the private incident path. Do not copy sensitive details into an issue, message, screenshot, email, or AI tool.
+
 ### Pause new commerce — NOT AVAILABLE YET
 
 **Status:** [#151](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/151) adds source checks only. There is no approved officer button or procedure for changing the server control. Do not edit Firebase, Stripe, or release settings yourself.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -10,37 +10,46 @@ interface Props {
 }
 
 interface State {
-  error: Error | null;
+  hasError: boolean;
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { error: null };
+    this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error): State {
-    return { error };
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
   }
 
-  componentDidCatch(error: Error) {
-    captureException(error);
+  componentDidCatch(error: unknown) {
     reportClientFailure(clientFailureEvents.renderFailed);
+    try {
+      captureException(error);
+    } catch {
+      // Best-effort monitoring must not replace the recovery UI.
+    }
   }
 
   handleReset = () => {
-    this.setState({ error: null });
+    this.setState({ hasError: false });
   };
 
   render() {
-    const { error } = this.state;
+    const { hasError } = this.state;
     const { children } = this.props;
-    if (!error) return children;
+    if (!hasError) return children;
     return (
       <div className="container mx-auto p-6 max-w-xl text-center">
         <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
-        <p className="text-gray-700 mb-4">
-          We hit an unexpected error rendering this page. The team has been notified.
+        <p
+          className="text-gray-700 mb-4"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
+          Try again, and contact an MPRC officer if this keeps happening.
         </p>
         <div className="flex gap-2 justify-center">
           <button
@@ -57,13 +66,6 @@ class ErrorBoundary extends React.Component<Props, State> {
             Go home
           </a>
         </div>
-        {process.env.NODE_ENV === 'development' && (
-          <pre className="mt-6 text-left text-xs text-red-700 bg-red-50 p-3 rounded overflow-auto max-h-64">
-            {error.message}
-            {'\n\n'}
-            {error.stack}
-          </pre>
-        )}
       </div>
     );
   }

--- a/src/services/monitoring/clientDiagnostics.test.ts
+++ b/src/services/monitoring/clientDiagnostics.test.ts
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const React = require('react');
 const ts = require('typescript');
-const { render, screen } = require('@testing-library/react');
+const { fireEvent, render, screen } = require('@testing-library/react');
 
 const mockCaptureException = jest.fn();
 const mockCreateUserWithEmailAndPassword = jest.fn();
@@ -46,6 +46,14 @@ const SAFE_CONSOLE_OWNER = path.join(
   'services',
   'monitoring',
   'clientDiagnostics.ts',
+);
+const ERROR_BOUNDARY_SOURCE = path.join(
+  'src',
+  'components',
+  'ErrorBoundary.tsx',
+);
+const RENDER_FAILURE_MESSAGE = (
+  'Try again, and contact an MPRC officer if this keeps happening.'
 );
 
 function runtimeFiles(directory: string, includeHtml = false): string[] {
@@ -228,6 +236,133 @@ describe('client diagnostic privacy', () => {
     expect(serializedConsole).not.toContain(emailCanary);
     expect(serializedConsole).not.toContain(tokenCanary);
     expect(serializedConsole).not.toContain('private component stack');
+  });
+
+  test('keeps only the closed render-failed state, not the thrown value', () => {
+    const getTrap = jest.fn(() => { throw new Error('private-get-canary'); });
+    const ownKeysTrap = jest.fn(() => { throw new Error('private-keys-canary'); });
+    const descriptorTrap = jest.fn(() => { throw new Error('private-descriptor-canary'); });
+    const hostileFailure = new Proxy(Object.create(null), {
+      get: getTrap,
+      ownKeys: ownKeysTrap,
+      getOwnPropertyDescriptor: descriptorTrap,
+    });
+
+    [null, undefined, false, '', hostileFailure].forEach((failure) => {
+      const state = ErrorBoundary.getDerivedStateFromError(failure);
+      const hasErrorDescriptor = Object.getOwnPropertyDescriptor(state, 'hasError');
+
+      expect(Reflect.ownKeys(state)).toEqual(['hasError']);
+      expect(hasErrorDescriptor).toBeDefined();
+      expect(hasErrorDescriptor?.value).toBe(true);
+    });
+    expect(getTrap).not.toHaveBeenCalled();
+    expect(ownKeysTrap).not.toHaveBeenCalled();
+    expect(descriptorTrap).not.toHaveBeenCalled();
+  });
+
+  test('renders one fixed accessible fallback without environment-specific detail', () => {
+    const error = new Error('private-message-canary');
+    error.stack = 'private-stack-canary';
+    const previousEnvironment = process.env.NODE_ENV;
+    const fallbackMarkup: Record<string, string> = {};
+
+    try {
+      ['test', 'development'].forEach((environment) => {
+        process.env.NODE_ENV = environment;
+        const boundary = new ErrorBoundary({ children: null });
+        (boundary as any).state = ErrorBoundary.getDerivedStateFromError(error);
+        const view = render(boundary.render());
+        fallbackMarkup[environment] = view.container.innerHTML;
+        view.unmount();
+      });
+    } finally {
+      process.env.NODE_ENV = previousEnvironment;
+    }
+
+    expect(fallbackMarkup.development).not.toContain('private-message-canary');
+    expect(fallbackMarkup.development).not.toContain('private-stack-canary');
+    expect(fallbackMarkup.development).toBe(fallbackMarkup.test);
+
+    const boundary = new ErrorBoundary({ children: null });
+    (boundary as any).state = ErrorBoundary.getDerivedStateFromError(error);
+    const view = render(boundary.render());
+    const alerts = screen.getAllByRole('alert');
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toHaveAttribute('aria-live', 'assertive');
+    expect(alerts[0]).toHaveAttribute('aria-atomic', 'true');
+    expect(alerts[0].textContent).toBe(RENDER_FAILURE_MESSAGE);
+    expect(view.container).not.toHaveTextContent('private-message-canary');
+    expect(view.container).not.toHaveTextContent('private-stack-canary');
+    expect(view.container).not.toHaveTextContent('team has been notified');
+  });
+
+  test('has no raw-error or environment-specific fallback branch in source', () => {
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const source = fs.readFileSync(path.join(projectRoot, ERROR_BOUNDARY_SOURCE), 'utf8');
+
+    expect(source).not.toMatch(/\berror\.(?:message|stack)\b/);
+    expect(source).not.toContain('process.env.NODE_ENV');
+    expect(source).not.toContain('The team has been notified');
+  });
+
+  test('passes the original failure only to captureException and emits fixed diagnostics', () => {
+    const hostileFailure = {};
+    const messageGetter = jest.fn(() => { throw new Error('private-message-canary'); });
+    const stackGetter = jest.fn(() => { throw new Error('private-stack-canary'); });
+    const toString = jest.fn(() => { throw new Error('private-string-canary'); });
+    Object.defineProperties(hostileFailure, {
+      message: { get: messageGetter },
+      stack: { get: stackGetter },
+      toString: { value: toString },
+    });
+    const boundary = new ErrorBoundary({ children: null });
+
+    expect(() => boundary.componentDidCatch(hostileFailure)).not.toThrow();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][0]).toBe(hostileFailure);
+    expect(consoleError.mock.calls).toEqual([['[MPRC client] render_failed']]);
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(stackGetter).not.toHaveBeenCalled();
+    expect(toString).not.toHaveBeenCalled();
+  });
+
+  test('keeps fixed recovery diagnostics when the monitoring adapter fails', () => {
+    const adapterFailureCanary = 'private-monitoring-adapter-canary';
+    mockCaptureException.mockImplementationOnce(() => {
+      throw new Error(adapterFailureCanary);
+    });
+    const boundary = new ErrorBoundary({ children: null });
+
+    expect(() => boundary.componentDidCatch(new Error('synthetic render failure'))).not.toThrow();
+    expect(consoleError.mock.calls).toEqual([['[MPRC client] render_failed']]);
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(adapterFailureCanary);
+  });
+
+  test('keeps recovery and home actions after a render failure', () => {
+    let shouldThrow = true;
+    function RecoverableChild() {
+      if (shouldThrow) throw new Error('synthetic render failure');
+      return React.createElement('p', null, 'Recovered child');
+    }
+
+    render(React.createElement(
+      ErrorBoundary,
+      null,
+      React.createElement(RecoverableChild),
+    ));
+
+    expect(screen.getByRole('alert').textContent).toBe(RENDER_FAILURE_MESSAGE);
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(screen.getByText('Recovered child')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   test('verification-email failure returns unavailable without logging provider data', async () => {


### PR DESCRIPTION
## Outcome

The global “Something went wrong” page now keeps only a boolean failure state and shows one fixed accessible recovery message. It no longer stores or renders the thrown error, exposes development message/stack detail, or claims the team was notified.

Monitoring remains best-effort: the original reference is passed once to the existing adapter, a synchronous adapter failure cannot replace the recovery page, and the only MPRC-owned console outcome remains the fixed `render_failed` identifier.

Closes #293.

## Security invariant

MPRC’s ErrorBoundary state derivation and fallback rendering do not read, enumerate, coerce, stringify, retain in state, log, or render the thrown value. This PR does not claim that React or Sentry SDK internals never inspect or report a thrown value before the existing outbound sanitizer.

## Changes

- replace raw `Error | null` state with `{ hasError: boolean }`;
- remove the development message/stack block;
- use one exact assertive/atomic recovery alert with no notification claim;
- keep Try again, Go home, child recovery, and the existing reporting boundary;
- guard a synchronous monitoring-adapter failure without reading or logging it;
- add hostile/falsey/error-environment/accessibility/recovery regression tests;
- add a plain-language source-only officer recovery procedure and diagram.

## Verification

Exact reviewed head: `ce17c99df23cd126a188fadb6c1edf873eb5a517`
Exact base: `d4b9e4d2bf2743a39c019f09495664bd85ce2533`
Exact diff SHA-256: `2d13ccd1fe76c07735607c8879388e2708b1c231b29d2e8693a591d17bec0fc6`

Node 20.19.5:

- deliberate old-source proof: 5 intended failures exposed raw development message/stack, retained raw state, unguarded adapter failure, and missing alert;
- focused diagnostics: 30/30;
- complete frontend: 12 suites / 318 tests;
- TypeScript no-emit: pass;
- frontend lint ledger unchanged: 106 files / 123 reviewed errors / 7 reviewed warnings;
- SPA/workflow/release/readback/artifact safety: 53/53;
- diagnostic production build: pass;
- Functions lint and 1,959 active tests: pass on the byte-identical source diff before the disjoint #291 base refresh;
- Firestore Rules: 378/378;
- real demo-only commerce emulator: 63/63;
- diff check and officer-guide relative links: pass;
- three independent exact-hash reviews: approved.

## Residual boundary

React’s renderer and Sentry SDK normalization may independently inspect or report a thrown value. Monitoring configuration, provider ingestion, alert routing, retention, and human acknowledgement remain outside this source-only PR and unverified.

## Officer impact

Officers will eventually see a fixed recovery message and direct-contact guidance instead of technical error detail or a false notification promise. The guide says when not to retry and never to copy a query, fragment, console, token, or private detail.

## Officer documentation

`docs/officers/EMERGENCY_AND_RECOVERY.md`

## Deployment evidence

Source changed, local tests passed, and the branch is reviewable. Nothing in this PR proves merge, website publication, `runmprc.com` revision, Firebase deployment, monitoring-provider configuration/delivery, production behavior, or human notification. Those states will be recorded separately.
