### PR TITLE
PAY-001B1A — Fail closed on malformed registration windows

### DIFF
--- a/functions/stripeHelpers.js
+++ b/functions/stripeHelpers.js
@@ -2,6 +2,7 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const Stripe = require('stripe');
 const crypto = require('crypto');
+const { types: { isProxy } } = require('node:util');
 const { loadCallableServerConfig } = require('./serverConfig');
 const {
   isVerifiedAdmin,
@@ -13,6 +14,21 @@ const {
 } = require('firebase-admin/firestore');
 
 const STRIPE_API_VERSION = '2023-10-16';
+const INVALID_REGISTRATION_WINDOW_VALUE = Symbol('invalid-registration-window-value');
+const MISSING_REGISTRATION_WINDOW_VALUE = Symbol('missing-registration-window-value');
+const MIN_TIMESTAMP_SECONDS = -62_135_596_800;
+const MAX_TIMESTAMP_SECONDS = 253_402_300_799;
+const MAX_TIMESTAMP_NANOSECONDS = 999_999_999;
+const dateNow = Date.now;
+const mathFloor = Math.floor;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwn = Object.hasOwn;
+const objectPrototype = Object.prototype;
+const numberIsFinite = Number.isFinite;
+const numberIsSafeInteger = Number.isSafeInteger;
+const reflectOwnKeys = Reflect.ownKeys;
+const timestampPrototype = Timestamp.prototype;
 
 let _stripeClient = null;
 function getStripe() {
@@ -99,20 +115,100 @@ function isEarlyBirdActive(event, now = Date.now()) {
   return now < untilMs;
 }
 
-function isRegistrationOpen(event, now = Date.now()) {
-  if (event.status !== 'open') return false;
-  if (event.registrationOpensAt) {
-    const opensMs = event.registrationOpensAt.toMillis
-      ? event.registrationOpensAt.toMillis()
-      : new Date(event.registrationOpensAt).getTime();
-    if (now < opensMs) return false;
+function isProxyValue(value) {
+  try {
+    return isProxy(value);
+  } catch (_error) {
+    return true;
   }
-  if (event.registrationClosesAt) {
-    const closesMs = event.registrationClosesAt.toMillis
-      ? event.registrationClosesAt.toMillis()
-      : new Date(event.registrationClosesAt).getTime();
-    if (now > closesMs) return false;
+}
+
+function isPlainEventRecord(value) {
+  if (value === null || typeof value !== 'object' || isProxyValue(value)) return false;
+  try {
+    return objectGetPrototypeOf(value) === objectPrototype;
+  } catch (_error) {
+    return false;
   }
+}
+
+function selectedOwnDataValue(record, key, requireEnumerable = false) {
+  let descriptor;
+  try {
+    descriptor = objectGetOwnPropertyDescriptor(record, key);
+  } catch (_error) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+  if (!descriptor) return MISSING_REGISTRATION_WINDOW_VALUE;
+  if (!objectHasOwn(descriptor, 'value')
+    || (requireEnumerable && descriptor.enumerable !== true)) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+  return descriptor.value;
+}
+
+function timestampToMillis(value) {
+  if (value === null || typeof value !== 'object' || isProxyValue(value)) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+
+  // Firestore decodes valid bounds as this locked SDK class. Read its scalar
+  // state directly so a stored method, accessor, or coercion can never run.
+  let prototype;
+  let keys;
+  try {
+    prototype = objectGetPrototypeOf(value);
+    keys = reflectOwnKeys(value);
+  } catch (_error) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+  if (prototype !== timestampPrototype || keys.length !== 2) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+  const hasExactInternalKeys = (keys[0] === '_seconds' && keys[1] === '_nanoseconds')
+    || (keys[0] === '_nanoseconds' && keys[1] === '_seconds');
+  if (!hasExactInternalKeys) return INVALID_REGISTRATION_WINDOW_VALUE;
+
+  const seconds = selectedOwnDataValue(value, '_seconds', true);
+  const nanoseconds = selectedOwnDataValue(value, '_nanoseconds', true);
+  if (!numberIsSafeInteger(seconds)
+    || seconds < MIN_TIMESTAMP_SECONDS
+    || seconds > MAX_TIMESTAMP_SECONDS
+    || !numberIsSafeInteger(nanoseconds)
+    || nanoseconds < 0
+    || nanoseconds > MAX_TIMESTAMP_NANOSECONDS) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+
+  const milliseconds = seconds * 1_000 + mathFloor(nanoseconds / 1_000_000);
+  return numberIsFinite(milliseconds)
+    ? milliseconds
+    : INVALID_REGISTRATION_WINDOW_VALUE;
+}
+
+function registrationBoundMillis(event, key) {
+  const value = selectedOwnDataValue(event, key);
+  if (value === MISSING_REGISTRATION_WINDOW_VALUE || value === null) {
+    return MISSING_REGISTRATION_WINDOW_VALUE;
+  }
+  if (value === INVALID_REGISTRATION_WINDOW_VALUE) {
+    return INVALID_REGISTRATION_WINDOW_VALUE;
+  }
+  return timestampToMillis(value);
+}
+
+function isRegistrationOpen(event, now = dateNow()) {
+  if (!numberIsFinite(now) || !isPlainEventRecord(event)) return false;
+  if (selectedOwnDataValue(event, 'status') !== 'open') return false;
+
+  const opensMs = registrationBoundMillis(event, 'registrationOpensAt');
+  if (opensMs === INVALID_REGISTRATION_WINDOW_VALUE) return false;
+  if (opensMs !== MISSING_REGISTRATION_WINDOW_VALUE && now < opensMs) return false;
+
+  const closesMs = registrationBoundMillis(event, 'registrationClosesAt');
+  if (closesMs === INVALID_REGISTRATION_WINDOW_VALUE) return false;
+  if (closesMs !== MISSING_REGISTRATION_WINDOW_VALUE && now > closesMs) return false;
+
   return true;
 }
 

--- a/functions/stripeHelpers.test.js
+++ b/functions/stripeHelpers.test.js
@@ -17,19 +17,309 @@ jest.mock('firebase-admin', () => ({
   firestore: jest.fn(),
 }));
 
-jest.mock('firebase-admin/firestore', () => ({
-  Timestamp: { now: jest.fn() },
-  FieldValue: {},
-}));
+jest.mock('firebase-admin/firestore', () => {
+  const actual = jest.requireActual('firebase-admin/firestore');
+  return {
+    Timestamp: actual.Timestamp,
+    FieldValue: actual.FieldValue,
+  };
+});
 
 jest.mock('./serverConfig', () => ({
   loadCallableServerConfig: (...args) => mockLoadCallableServerConfig(...args),
 }));
 
 const {
+  isRegistrationOpen,
   requireAdmin,
   resolveCallerRole,
+  Timestamp,
 } = require('./stripeHelpers');
+
+const NOW_MS = 1_735_689_600_000;
+
+function openEvent(overrides = {}) {
+  return { status: 'open', ...overrides };
+}
+
+describe('registration-window validation', () => {
+  test('keeps missing and null bounds unbounded', () => {
+    expect(isRegistrationOpen(openEvent(), NOW_MS)).toBe(true);
+    expect(isRegistrationOpen(openEvent({
+      registrationOpensAt: null,
+      registrationClosesAt: null,
+    }), NOW_MS)).toBe(true);
+  });
+
+  test.each([
+    ['before the opening instant', NOW_MS - 1, false],
+    ['at the opening instant', NOW_MS, true],
+    ['inside the window', NOW_MS + 500, true],
+    ['at the closing instant', NOW_MS + 1_000, true],
+    ['after the closing instant', NOW_MS + 1_001, false],
+  ])('uses inclusive valid Timestamp bounds %s', (_name, now, expected) => {
+    const event = openEvent({
+      registrationOpensAt: Timestamp.fromMillis(NOW_MS),
+      registrationClosesAt: Timestamp.fromMillis(NOW_MS + 1_000),
+    });
+
+    expect(isRegistrationOpen(event, now)).toBe(expected);
+  });
+
+  test('accepts either valid bound alone and frozen genuine Timestamps', () => {
+    const opensAtNow = Object.freeze(Timestamp.fromMillis(NOW_MS));
+    const closesAtNow = Object.freeze(Timestamp.fromMillis(NOW_MS));
+
+    expect(isRegistrationOpen(openEvent({
+      registrationOpensAt: opensAtNow,
+    }), NOW_MS)).toBe(true);
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: closesAtNow,
+    }), NOW_MS)).toBe(true);
+  });
+
+  test.each([
+    ['missing', undefined],
+    ['draft', 'draft'],
+    ['closed', 'closed'],
+    ['cancelled', 'cancelled'],
+    ['uppercase', 'OPEN'],
+    ['boolean', true],
+  ])('rejects a %s status', (_name, status) => {
+    const event = status === undefined ? {} : { status };
+    expect(isRegistrationOpen(event, NOW_MS)).toBe(false);
+  });
+
+  test.each([
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['numeric string', String(NOW_MS)],
+    ['Date', new Date(NOW_MS)],
+    ['null', null],
+  ])('rejects non-finite-number now: %s', (_name, now) => {
+    expect(isRegistrationOpen(openEvent(), now)).toBe(false);
+  });
+
+  test('rejects coercible now values without invoking coercion', () => {
+    const valueOf = jest.fn(() => NOW_MS);
+    const now = { valueOf };
+    expect(isRegistrationOpen(openEvent({
+      registrationOpensAt: Timestamp.fromMillis(NOW_MS),
+    }), now)).toBe(false);
+    expect(valueOf).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 1],
+    ['string', 'event'],
+    ['array', []],
+  ])('rejects a %s event root without throwing', (_name, event) => {
+    expect(() => isRegistrationOpen(event, NOW_MS)).not.toThrow();
+    expect(isRegistrationOpen(event, NOW_MS)).toBe(false);
+  });
+
+  test('rejects custom and inherited event records', () => {
+    class EventRecord {
+      constructor() {
+        this.status = 'open';
+      }
+    }
+    expect(isRegistrationOpen(new EventRecord(), NOW_MS)).toBe(false);
+
+    const inheritedStatus = Object.create({ status: 'open' });
+    expect(isRegistrationOpen(inheritedStatus, NOW_MS)).toBe(false);
+
+    const inheritedBound = Object.create({
+      registrationOpensAt: Timestamp.fromMillis(NOW_MS - 1),
+    });
+    inheritedBound.status = 'open';
+    expect(isRegistrationOpen(inheritedBound, NOW_MS)).toBe(false);
+  });
+
+  const malformedBounds = [
+    ['false', false],
+    ['zero', 0],
+    ['empty string', ''],
+    ['true', true],
+    ['number', NOW_MS],
+    ['ISO string', new Date(NOW_MS).toISOString()],
+    ['Date', new Date(NOW_MS)],
+    ['array', []],
+    ['plain map', {}],
+    ['Map', new Map()],
+    ['undefined', undefined],
+    ['pseudo toMillis value', { toMillis: NOW_MS }],
+  ];
+
+  test.each(['registrationOpensAt', 'registrationClosesAt'])(
+    'rejects malformed %s values without throwing',
+    (field) => {
+      malformedBounds.forEach(([_name, value]) => {
+        expect(() => isRegistrationOpen(openEvent({ [field]: value }), NOW_MS))
+          .not.toThrow();
+        expect(isRegistrationOpen(openEvent({ [field]: value }), NOW_MS))
+          .toBe(false);
+      });
+    },
+  );
+
+  test.each(['registrationOpensAt', 'registrationClosesAt'])(
+    'does not invoke pseudo methods or own accessors for %s',
+    (field) => {
+      const pseudoMethod = jest.fn(() => NOW_MS);
+      expect(isRegistrationOpen(openEvent({
+        [field]: { toMillis: pseudoMethod },
+      }), NOW_MS)).toBe(false);
+      expect(pseudoMethod).not.toHaveBeenCalled();
+
+      const throwingMethod = jest.fn(() => {
+        throw new Error('synthetic timestamp method must not run');
+      });
+      expect(() => isRegistrationOpen(openEvent({
+        [field]: { toMillis: throwingMethod },
+      }), NOW_MS)).not.toThrow();
+      expect(throwingMethod).not.toHaveBeenCalled();
+
+      const boundGetter = jest.fn(() => Timestamp.fromMillis(NOW_MS));
+      const eventWithAccessor = openEvent();
+      Object.defineProperty(eventWithAccessor, field, { get: boundGetter });
+      expect(isRegistrationOpen(eventWithAccessor, NOW_MS)).toBe(false);
+      expect(boundGetter).not.toHaveBeenCalled();
+
+      const toMillisGetter = jest.fn(() => () => NOW_MS);
+      const timestampLike = {};
+      Object.defineProperty(timestampLike, 'toMillis', { get: toMillisGetter });
+      expect(isRegistrationOpen(openEvent({ [field]: timestampLike }), NOW_MS))
+        .toBe(false);
+      expect(toMillisGetter).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['registrationOpensAt', 'registrationClosesAt'])(
+    'rejects Proxy %s values without invoking traps',
+    (field) => {
+      const proxyTrap = jest.fn(() => {
+        throw new Error('synthetic Proxy trap must not run');
+      });
+      const proxiedBound = new Proxy(Timestamp.fromMillis(NOW_MS), {
+        get: proxyTrap,
+        getOwnPropertyDescriptor: proxyTrap,
+        getPrototypeOf: proxyTrap,
+        ownKeys: proxyTrap,
+      });
+
+      expect(() => isRegistrationOpen(openEvent({ [field]: proxiedBound }), NOW_MS))
+        .not.toThrow();
+      expect(isRegistrationOpen(openEvent({ [field]: proxiedBound }), NOW_MS))
+        .toBe(false);
+      expect(proxyTrap).not.toHaveBeenCalled();
+
+      const revoked = Proxy.revocable(Timestamp.fromMillis(NOW_MS), {});
+      revoked.revoke();
+      expect(() => isRegistrationOpen(openEvent({
+        [field]: revoked.proxy,
+      }), NOW_MS)).not.toThrow();
+      expect(isRegistrationOpen(openEvent({
+        [field]: revoked.proxy,
+      }), NOW_MS)).toBe(false);
+    },
+  );
+
+  test('rejects Proxy and accessor-backed event roots without invoking them', () => {
+    const rootProxyTrap = jest.fn(() => {
+      throw new Error('synthetic root Proxy trap must not run');
+    });
+    const proxiedEvent = new Proxy(openEvent(), {
+      get: rootProxyTrap,
+      getOwnPropertyDescriptor: rootProxyTrap,
+      getPrototypeOf: rootProxyTrap,
+      ownKeys: rootProxyTrap,
+    });
+    expect(() => isRegistrationOpen(proxiedEvent, NOW_MS)).not.toThrow();
+    expect(isRegistrationOpen(proxiedEvent, NOW_MS)).toBe(false);
+    expect(rootProxyTrap).not.toHaveBeenCalled();
+
+    const statusGetter = jest.fn(() => 'open');
+    const accessorEvent = {};
+    Object.defineProperty(accessorEvent, 'status', { get: statusGetter });
+    expect(isRegistrationOpen(accessorEvent, NOW_MS)).toBe(false);
+    expect(statusGetter).not.toHaveBeenCalled();
+  });
+
+  test('rejects modified and malformed Timestamp-shaped values', () => {
+    const modified = Timestamp.fromMillis(NOW_MS);
+    const ownMethod = jest.fn(() => NOW_MS);
+    Object.defineProperty(modified, 'toMillis', { value: ownMethod });
+    expect(isRegistrationOpen(openEvent({
+      registrationOpensAt: modified,
+    }), NOW_MS)).toBe(false);
+    expect(ownMethod).not.toHaveBeenCalled();
+
+    const malformed = Object.create(Timestamp.prototype);
+    Object.defineProperties(malformed, {
+      _seconds: { value: Number.POSITIVE_INFINITY, enumerable: true },
+      _nanoseconds: { value: 0, enumerable: true },
+    });
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: malformed,
+    }), NOW_MS)).toBe(false);
+
+    const internalGetter = jest.fn(() => Math.floor(NOW_MS / 1_000));
+    const accessorInternals = Object.create(Timestamp.prototype);
+    Object.defineProperties(accessorInternals, {
+      _seconds: { get: internalGetter, enumerable: true },
+      _nanoseconds: { value: 0, enumerable: true },
+    });
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: accessorInternals,
+    }), NOW_MS)).toBe(false);
+    expect(internalGetter).not.toHaveBeenCalled();
+
+    const nonEnumerableInternals = Object.create(Timestamp.prototype);
+    Object.defineProperties(nonEnumerableInternals, {
+      _seconds: { value: Math.floor(NOW_MS / 1_000) },
+      _nanoseconds: { value: 0 },
+    });
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: nonEnumerableInternals,
+    }), NOW_MS)).toBe(false);
+
+    class TimestampSubclass extends Timestamp {}
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: new TimestampSubclass(
+        Math.floor(NOW_MS / 1_000),
+        0,
+      ),
+    }), NOW_MS)).toBe(false);
+
+    const extraOwnKey = Timestamp.fromMillis(NOW_MS);
+    Object.defineProperty(extraOwnKey, Symbol('synthetic-extra'), { value: true });
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: extraOwnKey,
+    }), NOW_MS)).toBe(false);
+  });
+
+  test.each([
+    ['seconds below the SDK range', -62_135_596_801, 0],
+    ['seconds above the SDK range', 253_402_300_800, 0],
+    ['fractional seconds', Math.floor(NOW_MS / 1_000) + 0.5, 0],
+    ['negative nanoseconds', Math.floor(NOW_MS / 1_000), -1],
+    ['nanoseconds above the SDK range', Math.floor(NOW_MS / 1_000), 1_000_000_000],
+    ['fractional nanoseconds', Math.floor(NOW_MS / 1_000), 0.5],
+  ])('rejects Timestamp-shaped %s', (_name, seconds, nanoseconds) => {
+    const malformed = Object.create(Timestamp.prototype);
+    Object.defineProperties(malformed, {
+      _seconds: { value: seconds, enumerable: true },
+      _nanoseconds: { value: nanoseconds, enumerable: true },
+    });
+    expect(isRegistrationOpen(openEvent({
+      registrationClosesAt: malformed,
+    }), NOW_MS)).toBe(false);
+  });
+});
 
 describe('shared Functions role guards', () => {
   test('preserves the unauthenticated error', async () => {


### PR DESCRIPTION
Closes #302.

## Outcome

Race checkout now fails closed when an event's registration window is malformed. Valid `firebase-admin` Timestamps, missing/null unbounded fields, and inclusive opening/closing equality keep their existing behavior.

The helper reads only own data descriptors and the locked SDK Timestamp's scalar state. It does not call stored `toMillis` methods, parse arbitrary values as Dates, coerce the clock, or invoke event/timestamp accessors and Proxy traps.

## Exact scope

- `functions/stripeHelpers.js`: strict registration-window projection and comparison.
- `functions/stripeHelpers.test.js`: real Admin SDK Timestamp compatibility plus positive, boundary, malformed-value, no-coercion, accessor, Proxy/revoked-Proxy, and internal-range cases.

No checkout endpoint, rate-limit, capacity, inventory, idempotency, early-bird, Firestore Rules, package, documentation, provider, deployment, or data path changed.

## Security and compatibility

- Status must be the own data value `open`; the resolved clock must be a finite number.
- Missing/null bounds remain unbounded. Explicit `undefined` and all other wrong types close registration.
- A present bound must have the exact locked Admin SDK Timestamp prototype, exact two own enumerable scalar fields, SDK integer ranges, and no extra own keys.
- Millisecond flooring matches the SDK formula; equality remains open.
- A malformed record returns `false`; no request value, PII, secret, or raw error is logged.
- This existing helper is reached after the endpoint's two rate-limit writes, but before role/capacity work, token or registration creation, Product creation, and Checkout Session creation. This PR does not move that order.

JavaScript cannot distinguish a constructor-created Timestamp from a perfectly forged in-process object with the same exact prototype and scalar descriptors because this SDK class has no private brand. A persisted Firestore map does not receive that prototype; compromise by already-trusted server code is outside this stored-data boundary. The implementation intentionally couples to the locked SDK field layout: a future incompatible SDK layout fails closed, and the real-SDK compatibility test must pass on dependency upgrades.

## Evidence

- Red baseline: 34 passed / 22 intended failures / 56 total after the full matrix was added. The old code failed open and invoked/threw from hostile values.
- Focused `stripeHelpers.test.js`: 56/56.
- Functions lint and full suite: 2,034 passed; 64 emulator-only skipped.
- Frontend Jest: 338/338.
- Firestore Rules emulator: 378/378 under Java 17.
- Real commerce concurrency emulator: 63/63.
- Workflow/release/Firebase-verification/artifact/SPA: 53/53.
- Frontend lint ledger: 106 files, unchanged 123 reviewed errors and 7 warnings.
- TypeScript and diagnostic production build: passed.

The first diagnostic build attempt stopped before compilation because local temporary storage was full. Only task-generated build output and the Jest temp cache were removed; the identical source then compiled successfully.

## Migration / residual work

No schema, backfill, provider, or production-data action. Valid Timestamp/null records are unchanged. Previously tolerated Date/string/number/map values become closed if this source is later deployed. #113 must privately inventory and repair malformed legacy records before a protected Firebase release.

## Officer continuity

Officer impact: None from this source/test merge. No live event or officer workflow changes until a future protected Functions deployment.

Officer documentation: None — this atomic patch changes no public content, navigation, admin duty, collected data, permissions, external account, or deploy procedure. A future deployment/inventory issue must update the applicable guide with staging and readback evidence.

Deployment evidence: Source/test only. No website publication, `runmprc.com` verification, Firebase Functions or Rules deployment, Stripe/provider call or configuration, production-data action, migration, or live behavior verification occurred.
