### PR TITLE
WEB-PRIVACY-001O: fail closed on Admin website-account list errors

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -1206,6 +1206,64 @@ The existing Fulfill, Refund, and Cancel requests, prompts, action responses, ra
 
 No system-topology diagram changes for this source slice because page hierarchy, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected list-result display and current-request behavior.
 
+### Admin website-account role-list load failure privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep an unknown website-account role list private and fail closed. The page must not show a raw technical detail, false zero role counts, old names or email addresses, or role-change controls from an earlier request. A website role is not proof of annual paid membership.
+
+**Approver:** membership lead plus identity/platform security and privacy owners. Add the treasurer before any future work that displays annual membership, dues, pricing, or discount eligibility.
+
+**Prerequisites:** issue [#307](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/307) must be merged for source review. Use only a made-up admin identity, mocked database references, made-up website accounts, and mocked list results. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply. Issue [#116](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/116) remains the separate future owner of the authoritative current-membership roster and CSV export. This slice does not approve the screen or role changes, implement a roster or export, deploy Firebase, change an account or membership, use production data, or prove live behavior.
+
+Before #307, the source could show raw load errors, false zero counts, old account details, and broad labels that could be mistaken for membership. A merged source fix and green tests do not publish the website. A website publication does not prove Firebase, permissions, account records, annual membership, dues, pricing, discounts, or role-action safety.
+
+```mermaid
+flowchart LR
+    A["Made-up Admin website-account route"] --> B["Current mocked account-role lookup"]
+    B -- "Pending" --> C["Loading; no role counts, account details, or role buttons"]
+    B -- "Rejected" --> D["Fixed stop alert; no role counts, account details, or role buttons"]
+    B -- "Fulfilled empty" --> E["Zero website-account role counts"]
+    B -- "Fulfilled with accounts" --> F["Website-account roles and access controls"]
+    F -. "Not membership proof" .-> G["Annual paid-membership roster — #116 NOT AVAILABLE YET"]
+    H["Obsolete result"] -. "Ignored" .-> I["No display change"]
+```
+
+Text alternative: only the current successful mocked lookup may show website-account roles. Loading, rejection, and obsolete results show no account-derived content. Website roles, account dates, and email verification never prove annual paid membership; the future #116 roster is separate.
+
+Officer review steps after the source merge:
+
+1. Keep the Admin website-account screen and the #116 membership roster marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #307 issue, reviewed pull request, merged commit, and synthetic frontend test result.
+3. Confirm the tests use only a made-up admin identity, mocked database references, and made-up website accounts.
+4. Confirm no test clicks a role-change button or calls the role-change service.
+5. Confirm loading and failure show no role counts, filters, names, email addresses, dates, verification state, rows, or role buttons.
+6. Confirm a mocked rejection shows exactly `We could not load website accounts right now. Stop and contact the membership lead and platform owner before changing website access.`
+7. Confirm assistive technology receives the whole sentence immediately as one alert.
+8. Confirm the rejected value is not inspected, logged, measured, stored, sent to analytics, or displayed.
+9. Confirm an older success or failure cannot replace the current result after the database reference changes or the page closes.
+10. Confirm a successful mocked empty list shows only zero website-account role counts and no matching website accounts.
+11. Confirm a successful made-up list uses `Website accounts`, `Website role`, and `Account created` labels while preserving the existing account-access display.
+12. Confirm the `member` website role is never described as current, paid, or annual club membership.
+13. Confirm account creation and email verification are never described as membership or dues evidence.
+14. Confirm the #116 roster view and CSV export remain unavailable and no roster file is created.
+15. Confirm the page heading and **Admin home** link remain during loading and failure. Do not follow the link.
+16. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, permissions, account records, membership records, provider configuration, Admin-screen approval, and live behavior as separate results.
+
+**Expected result:** only a current successful mocked lookup shows website-account roles. Loading and rejection show one private fail-closed state with no false zero, stale account information, or role button. Successful results describe website access and account creation only. They do not display or infer annual membership, dues, eligibility, member pricing, discounts, or roster status. This does not authorize an officer to open the screen or change a role live.
+
+The existing role-change request, raw action-error text, authorization, audit, replay protection, and account-recovery behavior remain separate unfinished work. This slice does not make the Admin website-account screen or its role actions safe. Issue #116 remains responsible for the future server-authoritative membership roster and export.
+
+**Stop conditions:** any real account, member, name, email address, payment, dues record, membership record, provider record, credential, or production data; an attempted role change; a request to infer membership from a role, account date, or email verification; a Firebase, permission, provider, account, or membership-record change; or a claim that source, tests, merge, preview, or a green workflow proves the screen or roster is live.
+
+**Success proof:** for source completion, record the exact #307 issue, reviewed pull request, merged commit, recorded old-source failures, green synthetic tests, relevant full checks, and independent privacy, identity, membership-truth, lifecycle, and officer-continuity reviews. The safe review stops at source and mocked tests because the Admin screen is not approved for officer use. Live availability requires a separate approved release and exact-revision verification after authorization, role-action safety, audit, backup, rollback, and Firebase evidence are complete. The #116 roster additionally requires its own policy, server authority, scoped capability, field approval, deployment, audit, export, and backup-officer proof. Record website publication, `runmprc.com`, Firebase deployment, permission changes, provider configuration, account or membership changes, roster/export activity, production-data actions, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend and guide revert or safe roll-forward. After any later approved publication, use the protected website release path and verify the replacement revision. Never undo by changing a website role, membership, dues record, account, permission, database record, or provider setting.
+
+**Escalation:** membership lead plus identity/platform security owner. Add the privacy owner if account details appeared. Add the treasurer if anyone inferred paid membership, dues, pricing, or discount eligibility. Use the private incident path if an access change might have completed without a current readback. Do not copy personal details into an issue, screenshot, email, message, or AI tool.
+
+No system-topology diagram changes are required because data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the website-account list display and the boundary separating website roles from the future authoritative membership roster.
+
 ## Stop conditions
 
 Stop if staging is not isolated, the owner/policy is missing, a test uses real people or money, Firebase deployment skipped, rollback is untested, or the requested action directly edits payment/member state.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,6 +7,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { resolvePath } from 'react-router-dom';
 import { useServiceLocator } from './services/ServiceLocatorContext';
@@ -19,6 +20,10 @@ import {
   listPublicEvents,
 } from './services/events/eventsService';
 import { listAllEvents } from './services/events/adminService';
+import {
+  listAllMembers,
+  setMemberRole,
+} from './services/account/adminMembersService';
 import { events as analyticsEvents, track } from './services/analytics/analytics';
 import { useAuth } from './services/hooks/useAuth';
 import {
@@ -74,6 +79,15 @@ jest.mock('./services/events/adminService', () => {
   };
 });
 
+jest.mock('./services/account/adminMembersService', () => {
+  const actual = jest.requireActual('./services/account/adminMembersService');
+  return {
+    ...actual,
+    listAllMembers: jest.fn(),
+    setMemberRole: jest.fn(),
+  };
+});
+
 jest.mock('./services/analytics/analytics', () => {
   const actual = jest.requireActual('./services/analytics/analytics');
   return { ...actual, track: jest.fn() };
@@ -107,6 +121,8 @@ beforeEach(() => {
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
   listAllEvents.mockReset();
+  listAllMembers.mockReset();
+  setMemberRole.mockReset();
   track.mockReset();
   useAuth.mockReset();
   useAuth.mockReturnValue({
@@ -216,6 +232,7 @@ const ADMIN_PRODUCT_EDITOR_LOAD_FAILURE = 'We could not load this product right 
 const ADMIN_EVENTS_LOAD_FAILURE = 'We could not load events right now. Please try again later.';
 const ADMIN_DASHBOARD_LOAD_FAILURE = 'We could not load the admin summary right now. Please try again later.';
 const ADMIN_ORDERS_LOAD_FAILURE = 'We could not load orders right now. Stop and contact the treasurer and platform owner before taking any order action.';
+const ADMIN_MEMBERS_LOAD_FAILURE = 'We could not load website accounts right now. Stop and contact the membership lead and platform owner before changing website access.';
 const firebaseApp = { name: 'synthetic-firebase-app' };
 const firestore = { name: 'synthetic-firestore' };
 
@@ -271,6 +288,11 @@ function renderAdminDashboard() {
 
 function renderAdminOrders() {
   window.history.pushState({}, '', '/admin/orders');
+  return render(<App />);
+}
+
+function renderAdminMembers() {
+  window.history.pushState({}, '', '/admin/members');
   return render(<App />);
 }
 
@@ -3169,5 +3191,490 @@ describe('Admin Orders list-load failure boundary', () => {
     expect(messageGetter).not.toHaveBeenCalled();
     expect(track).not.toHaveBeenCalled();
     expect(adminOrderAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('Admin website-account role-list load failure boundary', () => {
+  function syntheticTimestamp(value) {
+    const date = new Date(value);
+    return { toDate: () => date };
+  }
+
+  function syntheticWebsiteAccount({
+    uid = 'synthetic-account',
+    email = `${uid}@example.test`,
+    fullName = 'Synthetic Website Account',
+    role = 'member',
+    emailVerified = true,
+    createdAt = '2030-01-12T20:00:00Z',
+  } = {}) {
+    return {
+      uid,
+      email,
+      fullName,
+      role,
+      emailVerified,
+      createdAt: syntheticTimestamp(createdAt),
+    };
+  }
+
+  function expectGenericAdminMembersShell() {
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Admin home/ }))
+      .toHaveAttribute('href', '/admin');
+    expect(window.location.pathname).toBe('/admin/members');
+  }
+
+  function expectWebsiteAccountResultsToBeHidden() {
+    [
+      'Admins',
+      'Members',
+      'Pending verification',
+      'Total',
+      'Admin website access',
+      'Member website access',
+      'Pending website verification',
+      'Total website accounts',
+    ].forEach((label) => {
+      const summaryLabels = screen.queryAllByText(label)
+        .filter((element) => element.tagName === 'DIV');
+      expect(summaryLabels).toHaveLength(0);
+    });
+    expect(screen.queryByPlaceholderText('Search by name or email...'))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByText('No members matched')).not.toBeInTheDocument();
+    expect(screen.queryByText('No website accounts matched')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('button', {
+      name: /^(admin|member|unverified)$/i,
+    })).toHaveLength(0);
+  }
+
+  function getWebsiteAccountSummaryTile(label) {
+    return screen.getByText(label).parentElement;
+  }
+
+  function spyOnBrowserConsole() {
+    return ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  }
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-current-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: true,
+    });
+    listAllMembers.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    expect(setMemberRole).not.toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
+
+  test('hides every account-derived result and role control while the current read is pending', async () => {
+    listAllMembers.mockReturnValueOnce(new Promise(() => {}));
+
+    const view = renderAdminMembers();
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    expectGenericAdminMembersShell();
+    expectWebsiteAccountResultsToBeHidden();
+    expect(listAllMembers).toHaveBeenCalledWith(firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  test('replaces an ordinary rejection with one fixed accessible stop result', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    listAllMembers.mockRejectedValueOnce(Object.assign(
+      new Error('admin-members-private-canary officer-private@example.test'),
+      {
+        code: 'firestore/admin-members-private-canary',
+        endpoint: 'https://provider.example.test/?token=admin-members-secret-canary',
+      },
+    ));
+
+    renderAdminMembers();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_MEMBERS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expectWebsiteAccountResultsToBeHidden();
+    expectGenericAdminMembersShell();
+    expect(document.body).not.toHaveTextContent(
+      /admin-members-private-canary|officer-private@example\.test|provider\.example|admin-members-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /admin-members-private-canary|officer-private@example\.test|provider\.example|admin-members-secret-canary/i,
+    );
+    expect(track).not.toHaveBeenCalled();
+    expect(listAllMembers).toHaveBeenCalledWith(firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not inspect, log, measure, or render a hostile rejected value', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    const messageGetter = jest.fn(() => 'admin-members-message-getter-canary');
+    listAllMembers.mockRejectedValueOnce(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    );
+
+    renderAdminMembers();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_MEMBERS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('admin-members-message-getter-canary');
+    expect(JSON.stringify(track.mock.calls))
+      .not.toContain('admin-members-message-getter-canary');
+    expectWebsiteAccountResultsToBeHidden();
+    expectGenericAdminMembersShell();
+    expect(track).not.toHaveBeenCalled();
+    expect(listAllMembers).toHaveBeenCalledWith(firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('shows a genuine successful empty result with website-account labels', async () => {
+    renderAdminMembers();
+
+    expect(await screen.findByText('No website accounts matched')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Website accounts' }))
+      .toBeInTheDocument();
+    expect(getWebsiteAccountSummaryTile('Admin website access'))
+      .toHaveTextContent(/Admin website access\s*0/);
+    expect(getWebsiteAccountSummaryTile('Member website access'))
+      .toHaveTextContent(/Member website access\s*0/);
+    expect(getWebsiteAccountSummaryTile('Pending website verification'))
+      .toHaveTextContent(/Pending website verification\s*0/);
+    expect(getWebsiteAccountSummaryTile('Total website accounts'))
+      .toHaveTextContent(/Total website accounts\s*0/);
+    expect(screen.getByPlaceholderText('Search by name or email...')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('all');
+    expect(screen.getByRole('option', { name: 'All website roles' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Website role' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Account created' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Change website role to...' }))
+      .toBeInTheDocument();
+    expect(screen.queryByText('Members')).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Role' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Joined' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(
+      /paid annual membership|dues paid|member pricing|discount access/i,
+    );
+    expect(listAllMembers).toHaveBeenCalledWith(firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves populated projection, filtering, dates, and the self-demotion guard under truthful labels', async () => {
+    const currentAdmin = syntheticWebsiteAccount({
+      uid: 'synthetic-current-admin',
+      fullName: 'Synthetic Current Admin',
+      role: 'admin',
+      createdAt: '2030-01-12T20:00:00Z',
+    });
+    const otherAdmin = syntheticWebsiteAccount({
+      uid: 'synthetic-other-admin',
+      fullName: 'Synthetic Other Admin',
+      role: 'admin',
+      createdAt: '2030-02-13T20:00:00Z',
+    });
+    const memberAccount = syntheticWebsiteAccount({
+      uid: 'synthetic-member-account',
+      fullName: 'Synthetic Member Account',
+      role: 'member',
+      createdAt: '2030-03-14T20:00:00Z',
+    });
+    const unverifiedAccount = syntheticWebsiteAccount({
+      uid: 'synthetic-unverified-account',
+      fullName: 'Synthetic Unverified Account',
+      role: 'unverified',
+      emailVerified: false,
+      createdAt: '2030-04-15T20:00:00Z',
+    });
+    listAllMembers.mockResolvedValueOnce([
+      currentAdmin,
+      otherAdmin,
+      memberAccount,
+      unverifiedAccount,
+    ]);
+
+    renderAdminMembers();
+
+    expect(await screen.findByText('Synthetic Current Admin')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Website accounts' }))
+      .toBeInTheDocument();
+    expect(getWebsiteAccountSummaryTile('Admin website access'))
+      .toHaveTextContent(/Admin website access\s*2/);
+    expect(getWebsiteAccountSummaryTile('Member website access'))
+      .toHaveTextContent(/Member website access\s*1/);
+    expect(getWebsiteAccountSummaryTile('Pending website verification'))
+      .toHaveTextContent(/Pending website verification\s*1/);
+    expect(getWebsiteAccountSummaryTile('Total website accounts'))
+      .toHaveTextContent(/Total website accounts\s*4/);
+    expect(screen.getByRole('columnheader', { name: 'Website role' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Account created' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Change website role to...' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('synthetic-member-account@example.test')).toBeInTheDocument();
+    expect(screen.getByText(
+      memberAccount.createdAt.toDate().toLocaleDateString('en-US', {
+        year: 'numeric', month: 'short', day: 'numeric',
+      }),
+    )).toBeInTheDocument();
+    expect(screen.getAllByText('yes').length).toBeGreaterThan(0);
+    expect(screen.getByText('no')).toBeInTheDocument();
+
+    const selfRow = screen.getByText('synthetic-current-admin@example.test').closest('tr');
+    expect(selfRow).not.toBeNull();
+    expect(within(selfRow).getByRole('button', { name: 'member' })).toBeDisabled();
+    expect(within(selfRow).getByRole('button', { name: 'unverified' })).toBeDisabled();
+
+    const search = screen.getByPlaceholderText('Search by name or email...');
+    fireEvent.change(search, { target: { value: 'member account' } });
+    expect(screen.getByText('Synthetic Member Account')).toBeInTheDocument();
+    expect(screen.queryByText('Synthetic Current Admin')).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: '' } });
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'unverified' } });
+    expect(screen.getByText('Synthetic Unverified Account')).toBeInTheDocument();
+    expect(screen.queryByText('Synthetic Member Account')).not.toBeInTheDocument();
+    expect(screen.queryByText('Members')).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Role' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Joined' })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(
+      /paid annual membership|dues paid|member pricing|discount access/i,
+    );
+    expect(listAllMembers).toHaveBeenCalledWith(firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not reload when only the services wrapper changes around the same Firestore object', async () => {
+    listAllMembers.mockResolvedValueOnce([syntheticWebsiteAccount()]);
+    const view = renderAdminMembers();
+    expect(await screen.findByText('Synthetic Website Account')).toBeInTheDocument();
+
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByText('Synthetic Website Account')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores an older success after a newer read for the same Firestore object', async () => {
+    let resolveOlderLookup;
+    listAllMembers.mockReturnValueOnce(new Promise((resolve) => {
+      resolveOlderLookup = resolve;
+    }));
+    const view = renderAdminMembers();
+    await waitFor(() => expect(listAllMembers).toHaveBeenCalledTimes(1));
+
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: false,
+    });
+    view.rerender(<App />);
+
+    listAllMembers.mockResolvedValueOnce([
+      syntheticWebsiteAccount({ fullName: 'Current Same-Database Account' }),
+    ]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    expect(await screen.findByText('Current Same-Database Account')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveOlderLookup([
+        syntheticWebsiteAccount({ fullName: 'Obsolete Same-Database Account' }),
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Current Same-Database Account')).toBeInTheDocument();
+    expect(screen.queryByText('Obsolete Same-Database Account')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(2);
+  });
+
+  test('hides earlier account truth during a current Firestore read, then shows current empty truth', async () => {
+    listAllMembers.mockResolvedValueOnce([syntheticWebsiteAccount()]);
+    const view = renderAdminMembers();
+    expect(await screen.findByText('Synthetic Website Account')).toBeInTheDocument();
+
+    let resolveCurrentLookup;
+    listAllMembers.mockReturnValueOnce(new Promise((resolve) => {
+      resolveCurrentLookup = resolve;
+    }));
+    const currentFirestore = { name: 'synthetic-members-firestore-current' };
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    await waitFor(() => expect(listAllMembers).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectWebsiteAccountResultsToBeHidden();
+    expect(screen.queryByText('Synthetic Website Account')).not.toBeInTheDocument();
+
+    await act(async () => { resolveCurrentLookup([]); });
+    expect(await screen.findByText('No website accounts matched')).toBeInTheDocument();
+    expect(getWebsiteAccountSummaryTile('Total website accounts'))
+      .toHaveTextContent(/Total website accounts\s*0/);
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('hides earlier account truth when the current Firestore read rejects', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    listAllMembers.mockResolvedValueOnce([syntheticWebsiteAccount()]);
+    const view = renderAdminMembers();
+    expect(await screen.findByText('Synthetic Website Account')).toBeInTheDocument();
+
+    const currentFirestore = { name: 'synthetic-members-firestore-failure' };
+    listAllMembers.mockRejectedValueOnce(
+      new Error('admin-members-transition-private-canary'),
+    );
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ADMIN_MEMBERS_LOAD_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expectWebsiteAccountResultsToBeHidden();
+    expect(screen.queryByText('Synthetic Website Account')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('admin-members-transition-private-canary');
+    expect(track).not.toHaveBeenCalled();
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, currentFirestore);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('ignores an older success after a newer Firestore read resolves empty', async () => {
+    let resolveOlderLookup;
+    listAllMembers.mockReturnValueOnce(new Promise((resolve) => {
+      resolveOlderLookup = resolve;
+    }));
+    const view = renderAdminMembers();
+    await waitFor(() => expect(listAllMembers).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-members-firestore-newer-empty' };
+    listAllMembers.mockResolvedValueOnce([]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect(await screen.findByText('No website accounts matched')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveOlderLookup([syntheticWebsiteAccount({ fullName: 'Obsolete Website Account' })]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('No website accounts matched')).toBeInTheDocument();
+    expect(screen.queryByText('Obsolete Website Account')).not.toBeInTheDocument();
+    expect(getWebsiteAccountSummaryTile('Total website accounts'))
+      .toHaveTextContent(/Total website accounts\s*0/);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('ignores an older hostile rejection after a newer Firestore read succeeds', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    let rejectOlderLookup;
+    listAllMembers.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectOlderLookup = reject;
+    }));
+    const view = renderAdminMembers();
+    await waitFor(() => expect(listAllMembers).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-members-firestore-newer-success' };
+    listAllMembers.mockResolvedValueOnce([
+      syntheticWebsiteAccount({ fullName: 'Current Website Account' }),
+    ]);
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore: currentFirestore } },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    expect(await screen.findByText('Current Website Account')).toBeInTheDocument();
+
+    const messageGetter = jest.fn(() => 'obsolete-admin-members-private-canary');
+    await act(async () => {
+      rejectOlderLookup(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Current Website Account')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-admin-members-private-canary');
+    expect(track).not.toHaveBeenCalled();
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, currentFirestore);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('ignores a hostile rejection after the Admin website-account page unmounts', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    let rejectLookup;
+    listAllMembers.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectLookup = reject;
+    }));
+    const view = renderAdminMembers();
+    await waitFor(() => expect(listAllMembers).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const messageGetter = jest.fn(() => 'unmounted-admin-members-private-canary');
+    await act(async () => {
+      rejectLookup(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });

--- a/src/pages/admin/members/AdminMembers.tsx
+++ b/src/pages/admin/members/AdminMembers.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../../components/SEO';
 import AdminGuard from '../AdminGuard';
@@ -11,6 +13,14 @@ import {
 } from '../../../services/account/adminMembersService';
 
 const ROLES: MemberRole[] = ['unverified', 'member', 'admin'];
+
+interface MembersLoadOutcome {
+  firestore: unknown;
+  status: 'loading' | 'resolved' | 'unavailable';
+  members: Member[];
+}
+
+const LOAD_FAILURE = 'We could not load website accounts right now. Stop and contact the membership lead and platform owner before changing website access.';
 
 function RolePill({ role }: { role: string }) {
   const style: Record<string, string> = {
@@ -34,30 +44,48 @@ function fmtDate(ts: any) {
 function Inner() {
   const { services, isReady } = useServiceLocator();
   const { user } = useAuth();
-  const [members, setMembers] = useState<Member[]>([]);
-  const [loading, setLoading] = useState(true);
+  const firestore = isReady && services
+    ? services.firebaseResources.firestore
+    : null;
+  const currentFirestoreRef = useRef(firestore);
+  currentFirestoreRef.current = firestore;
+  const requestSequence = useRef(0);
+  const [loadOutcome, setLoadOutcome] = useState<MembersLoadOutcome | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [updating, setUpdating] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
   const [roleFilter, setRoleFilter] = useState<'all' | MemberRole>('all');
 
-  async function reload() {
-    if (!services) return;
-    setLoading(true);
+  const currentOutcome = loadOutcome?.firestore === firestore ? loadOutcome : null;
+  const currentStatus = currentOutcome?.status ?? 'loading';
+  const members = currentOutcome?.status === 'resolved' ? currentOutcome.members : [];
+
+  const reload = useCallback(async () => {
+    if (!firestore || currentFirestoreRef.current !== firestore) return;
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
+    const outcomeKey = { firestore };
+    setLoadOutcome({ ...outcomeKey, status: 'loading', members: [] });
     try {
-      const all = await listAllMembers(services.firebaseResources.firestore);
-      setMembers(all);
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
+      const all = await listAllMembers(firestore);
+      if (requestId !== requestSequence.current
+        || currentFirestoreRef.current !== firestore) return;
+      setLoadOutcome({ ...outcomeKey, status: 'resolved', members: all });
+    } catch {
+      if (requestId !== requestSequence.current
+        || currentFirestoreRef.current !== firestore) return;
+      setLoadOutcome({ ...outcomeKey, status: 'unavailable', members: [] });
     }
-  }
+  }, [firestore]);
 
   useEffect(() => {
-    if (!isReady || !services) return;
+    if (!firestore) {
+      requestSequence.current += 1;
+      return () => undefined;
+    }
     reload();
-  }, [services, isReady]);
+    return () => { requestSequence.current += 1; };
+  }, [firestore, reload]);
 
   async function changeRole(email: string, role: MemberRole) {
     if (!services) return;
@@ -92,71 +120,87 @@ function Inner() {
 
   return (
     <>
-      <SEO title="Admin — Members" noindex />
+      <SEO title="Admin — Website accounts" noindex />
       <div className="container mx-auto p-4 max-w-5xl">
         <Link to="/admin" className="text-sm text-blue-600 hover:underline">
           ← Admin home
         </Link>
-        <h1 className="text-2xl font-bold mt-2">Members</h1>
+        <h1 className="text-2xl font-bold mt-2">Website accounts</h1>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 my-4">
-          <div className="border rounded p-3 bg-purple-50">
-            <div className="text-xs text-gray-600">Admins</div>
-            <div className="text-xl font-bold">{counts.admin}</div>
-          </div>
-          <div className="border rounded p-3 bg-green-50">
-            <div className="text-xs text-gray-600">Members</div>
-            <div className="text-xl font-bold">{counts.member}</div>
-          </div>
-          <div className="border rounded p-3 bg-gray-50">
-            <div className="text-xs text-gray-600">Pending verification</div>
-            <div className="text-xl font-bold">{counts.unverified}</div>
-          </div>
-          <div className="border rounded p-3 bg-blue-50">
-            <div className="text-xs text-gray-600">Total</div>
-            <div className="text-xl font-bold">{counts.total}</div>
-          </div>
-        </div>
+        {currentStatus === 'resolved' && (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 my-4">
+              <div className="border rounded p-3 bg-purple-50">
+                <div className="text-xs text-gray-600">Admin website access</div>
+                <div className="text-xl font-bold">{counts.admin}</div>
+              </div>
+              <div className="border rounded p-3 bg-green-50">
+                <div className="text-xs text-gray-600">Member website access</div>
+                <div className="text-xl font-bold">{counts.member}</div>
+              </div>
+              <div className="border rounded p-3 bg-gray-50">
+                <div className="text-xs text-gray-600">Pending website verification</div>
+                <div className="text-xl font-bold">{counts.unverified}</div>
+              </div>
+              <div className="border rounded p-3 bg-blue-50">
+                <div className="text-xs text-gray-600">Total website accounts</div>
+                <div className="text-xl font-bold">{counts.total}</div>
+              </div>
+            </div>
 
-        <div className="flex gap-2 flex-wrap items-center my-3">
-          <input
-            className="border rounded px-3 py-2 flex-1 min-w-[200px]"
-            placeholder="Search by name or email..."
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-          />
-          <select
-            className="border rounded px-3 py-2"
-            value={roleFilter}
-            onChange={(e) => setRoleFilter(e.target.value as any)}
+            <div className="flex gap-2 flex-wrap items-center my-3">
+              <input
+                className="border rounded px-3 py-2 flex-1 min-w-[200px]"
+                placeholder="Search by name or email..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+              <select
+                className="border rounded px-3 py-2"
+                value={roleFilter}
+                onChange={(e) => setRoleFilter(e.target.value as any)}
+              >
+                <option value="all">All website roles</option>
+                <option value="unverified">Unverified</option>
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+          </>
+        )}
+
+        {currentStatus === 'loading' && <p>Loading...</p>}
+        {currentStatus === 'unavailable' && (
+          <p
+            className="text-red-500 text-sm"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
           >
-            <option value="all">All roles</option>
-            <option value="unverified">Unverified</option>
-            <option value="member">Member</option>
-            <option value="admin">Admin</option>
-          </select>
-        </div>
+            {LOAD_FAILURE}
+          </p>
+        )}
+        {currentStatus === 'resolved' && error && (
+          <p className="text-red-500 text-sm">{error}</p>
+        )}
 
-        {loading && <p>Loading...</p>}
-        {error && <p className="text-red-500 text-sm">{error}</p>}
-
-        {!loading && (
+        {currentStatus === 'resolved' && (
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr className="border-b bg-gray-50">
                 <th className="text-left p-2">Name</th>
                 <th className="text-left p-2">Email</th>
-                <th className="text-left p-2">Role</th>
-                <th className="text-left p-2">Joined</th>
+                <th className="text-left p-2">Website role</th>
+                <th className="text-left p-2">Account created</th>
                 <th className="text-left p-2">Email verified</th>
-                <th className="text-right p-2">Change role to...</th>
+                <th className="text-right p-2">Change website role to...</th>
               </tr>
             </thead>
             <tbody>
               {filtered.length === 0 && (
                 <tr>
                   <td colSpan={6} className="p-4 text-center text-gray-500">
-                    No members matched
+                    No website accounts matched
                   </td>
                 </tr>
               )}


### PR DESCRIPTION
Closes #307.

## Outcome

The Admin website-account role list now shows account-derived content only after the latest read for the current Firestore object succeeds.

Pending and rejected reads hide role counts, filters, names, email addresses, dates, verification state, empty claims, rows, and role-change controls. Rejections are discarded unbound and replaced by one fixed accessible stop result. Obsolete and unmounted results are inert.

Successful states now say `Website accounts`, `Website role`, and `Account created`; they do not imply that a website role, account date, or verified email proves paid annual membership.

## Exact scope

- `src/pages/admin/members/AdminMembers.tsx`
- `src/App.test.jsx` — additive named #307 support/tests only
- `docs/officers/EVENTS_SHOP_MEMBERS.md` — named #307 procedure/diagram only

Exact base: `08f3d444fb7b826dce533cb02f38ead037445fb4`

Exact reviewed source head: `20453834242b1858c7e8a446ff92913ea9fb2b5e`

Exact diff SHA-256: `f7ffb9bc796612529e0f44cf4d19afa777d473f3182c45a4301a6f68b1b95738`

All five #306 SUPPLY-001D3 paths remain byte-identical to the exact base.

## Security and compatibility

- Current-Firestore identity, a monotonic request sequence, and effect cleanup guard every list settlement.
- Every new read immediately replaces prior list truth with a hidden loading state.
- `catch {}` never binds, inspects, logs, measures, stores, analyzes, or renders rejected values.
- One assertive, atomic fixed alert replaces current list failures.
- A new services wrapper around the same Firestore object does not reload.
- A newer read wins even when both attempts use the identical Firestore object.
- Successful empty/populated projection, filtering, date formatting, role choices, self-demotion guard, and role buttons remain.
- Role-action request/payload/busy/error behavior is excluded and unchanged. The raw role-action error remains an open residual.
- No schema, service, Function, Rule, permission, provider, role, record, migration, or production-data change.

## Verification

- Old-source red proof: 11/11 focused cases failed for intended defects.
- Same-Firestore red addendum: 1/1 latest-attempt case failed old source.
- Node 20.20.2 focused #307: 12/12.
- Node 20.20.2 full frontend: 12 suites / 361 tests.
- TypeScript: passed.
- Frontend lint: unchanged 106 files / 123 reviewed errors / 7 reviewed warnings.
- Node 20 diagnostic production build: passed.
- Node 20 Functions lint: passed.
- Node 20 Functions: 29 suites / 2,034 passed; 2 suites / 64 skipped by design.
- Firestore Rules on `demo-rules-test`: 4 suites / 378.
- Commerce command-journal emulator on `demo-pay002b2-test`: 1 suite / 63.
- SPA safety: 11/11.
- CI/release/Firebase-readback/artifact/root-dependency safety: 46/46.
- Officer-guide relative links: 9 checked / 0 missing.
- `git diff --check`: passed.
- Three independent exact-hash reviews approved.

## Residual risks / exclusions

- The current client service still reads broad member documents and filters them in the browser. #110 and #116 own minimization and the future server-authoritative roster projection/export.
- #115 and shared AUTH/ADMIN work own audited membership association, scoped privileged role changes, MFA/recent-auth, replay protection, durable audit, and safe action errors.
- #81/#114 own annual membership and dues truth.
- Success-path hostile member-field/date validation is not changed.
- The complete Admin screen and future #116 roster remain **NOT AVAILABLE YET**.

Officer impact: A future published version would stop showing false, stale, or technical website-account results, tell an officer to stop before changing access, and stop labeling website-account roles as paid membership.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` contains a new plain-language procedure, state diagram, text alternative, stop rules, proof, undo, and escalation path. It explicitly separates this screen from #116's annual-membership roster and CSV.

Deployment evidence: Source changed and local tests passed. No protected release ran for this branch. The website and exact `runmprc.com` revision are not published or verified. Firebase, permissions, account or membership records, provider configuration, role actions, production data, migrations, and live behavior were not changed or tested. Hosted PR CI and preview, merge state, exact-main CI, deployment records, and any later live publication will be recorded separately.
