### PR TITLE
WEB-PRIVACY-001M: fail closed on Admin dashboard summary errors

### DIFF
--- a/.github/lint-baseline.json
+++ b/.github/lint-baseline.json
@@ -31,7 +31,7 @@
     ".ts": 0,
     ".tsx": 7
   },
-  "fingerprint": "sha256:0c34434815d7a5fb07cf657b7b0ca38d6b21a060cf6bb3facc0f5dbd6f6b3a8b",
+  "fingerprint": "sha256:3164e36fd09ee5a7b57a31403c4dbb6cab134f10db35bcd86fd099305e7b5d3b",
   "scannedFiles": [
     "src/App.jsx",
     "src/App.test.jsx",
@@ -234,9 +234,9 @@
     },
     {
       "file": "src/pages/admin/AdminHome.tsx",
-      "line": 148,
+      "line": 196,
       "column": 1,
-      "endLine": 148,
+      "endLine": 196,
       "endColumn": 114,
       "severity": 2,
       "ruleId": "max-len",

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -1101,6 +1101,57 @@ Officer review steps after the source merge:
 
 No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
 
+### Admin dashboard summary load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give an officer one plain result when the Admin dashboard cannot load a complete summary. The page must not show a private technical detail, a false zero, a partial money total, or figures from an older request.
+
+**Approver:** events lead plus platform/security and privacy owners. The treasurer must also approve any future live review of registration or gross-payment figures.
+
+**Prerequisites:** issue [#297](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/297) must be merged for source review. Use only a made-up admin identity, mocked database references, made-up events and registrations, and mocked lookup results. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply. This slice does not approve the dashboard, role, permissions, backup, preview, rollback, event source, publication, registration, payment, or production use. It does not deploy Firebase, change Rules or records, contact Stripe or another provider, use production data, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Made-up Admin dashboard"] --> B["Mocked event-list lookup"]
+    B -- "Rejected" --> F["Fixed alert; no summary"]
+    B -- "Fulfilled; no next event" --> C["Complete overall totals"]
+    B -- "Fulfilled; next event" --> D["Mocked registration lookup"]
+    D -- "Rejected" --> F
+    D -- "Fulfilled" --> E["Complete overall and next-event summary"]
+    G["Obsolete result"] -. "Ignored" .-> H["No display change"]
+```
+
+Text alternative: only the active event lookup and, when needed, its registration lookup may show complete figures. Either rejection shows the same fixed alert with no summary. An obsolete result changes nothing.
+
+Officer review steps after the source merge:
+
+1. Keep this failure sentence and the complete Admin dashboard marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #297 issue, reviewed pull request, merge commit, and synthetic test result.
+3. Confirm the tests use only a made-up admin identity, mocked database references, made-up events and registrations, and mocked results.
+4. Confirm a mocked event-list or registration rejection shows exactly `We could not load the admin summary right now. Please try again later.`
+5. Confirm assistive technology receives the whole sentence immediately as one alert.
+6. Confirm the complete rejected value is not inspected, logged, measured, stored, sent to analytics, or displayed.
+7. Confirm loading and failure show no **Next event**, **Overall**, **Total events**, **Upcoming**, **Drafts**, registration counts, gross amount, or capacity figure.
+8. Confirm an older event or registration result cannot replace the current dashboard after its database reference changes or the page closes.
+9. Confirm a successful empty event list shows the existing complete zero totals and starts no registration lookup.
+10. Confirm a complete made-up success keeps the earliest eligible event, existing counts, gross amount, capacity calculation, date, location, and signup links.
+11. Confirm the **Admin** heading and **Manage** navigation remain during loading and failure. Do not follow the links.
+12. Confirm the mocked lookups receive only the active mocked database reference and selected made-up event ID.
+13. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, event or registration records, production data, Admin-screen approval, and live behavior as separate results.
+
+**Expected result:** the reviewed source commits a summary only after every lookup needed for that summary succeeds. Loading and either lookup failure show no summary figures. A failure uses one fixed accessible sentence and no rejected detail. Older results are inert. Successful empty and complete made-up results keep the existing selection, counts, gross amount, capacity, date, location, and navigation. These mocked figures prove only the display calculation; they do not prove a registration, payment, refund, provider record, or live total. This does not authorize an officer to open or use the Admin dashboard live.
+
+**Stop conditions:** any real officer, member, event, registration, runner, contact detail, waiver, price, gross amount, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; a zero, partial, or stale summary during loading or failure; an attempted Admin action; a Firebase, Rules, provider, permission, source, or record change; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or dashboard is live.
+
+**Success proof:** for source completion, record the exact #297 issue, reviewed pull request, merged commit, eight intended old-source failures, eleven green synthetic dashboard tests, relevant full checks, and independent privacy, accessibility, lifecycle, money-display, and officer-continuity reviews. The safe review stops at source and mocked tests because the Admin dashboard is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, Rules or permission changes, provider configuration, event or registration changes, production-data actions, payments, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend and guide revert or safe roll-forward. After any later approved publication, use the same protected website release path and verify the replacement revision. Do not undo by changing or deleting an event, registration, payment, officer account, permission, database record, source document, or provider setting.
+
+**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, Firebase, provider, account, event, registration, runner, endpoint, token-shaped, or technical detail appeared. Add the treasurer if a count, gross amount, refund, registration, or payment state might be wrong. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only complete-summary display and current-request behavior.
+
 ## Stop conditions
 
 Stop if staging is not isolated, the owner/policy is missing, a test uses real people or money, Firebase deployment skipped, rollback is untested, or the requested action directly edits payment/member state.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6,12 +6,15 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@testing-library/react';
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
 import {
   createCheckoutSession,
+  formatEventDate,
   getEventBySlug,
+  listEventRegistrations,
   listMemberEvents,
   listPublicEvents,
 } from './services/events/eventsService';
@@ -53,6 +56,7 @@ jest.mock('./services/events/eventsService', () => {
     ...actual,
     createCheckoutSession: jest.fn(),
     getEventBySlug: jest.fn(),
+    listEventRegistrations: jest.fn(),
     listMemberEvents: jest.fn(),
     listPublicEvents: jest.fn(),
   };
@@ -93,6 +97,7 @@ beforeEach(() => {
   listAllProducts.mockReset();
   createCheckoutSession.mockReset();
   getEventBySlug.mockReset();
+  listEventRegistrations.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
   listAllEvents.mockReset();
@@ -203,6 +208,7 @@ const EVENT_REGISTER_SUBMIT_FAILURE = 'We could not confirm your registration. P
 const ADMIN_PRODUCTS_LOAD_FAILURE = 'We could not load products right now. Please try again later.';
 const ADMIN_PRODUCT_EDITOR_LOAD_FAILURE = 'We could not load this product right now. Please try again later.';
 const ADMIN_EVENTS_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
+const ADMIN_DASHBOARD_LOAD_FAILURE = 'We could not load the admin summary right now. Please try again later.';
 const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
@@ -248,6 +254,11 @@ function renderAdminProductEditor() {
 
 function renderAdminEvents() {
   window.history.pushState({}, '', '/admin/events');
+  return render(<App />);
+}
+
+function renderAdminDashboard() {
+  window.history.pushState({}, '', '/admin');
   return render(<App />);
 }
 
@@ -2049,6 +2060,467 @@ describe('Admin Product editor load-failure boundary', () => {
     expect(getProductBySlug).toHaveBeenCalledWith(firestore, 'synthetic-product');
     expect(getProductBySlug).toHaveBeenCalledTimes(1);
     expect(window.location.pathname).toBe('/admin/products/synthetic-product/edit');
+  });
+});
+
+describe('Admin dashboard summary load-failure boundary', () => {
+  function timestamp(value) {
+    const date = new Date(value);
+    return {
+      toDate: () => date,
+      toMillis: () => date.getTime(),
+    };
+  }
+
+  function adminEvent({
+    id,
+    slug,
+    title,
+    startsAt,
+    status = 'open',
+    location = 'Synthetic Park',
+    capacity = null,
+  }) {
+    return {
+      id,
+      slug,
+      title,
+      startAt: timestamp(startsAt),
+      status,
+      location,
+      capacity,
+    };
+  }
+
+  function expectSummaryToBeHidden() {
+    expect(screen.queryByText('Next event')).not.toBeInTheDocument();
+    expect(screen.queryByText('Overall')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total events')).not.toBeInTheDocument();
+    expect(screen.queryByText('Upcoming')).not.toBeInTheDocument();
+    expect(screen.queryByText('Drafts')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paid')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+    expect(screen.queryByText('Refunded')).not.toBeInTheDocument();
+    expect(screen.queryByText('Gross')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Capacity:/)).not.toBeInTheDocument();
+  }
+
+  function expectManagementNavigation() {
+    expect(document.querySelector('a[href="/admin/events"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/admin/events/new"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/admin/members"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/admin/products"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/admin/orders"]')).not.toBeNull();
+  }
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore } },
+      isReady: true,
+    });
+    listAllEvents.mockResolvedValue([]);
+    listEventRegistrations.mockResolvedValue([]);
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('hides every summary while the current event lookup is pending', async () => {
+    listAllEvents.mockReturnValueOnce(new Promise(() => {}));
+
+    const view = renderAdminDashboard();
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    expectSummaryToBeHidden();
+    expect(screen.getByRole('heading', { level: 1, name: 'Admin' })).toBeInTheDocument();
+    expect(screen.getByText('Manage')).toBeInTheDocument();
+    expectManagementNavigation();
+    expect(listEventRegistrations).not.toHaveBeenCalled();
+    view.unmount();
+  });
+
+  test('replaces event-list rejection details with one accessible fixed result', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listAllEvents.mockRejectedValueOnce(Object.assign(
+      new Error('admin-summary-private-canary officer@example.test'),
+      {
+        code: 'firestore/admin-summary-private-canary',
+        endpoint: 'https://provider.example.test/?token=admin-summary-secret-canary',
+      },
+    ));
+
+    renderAdminDashboard();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_DASHBOARD_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(document.body).not.toHaveTextContent(
+      /admin-summary-private-canary|officer@example\.test|provider\.example|admin-summary-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /admin-summary-private-canary|officer@example\.test|provider\.example|admin-summary-secret-canary/i,
+    );
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expectSummaryToBeHidden();
+    expect(screen.getByRole('heading', { level: 1, name: 'Admin' })).toBeInTheDocument();
+    expect(screen.getByText('Manage')).toBeInTheDocument();
+    expectManagementNavigation();
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+    expect(listEventRegistrations).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect or log a hostile event-list rejection', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    const messageGetter = jest.fn(() => {
+      throw new Error('admin-summary-message-getter-canary');
+    });
+    listAllEvents.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderAdminDashboard();
+
+    expect((await screen.findByRole('alert')).textContent)
+      .toBe(ADMIN_DASHBOARD_LOAD_FAILURE);
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('admin-summary-message-getter-canary');
+    expectSummaryToBeHidden();
+    expect(listEventRegistrations).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('hides partial event totals when the registration lookup rejects', async () => {
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+    listAllEvents.mockResolvedValueOnce([adminEvent({
+      id: 'synthetic-next-event',
+      slug: 'synthetic-next-run',
+      title: 'Synthetic Next Run',
+      startsAt: '2030-01-12T20:00:00Z',
+      capacity: 8,
+    })]);
+    listEventRegistrations.mockRejectedValueOnce(Object.assign(
+      new Error('admin-summary-registration-private-canary officer@example.test'),
+      {
+        endpoint: 'https://provider.example.test/?token=registration-secret-canary',
+      },
+    ));
+
+    renderAdminDashboard();
+
+    expect((await screen.findByRole('alert')).textContent)
+      .toBe(ADMIN_DASHBOARD_LOAD_FAILURE);
+    expect(document.body).not.toHaveTextContent(
+      /admin-summary-registration-private-canary|officer@example\.test|provider\.example|registration-secret-canary/i,
+    );
+    expectSummaryToBeHidden();
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listEventRegistrations).toHaveBeenCalledWith(
+      firestore,
+      'synthetic-next-event',
+    );
+    expect(listEventRegistrations).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('preserves a complete successful empty summary', async () => {
+    renderAdminDashboard();
+
+    const overall = (await screen.findByText('Overall')).parentElement;
+    expect(overall).toHaveTextContent(/Total events\s*0/);
+    expect(overall).toHaveTextContent(/Upcoming\s*0/);
+    expect(overall).toHaveTextContent(/Drafts\s*0/);
+    expect(screen.queryByText('Next event')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listEventRegistrations).not.toHaveBeenCalled();
+  });
+
+  test('preserves complete event, registration, money, and capacity summaries', async () => {
+    const selectedEvent = adminEvent({
+      id: 'synthetic-next-event',
+      slug: 'synthetic-next-run',
+      title: 'Synthetic Next Run',
+      startsAt: '2030-01-12T20:00:00Z',
+      capacity: 8,
+    });
+    listAllEvents.mockResolvedValueOnce([
+      adminEvent({
+        id: 'synthetic-later-event',
+        slug: 'synthetic-later-run',
+        title: 'Synthetic Later Run',
+        startsAt: '2031-02-12T20:00:00Z',
+        status: 'closed',
+      }),
+      selectedEvent,
+      adminEvent({
+        id: 'synthetic-draft-event',
+        slug: 'synthetic-draft-run',
+        title: 'Synthetic Draft Run',
+        startsAt: '2029-01-12T20:00:00Z',
+        status: 'draft',
+      }),
+      adminEvent({
+        id: 'synthetic-past-event',
+        slug: 'synthetic-past-run',
+        title: 'Synthetic Past Run',
+        startsAt: '2020-01-12T20:00:00Z',
+      }),
+    ]);
+    listEventRegistrations.mockResolvedValueOnce([
+      { status: 'paid', amountCents: 1500 },
+      { status: 'paid', amountCents: 2000 },
+      { status: 'pending', amountCents: 3500 },
+      { status: 'refunded', amountCents: 3500 },
+      { status: 'partially_refunded', amountCents: 500 },
+    ]);
+
+    renderAdminDashboard();
+
+    const eventLink = await screen.findByRole('link', { name: 'Synthetic Next Run' });
+    expect(eventLink).toHaveAttribute(
+      'href',
+      '/admin/events/synthetic-next-run/registrations',
+    );
+    expect(screen.getByRole('link', { name: /View signups/ })).toHaveAttribute(
+      'href',
+      '/admin/events/synthetic-next-run/registrations',
+    );
+    const nextEventSection = screen.getByText('Next event').parentElement;
+    expect(nextEventSection).toHaveTextContent(
+      `${formatEventDate(selectedEvent.startAt)} · Synthetic Park`,
+    );
+    expect(nextEventSection).toHaveTextContent(/Paid\s*2/);
+    expect(nextEventSection).toHaveTextContent(/Pending\s*1/);
+    expect(nextEventSection).toHaveTextContent(/Refunded\s*2/);
+    expect(nextEventSection).toHaveTextContent(/Gross\s*\$35\.00/);
+    expect(nextEventSection).toHaveTextContent(/Capacity:\s*3 \/ 8\s*\(38%\)/);
+    const overall = screen.getByText('Overall').parentElement;
+    expect(overall).toHaveTextContent(/Total events\s*4/);
+    expect(overall).toHaveTextContent(/Upcoming\s*3/);
+    expect(overall).toHaveTextContent(/Drafts\s*1/);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listEventRegistrations).toHaveBeenCalledWith(
+      firestore,
+      'synthetic-next-event',
+    );
+    expect(listEventRegistrations).toHaveBeenCalledTimes(1);
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears a previous summary while a changed database lookup is pending', async () => {
+    listAllEvents.mockResolvedValueOnce([adminEvent({
+      id: 'synthetic-previous-event',
+      slug: 'synthetic-previous-run',
+      title: 'Synthetic Previous Run',
+      startsAt: '2030-01-12T20:00:00Z',
+    })]);
+    const view = renderAdminDashboard();
+    expect(await screen.findByRole('link', { name: 'Synthetic Previous Run' }))
+      .toBeInTheDocument();
+
+    let resolveCurrentLookup;
+    listAllEvents.mockReturnValueOnce(new Promise((resolve) => {
+      resolveCurrentLookup = resolve;
+    }));
+    const currentFirestore = { name: 'synthetic-firestore-current-dashboard' };
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    expectSummaryToBeHidden();
+    expect(document.body).not.toHaveTextContent('Synthetic Previous Run');
+
+    await act(async () => {
+      resolveCurrentLookup([]);
+      await Promise.resolve();
+    });
+
+    const overall = await screen.findByText('Overall');
+    expect(overall.parentElement).toHaveTextContent(/Total events\s*0/);
+    expect(screen.queryByText('Next event')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('ignores an older event-list success after a newer empty result', async () => {
+    let resolveOlderLookup;
+    const olderLookup = new Promise((resolve) => {
+      resolveOlderLookup = resolve;
+    });
+    listAllEvents.mockReturnValueOnce(olderLookup);
+    const view = renderAdminDashboard();
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+
+    const currentFirestore = { name: 'synthetic-firestore-newer-dashboard' };
+    listAllEvents.mockResolvedValueOnce([]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect((await screen.findByText('Overall')).parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+
+    await act(async () => {
+      resolveOlderLookup([adminEvent({
+        id: 'synthetic-older-event',
+        slug: 'synthetic-older-run',
+        title: 'Synthetic Older Run',
+        startsAt: '2030-01-12T20:00:00Z',
+      })]);
+      await olderLookup;
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Overall').parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+    expect(document.body).not.toHaveTextContent('Synthetic Older Run');
+    expect(listEventRegistrations).not.toHaveBeenCalled();
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('ignores an older registration success after a newer empty result', async () => {
+    let resolveOlderRegistrations;
+    const olderRegistrations = new Promise((resolve) => {
+      resolveOlderRegistrations = resolve;
+    });
+    listAllEvents.mockResolvedValueOnce([adminEvent({
+      id: 'synthetic-older-event',
+      slug: 'synthetic-older-run',
+      title: 'Synthetic Older Run',
+      startsAt: '2030-01-12T20:00:00Z',
+      capacity: 4,
+    })]);
+    listEventRegistrations.mockReturnValueOnce(olderRegistrations);
+    const view = renderAdminDashboard();
+    await waitFor(() => expect(listEventRegistrations).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    expectSummaryToBeHidden();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    const currentFirestore = { name: 'synthetic-firestore-newest-dashboard' };
+    listAllEvents.mockResolvedValueOnce([]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect((await screen.findByText('Overall')).parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+
+    await act(async () => {
+      resolveOlderRegistrations([{ status: 'paid', amountCents: 4800 }]);
+      await olderRegistrations;
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('Next event')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('Overall').parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+    expect(document.body).not.toHaveTextContent('Synthetic Older Run');
+    expect(document.body).not.toHaveTextContent('$48.00');
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('ignores an older hostile registration rejection after a newer success', async () => {
+    let rejectOlderRegistrations;
+    listAllEvents.mockResolvedValueOnce([adminEvent({
+      id: 'synthetic-older-event',
+      slug: 'synthetic-older-run',
+      title: 'Synthetic Older Run',
+      startsAt: '2030-01-12T20:00:00Z',
+    })]);
+    listEventRegistrations.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectOlderRegistrations = reject;
+    }));
+    const view = renderAdminDashboard();
+    await waitFor(() => expect(listEventRegistrations).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-firestore-latest-dashboard' };
+    listAllEvents.mockResolvedValueOnce([]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect((await screen.findByText('Overall')).parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+
+    const messageGetter = jest.fn(() => {
+      throw new Error('admin-summary-older-message-getter-canary');
+    });
+    await act(async () => {
+      rejectOlderRegistrations(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('Overall').parentElement)
+      .toHaveTextContent(/Total events\s*0/);
+    expect(document.body).not.toHaveTextContent(
+      'admin-summary-older-message-getter-canary',
+    );
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('does not start a registration lookup after the dashboard unmounts', async () => {
+    let resolveLookup;
+    const pendingLookup = new Promise((resolve) => {
+      resolveLookup = resolve;
+    });
+    listAllEvents.mockReturnValueOnce(pendingLookup);
+    const view = renderAdminDashboard();
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    view.unmount();
+
+    await act(async () => {
+      resolveLookup([adminEvent({
+        id: 'synthetic-unmounted-event',
+        slug: 'synthetic-unmounted-run',
+        title: 'Synthetic Unmounted Run',
+        startsAt: '2030-01-12T20:00:00Z',
+      })]);
+      await pendingLookup;
+      await Promise.resolve();
+    });
+
+    expect(listEventRegistrations).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -18,6 +18,15 @@ interface EventSummary {
   grossCents: number;
 }
 
+interface DashboardLoadOutcome {
+  firestore: unknown;
+  status: 'loading' | 'resolved' | 'unavailable';
+  allEvents: Event[];
+  nextEvent: EventSummary | null;
+}
+
+const LOAD_FAILURE = 'We could not load the admin summary right now. Please try again later.';
+
 function Tile({
   label, value, subtitle,
 }: {
@@ -42,18 +51,32 @@ function isUpcoming(e: Event): boolean {
 
 function Inner() {
   const { services, isReady } = useServiceLocator();
-  const [nextEvent, setNextEvent] = useState<EventSummary | null>(null);
-  const [allEvents, setAllEvents] = useState<Event[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const firestore = isReady && services
+    ? services.firebaseResources.firestore
+    : null;
+  const [loadOutcome, setLoadOutcome] = useState<DashboardLoadOutcome | null>(null);
+
+  const currentOutcome = loadOutcome?.firestore === firestore ? loadOutcome : null;
+  const currentStatus = currentOutcome?.status ?? 'loading';
+  const allEvents = currentOutcome?.status === 'resolved' ? currentOutcome.allEvents : [];
+  const nextEvent = currentOutcome?.status === 'resolved' ? currentOutcome.nextEvent : null;
 
   useEffect(() => {
-    if (!isReady || !services) return;
-    const db = services.firebaseResources.firestore;
+    if (!firestore) return () => undefined;
+    let active = true;
+    const outcomeKey = { firestore };
+
+    setLoadOutcome({
+      ...outcomeKey,
+      status: 'loading',
+      allEvents: [],
+      nextEvent: null,
+    });
+
     (async () => {
       try {
-        const all = await listAllEvents(db);
-        setAllEvents(all);
+        const all = await listAllEvents(firestore);
+        if (!active) return;
 
         const upcoming = all
           .filter((e) => isUpcoming(e) && (e.status === 'open' || e.status === 'closed'))
@@ -63,28 +86,44 @@ function Inner() {
             return ams - bms;
           });
         const next = upcoming[0];
+        let nextSummary: EventSummary | null = null;
         if (next) {
-          const regs = await listEventRegistrations(db, next.id);
+          const regs = await listEventRegistrations(firestore, next.id);
+          if (!active) return;
           const paid = regs.filter((r) => r.status === 'paid');
           const pending = regs.filter((r) => r.status === 'pending');
           const refunded = regs.filter(
             (r) => r.status === 'refunded' || r.status === 'partially_refunded',
           );
-          setNextEvent({
+          nextSummary = {
             event: next,
             paidCount: paid.length,
             pendingCount: pending.length,
             refundedCount: refunded.length,
             grossCents: paid.reduce((s, r) => s + (r.amountCents || 0), 0),
-          });
+          };
         }
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
+
+        if (!active) return;
+        setLoadOutcome({
+          ...outcomeKey,
+          status: 'resolved',
+          allEvents: all,
+          nextEvent: nextSummary,
+        });
+      } catch {
+        if (!active) return;
+        setLoadOutcome({
+          ...outcomeKey,
+          status: 'unavailable',
+          allEvents: [],
+          nextEvent: null,
+        });
       }
     })();
-  }, [services, isReady]);
+
+    return () => { active = false; };
+  }, [firestore]);
 
   const totalEvents = allEvents.length;
   const upcomingCount = allEvents.filter(isUpcoming).length;
@@ -96,10 +135,19 @@ function Inner() {
       <div className="container mx-auto p-4 max-w-5xl">
         <h1 className="text-2xl font-bold mb-4">Admin</h1>
 
-        {loading && <p>Loading...</p>}
-        {error && <p className="text-red-500 text-sm">{error}</p>}
+        {currentStatus === 'loading' && <p>Loading...</p>}
+        {currentStatus === 'unavailable' && (
+          <p
+            className="text-red-500 text-sm"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
+            {LOAD_FAILURE}
+          </p>
+        )}
 
-        {!loading && nextEvent && (
+        {currentStatus === 'resolved' && nextEvent && (
           <section className="mb-6">
             <div className="text-xs uppercase tracking-wide text-gray-600 mb-2">
               Next event
@@ -153,16 +201,18 @@ function Inner() {
           </section>
         )}
 
-        <section className="mb-6">
-          <div className="text-xs uppercase tracking-wide text-gray-600 mb-2">
-            Overall
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-            <Tile label="Total events" value={totalEvents} />
-            <Tile label="Upcoming" value={upcomingCount} />
-            <Tile label="Drafts" value={draftCount} />
-          </div>
-        </section>
+        {currentStatus === 'resolved' && (
+          <section className="mb-6">
+            <div className="text-xs uppercase tracking-wide text-gray-600 mb-2">
+              Overall
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              <Tile label="Total events" value={totalEvents} />
+              <Tile label="Upcoming" value={upcomingCount} />
+              <Tile label="Drafts" value={draftCount} />
+            </div>
+          </section>
+        )}
 
         <section>
           <div className="text-xs uppercase tracking-wide text-gray-600 mb-2">


### PR DESCRIPTION
## Outcome

The Admin dashboard now shows summary figures only after every lookup needed for that summary succeeds. Loading, event-list failure, and registration-list failure show no zero, partial, or stale summary. Rejected values are discarded without inspection and use one fixed accessible result.

Closes #297

## Safety invariant

Only the current database request may commit one complete dashboard outcome. An obsolete or unmounted request is inert. This source-only change does not authorize use of the Admin screens.

## Changes

- Key dashboard load state to the current Firestore identity before rendering any result.
- Commit event and next-event registration summaries atomically after both required reads succeed.
- Replace raw rejection messages with one assertive, atomic alert.
- Keep the Admin heading and Manage navigation while hiding all summary figures during unknown states.
- Add 11 synthetic tests for both read stages, hostile values, second-stage loading, empty and populated compatibility, status filtering, exact date formatting, stale success and failure, service changes, and unmount.
- Add the plain-language officer procedure and state-flow diagram.
- Update only the existing AdminHome lint-record positions and derived fingerprint.

## Red proof

Against the unchanged old runtime, the focused matrix produced 8 intended failures and 2 preservation passes. It demonstrated raw detail, false zero totals, partial event totals, stale settlements, and a post-unmount registration read.

## Verification

Exact source head: `8cc302062bb7aed36f1738d23da512bc32bcce0a`
Exact four-file diff SHA-256: `f6f3678438315e513a0c3c4581809f746ac7235ef1919e6c880678e4ba101913`

- Focused Admin dashboard tests: 11/11
- Full frontend: 12 suites, 338/338
- TypeScript: pass
- Frontend lint ledger: 106 files, 123 reviewed errors, 7 reviewed warnings
- SPA plus workflow/release/Firebase-readback/artifact safety: 53/53
- Diagnostic production build: pass
- Functions on refreshed #299 base: 29 active suites, 1,994 passed, 64 emulator-only skipped
- Firestore Rules using `demo-rules-test`: 378/378
- Commerce journal using `demo-pay002b2-test`: 63/63
- Diff check: clean
- Three independent exact-diff reviews: approved with no remaining findings

One early Functions check used an incomplete worktree, and one default Node 22 run was discarded. The exact Node 20 reruns above passed.

## Officer impact

Officers will eventually see one fixed, private, accessible unknown-result sentence instead of provider detail, false zeros, partial totals, or stale figures. The Admin dashboard remains **NOT AVAILABLE YET**.

## Officer documentation

Updated `docs/officers/EVENTS_SHOP_MEMBERS.md` with purpose, approver, prerequisites, one-action steps, expected result, stops, proof, undo, escalation, diagram, and text alternative.

## Deployment evidence

Source and local tests only at PR creation. No protected release ran. The website and `runmprc.com` were not published or verified. Firebase Functions, Firestore Rules, and outside providers were not deployed or configured. No production event, registration, payment, member, product, order, or other record was read or changed. Live behavior is not proven.