### PR TITLE
ABUSE-001B1 — Fail closed on corrupt rate-limit bucket state

### DIFF
--- a/functions/rateLimit.js
+++ b/functions/rateLimit.js
@@ -1,6 +1,21 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+const { types: { isProxy } } = require('node:util');
 const { Timestamp } = require('firebase-admin/firestore');
+
+const INVALID_BUCKET_VALUE = Symbol('invalid-bucket-value');
+const MIN_TIMESTAMP_SECONDS = -62_135_596_800;
+const MAX_TIMESTAMP_SECONDS = 253_402_300_799;
+const MAX_TIMESTAMP_NANOSECONDS = 999_999_999;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwn = Object.hasOwn;
+const objectPrototype = Object.prototype;
+const reflectOwnKeys = Reflect.ownKeys;
+const numberIsFinite = Number.isFinite;
+const numberIsSafeInteger = Number.isSafeInteger;
+const mathFloor = Math.floor;
+const timestampPrototype = Timestamp.prototype;
 
 /**
  * Simple fixed-window rate limiter backed by Firestore.
@@ -23,6 +38,142 @@ function extractIp(context) {
   return req.ip || 'unknown';
 }
 
+function corruptBucketError() {
+  return new functions.https.HttpsError(
+    'internal',
+    'Rate limit state is unavailable.',
+  );
+}
+
+function limitExceededError() {
+  return new functions.https.HttpsError(
+    'resource-exhausted',
+    'Too many requests. Please wait a few minutes and try again.',
+  );
+}
+
+function isProxyValue(value) {
+  try {
+    return isProxy(value);
+  } catch (_error) {
+    return true;
+  }
+}
+
+function isPlainBucketRecord(value) {
+  if (value === null || typeof value !== 'object' || isProxyValue(value)) return false;
+  try {
+    return objectGetPrototypeOf(value) === objectPrototype;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function selectedOwnDataValue(record, key) {
+  let descriptor;
+  try {
+    descriptor = objectGetOwnPropertyDescriptor(record, key);
+  } catch (_error) {
+    return INVALID_BUCKET_VALUE;
+  }
+  if (!descriptor
+    || descriptor.enumerable !== true
+    || !objectHasOwn(descriptor, 'value')) {
+    return INVALID_BUCKET_VALUE;
+  }
+  return descriptor.value;
+}
+
+function projectTimestamp(value) {
+  if (value === null || typeof value !== 'object' || isProxyValue(value)) {
+    return null;
+  }
+
+  let prototype;
+  let keys;
+  try {
+    prototype = objectGetPrototypeOf(value);
+    keys = reflectOwnKeys(value);
+  } catch (_error) {
+    return null;
+  }
+  if (prototype !== timestampPrototype || keys.length !== 2) return null;
+  const hasExactKeys = (keys[0] === '_seconds' && keys[1] === '_nanoseconds')
+    || (keys[0] === '_nanoseconds' && keys[1] === '_seconds');
+  if (!hasExactKeys) return null;
+
+  const seconds = selectedOwnDataValue(value, '_seconds');
+  const nanoseconds = selectedOwnDataValue(value, '_nanoseconds');
+  if (!numberIsSafeInteger(seconds)
+    || seconds < MIN_TIMESTAMP_SECONDS
+    || seconds > MAX_TIMESTAMP_SECONDS
+    || !numberIsSafeInteger(nanoseconds)
+    || nanoseconds < 0
+    || nanoseconds > MAX_TIMESTAMP_NANOSECONDS) {
+    return null;
+  }
+
+  const milliseconds = seconds * 1_000 + mathFloor(nanoseconds / 1_000_000);
+  if (!numberIsFinite(milliseconds)) return null;
+
+  try {
+    return {
+      milliseconds,
+      nanoseconds,
+      seconds,
+      value: new Timestamp(seconds, nanoseconds),
+    };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function timestampPartsFromMillis(milliseconds) {
+  const seconds = mathFloor(milliseconds / 1_000);
+  return {
+    nanoseconds: (milliseconds - seconds * 1_000) * 1_000_000,
+    seconds,
+  };
+}
+
+function compareTimestampParts(left, right) {
+  if (left.seconds !== right.seconds) return left.seconds < right.seconds ? -1 : 1;
+  if (left.nanoseconds === right.nanoseconds) return 0;
+  return left.nanoseconds < right.nanoseconds ? -1 : 1;
+}
+
+function projectStoredBucket(data, {
+  scope, key, windowMs, now,
+}) {
+  if (!isPlainBucketRecord(data)) throw corruptBucketError();
+
+  const storedScope = selectedOwnDataValue(data, 'scope');
+  if (storedScope !== scope) throw corruptBucketError();
+
+  const storedKey = selectedOwnDataValue(data, 'key');
+  if (storedKey !== key) throw corruptBucketError();
+
+  const storedWindowMs = selectedOwnDataValue(data, 'windowMs');
+  if (storedWindowMs !== windowMs) throw corruptBucketError();
+
+  const count = selectedOwnDataValue(data, 'count');
+  if (!numberIsSafeInteger(count) || count <= 0) throw corruptBucketError();
+
+  const windowStart = projectTimestamp(selectedOwnDataValue(data, 'windowStart'));
+  if (!windowStart
+    || compareTimestampParts(windowStart, timestampPartsFromMillis(now)) > 0) {
+    throw corruptBucketError();
+  }
+
+  return {
+    count,
+    windowStart: windowStart.value,
+    windowStartMs: windowStart.milliseconds,
+    windowStartNanoseconds: windowStart.nanoseconds,
+    windowStartSeconds: windowStart.seconds,
+  };
+}
+
 /**
  * Throws HttpsError('resource-exhausted') if the caller exceeded the limit.
  * @param {{ scope: string, key: string, limit: number, windowMs: number }} opts
@@ -34,22 +185,32 @@ async function checkRateLimit({
   const db = admin.firestore();
   const docId = `${scope}__${sanitizeKey(key)}`;
   const ref = db.collection('ratelimits').doc(docId);
-  const now = Date.now();
 
   await db.runTransaction(async (tx) => {
     const snap = await tx.get(ref);
-    const data = snap.exists ? snap.data() : null;
-    const windowStartMs = data?.windowStart?.toMillis?.() ?? 0;
-    const inWindow = data && (now - windowStartMs) < windowMs;
-    const nextCount = inWindow ? (data.count || 0) + 1 : 1;
-    const nextWindowStart = inWindow ? data.windowStart : Timestamp.fromMillis(now);
+    const attemptNow = Date.now();
+    const stored = snap.exists
+      ? projectStoredBucket(snap.data(), {
+        scope,
+        key,
+        windowMs,
+        now: attemptNow,
+      })
+      : null;
+    const inWindow = stored
+      ? compareTimestampParts({
+        nanoseconds: stored.windowStartNanoseconds,
+        seconds: stored.windowStartSeconds,
+      }, timestampPartsFromMillis(attemptNow - windowMs)) > 0
+      : false;
 
-    if (inWindow && nextCount > limit) {
-      throw new functions.https.HttpsError(
-        'resource-exhausted',
-        'Too many requests. Please wait a few minutes and try again.',
-      );
-    }
+    if (inWindow && stored.count >= limit) throw limitExceededError();
+
+    const nextCount = inWindow ? stored.count + 1 : 1;
+    const nextWindowStart = inWindow
+      ? stored.windowStart
+      : Timestamp.fromMillis(attemptNow);
+    const nextWindowStartMs = inWindow ? stored.windowStartMs : attemptNow;
 
     tx.set(ref, {
       scope,
@@ -58,9 +219,9 @@ async function checkRateLimit({
       windowStart: nextWindowStart,
       windowMs,
       expiresAt: Timestamp.fromMillis(
-        (inWindow ? windowStartMs : now) + windowMs + 60_000,
+        nextWindowStartMs + windowMs + 60_000,
       ),
-      updatedAt: Timestamp.fromMillis(now),
+      updatedAt: Timestamp.fromMillis(attemptNow),
     });
   });
 }

--- a/functions/rateLimit.test.js
+++ b/functions/rateLimit.test.js
@@ -1,0 +1,517 @@
+const { Timestamp } = jest.requireActual('firebase-admin/firestore');
+
+jest.mock('firebase-functions', () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      constructor(code, message, details) {
+        super(message);
+        this.code = code;
+        this.details = details;
+      }
+    },
+  },
+}));
+
+jest.mock('firebase-admin', () => ({
+  firestore: jest.fn(),
+}));
+
+const admin = require('firebase-admin');
+const { checkRateLimit } = require('./rateLimit');
+
+const NOW = 1_800_000_000_000;
+const WINDOW_MS = 60_000;
+const SCOPE = 'checkout_email';
+const KEY = 'runner@example.test';
+const LIMIT = 3;
+const CORRUPT_ERROR = {
+  code: 'internal',
+  message: 'Rate limit state is unavailable.',
+  details: undefined,
+};
+const LIMIT_ERROR = {
+  code: 'resource-exhausted',
+  message: 'Too many requests. Please wait a few minutes and try again.',
+  details: undefined,
+};
+
+function bucket(overrides = {}) {
+  return {
+    scope: SCOPE,
+    key: KEY,
+    count: 1,
+    windowStart: Timestamp.fromMillis(NOW - 1_000),
+    windowMs: WINDOW_MS,
+    expiresAt: Timestamp.fromMillis(NOW + WINDOW_MS),
+    updatedAt: Timestamp.fromMillis(NOW - 1_000),
+    ...overrides,
+  };
+}
+
+function snapshot(value, exists = true) {
+  return {
+    exists,
+    data: jest.fn(() => value),
+  };
+}
+
+function makeHarness(value, { exists = true, transaction } = {}) {
+  const ref = { id: 'rate-limit-ref' };
+  const doc = jest.fn(() => ref);
+  const collection = jest.fn(() => ({ doc }));
+  const tx = {
+    get: jest.fn(async () => snapshot(value, exists)),
+    set: jest.fn(),
+  };
+  const runTransaction = jest.fn(transaction || (async (handler) => handler(tx)));
+  const db = { collection, runTransaction };
+  admin.firestore.mockReturnValue(db);
+  return {
+    collection, db, doc, ref, runTransaction, tx,
+  };
+}
+
+async function invoke(overrides = {}) {
+  return checkRateLimit({
+    scope: SCOPE,
+    key: KEY,
+    limit: LIMIT,
+    windowMs: WINDOW_MS,
+    ...overrides,
+  });
+}
+
+describe('checkRateLimit stored bucket integrity', () => {
+  let consoleSpies;
+
+  beforeEach(() => {
+    admin.firestore.mockReset();
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    consoleSpies = ['debug', 'error', 'info', 'log', 'warn'].map((method) => (
+      jest.spyOn(console, method).mockImplementation(() => undefined)
+    ));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function expectCorrupt(value, options) {
+    const harness = makeHarness(value, options);
+    await expect(invoke()).rejects.toMatchObject(CORRUPT_ERROR);
+    expect(harness.tx.set).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    return harness;
+  }
+
+  test('RED: a current negative count denies instead of becoming less negative', async () => {
+    await expectCorrupt(bucket({
+      count: -1_000,
+      windowStart: Timestamp.fromMillis(NOW),
+    }));
+  });
+
+  test('creates a first bucket without reading missing snapshot data', async () => {
+    const missing = snapshot(undefined, false);
+    const harness = makeHarness(undefined, {
+      exists: false,
+      transaction: async (handler) => {
+        harness.tx.get.mockResolvedValueOnce(missing);
+        return handler(harness.tx);
+      },
+    });
+
+    await expect(invoke()).resolves.toBeUndefined();
+
+    expect(missing.data).not.toHaveBeenCalled();
+    expect(harness.collection).toHaveBeenCalledWith('ratelimits');
+    expect(harness.doc).toHaveBeenCalledWith(`${SCOPE}__${KEY}`);
+    expect(harness.tx.set).toHaveBeenCalledTimes(1);
+    expect(harness.tx.set).toHaveBeenCalledWith(harness.ref, {
+      scope: SCOPE,
+      key: KEY,
+      count: 1,
+      windowStart: Timestamp.fromMillis(NOW),
+      windowMs: WINDOW_MS,
+      expiresAt: Timestamp.fromMillis(NOW + WINDOW_MS + 60_000),
+      updatedAt: Timestamp.fromMillis(NOW),
+    });
+  });
+
+  test('increments a current valid frozen bucket without inspecting extra fields', async () => {
+    const extraGetter = jest.fn(() => {
+      throw new Error('extra-field-canary');
+    });
+    const start = Object.freeze(Timestamp.fromMillis(NOW - 10_000));
+    const value = bucket({ count: 2, windowStart: start });
+    Object.defineProperty(value, 'futureField', {
+      enumerable: true,
+      get: extraGetter,
+    });
+    Object.freeze(value);
+    const harness = makeHarness(value);
+
+    await expect(invoke()).resolves.toBeUndefined();
+
+    expect(extraGetter).not.toHaveBeenCalled();
+    expect(harness.tx.set).toHaveBeenCalledWith(harness.ref, expect.objectContaining({
+      count: 3,
+      windowStart: Timestamp.fromMillis(NOW - 10_000),
+      expiresAt: Timestamp.fromMillis(NOW + 110_000),
+      updatedAt: Timestamp.fromMillis(NOW),
+    }));
+  });
+
+  test('allows the request that reaches the configured limit', async () => {
+    const harness = makeHarness(bucket({ count: LIMIT - 1 }));
+    await expect(invoke()).resolves.toBeUndefined();
+    expect(harness.tx.set).toHaveBeenCalledWith(
+      harness.ref,
+      expect.objectContaining({ count: LIMIT }),
+    );
+  });
+
+  test.each([LIMIT, LIMIT + 1, Number.MAX_SAFE_INTEGER])(
+    'denies the next request normally when a valid current count is %p',
+    async (count) => {
+      const harness = makeHarness(bucket({ count }));
+      await expect(invoke()).rejects.toMatchObject(LIMIT_ERROR);
+      expect(harness.tx.set).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    ['exact boundary', NOW - WINDOW_MS],
+    ['older boundary', NOW - WINDOW_MS - 1],
+  ])('resets a valid expired bucket at the %s', async (_label, startMs) => {
+    const harness = makeHarness(bucket({
+      count: Number.MAX_SAFE_INTEGER,
+      windowStart: Timestamp.fromMillis(startMs),
+    }));
+    await expect(invoke()).resolves.toBeUndefined();
+    expect(harness.tx.set).toHaveBeenCalledWith(harness.ref, {
+      scope: SCOPE,
+      key: KEY,
+      count: 1,
+      windowStart: Timestamp.fromMillis(NOW),
+      windowMs: WINDOW_MS,
+      expiresAt: Timestamp.fromMillis(NOW + WINDOW_MS + 60_000),
+      updatedAt: Timestamp.fromMillis(NOW),
+    });
+  });
+
+  test.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['string', '1'],
+    ['bigint', 1n],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+    ['object', {}],
+  ])('denies a %s stored count', async (_label, count) => {
+    await expectCorrupt(bucket({ count }));
+  });
+
+  test('denies an invalid count even when the window is expired', async () => {
+    await expectCorrupt(bucket({
+      count: -1,
+      windowStart: Timestamp.fromMillis(NOW - WINDOW_MS),
+    }));
+  });
+
+  test.each([
+    ['scope', { scope: 'other_scope' }],
+    ['raw key', { key: 'runner+collision@example.test' }],
+    ['window length', { windowMs: WINDOW_MS + 1 }],
+  ])('denies a stored %s mismatch', async (_label, overrides) => {
+    await expectCorrupt(bucket(overrides));
+  });
+
+  test('stops after the first mismatch without inspecting later fields', async () => {
+    const value = bucket({ scope: 'other_scope' });
+    const laterGetters = ['key', 'windowMs', 'count', 'windowStart'].map((field) => {
+      const getter = jest.fn(() => {
+        throw new Error(`${field}-after-scope-canary`);
+      });
+      Object.defineProperty(value, field, {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+      return getter;
+    });
+    await expectCorrupt(value);
+    laterGetters.forEach((getter) => expect(getter).not.toHaveBeenCalled());
+  });
+
+  test('denies raw keys that collide after document-id sanitization', async () => {
+    const harness = makeHarness(bucket({ key: 'runner/name' }));
+    await expect(invoke({ key: 'runner?name' })).rejects.toMatchObject(CORRUPT_ERROR);
+    expect(harness.doc).toHaveBeenCalledWith(`${SCOPE}__runner_name`);
+    expect(harness.tx.set).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['null', null],
+    ['array', []],
+    ['date', new Date(NOW)],
+    ['null-prototype record', Object.create(null)],
+    ['class instance', new (class Bucket {})()],
+  ])('denies a %s present root', async (_label, value) => {
+    await expectCorrupt(value);
+  });
+
+  test('denies a root Proxy without executing a trap', async () => {
+    const trap = jest.fn(() => {
+      throw new Error('root-proxy-canary');
+    });
+    const value = new Proxy(bucket(), {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    await expectCorrupt(value);
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test('denies a revoked root Proxy without touching it', async () => {
+    const revocable = Proxy.revocable(bucket(), {});
+    revocable.revoke();
+    await expectCorrupt(revocable.proxy);
+  });
+
+  test.each(['scope', 'key', 'windowMs', 'count', 'windowStart'])(
+    'denies a missing required own %s field',
+    async (field) => {
+      const value = bucket();
+      delete value[field];
+      await expectCorrupt(value);
+    },
+  );
+
+  test('denies an inherited window start without invoking it', async () => {
+    const inheritedGetter = jest.fn(() => {
+      throw new Error('inherited-window-start-canary');
+    });
+    const priorDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'windowStart');
+    Object.defineProperty(Object.prototype, 'windowStart', {
+      configurable: true,
+      enumerable: true,
+      get: inheritedGetter,
+    });
+    try {
+      const value = bucket();
+      delete value.windowStart;
+      await expectCorrupt(value);
+      expect(inheritedGetter).not.toHaveBeenCalled();
+    } finally {
+      if (priorDescriptor) {
+        Object.defineProperty(Object.prototype, 'windowStart', priorDescriptor);
+      } else {
+        delete Object.prototype.windowStart;
+      }
+    }
+  });
+
+  test.each(['scope', 'key', 'windowMs', 'count', 'windowStart'])(
+    'denies a non-enumerable required %s field',
+    async (field) => {
+      const value = bucket();
+      Object.defineProperty(value, field, {
+        configurable: true,
+        enumerable: false,
+        value: value[field],
+        writable: true,
+      });
+      await expectCorrupt(value);
+    },
+  );
+
+  test.each(['scope', 'key', 'windowMs', 'count', 'windowStart'])(
+    'denies an accessor-backed required %s without invoking it',
+    async (field) => {
+      const value = bucket();
+      const getter = jest.fn(() => {
+        throw new Error(`${field}-getter-canary`);
+      });
+      Object.defineProperty(value, field, {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+      await expectCorrupt(value);
+      expect(getter).not.toHaveBeenCalled();
+    },
+  );
+
+  test('denies a coercible count without invoking its coercion hook', async () => {
+    const valueOf = jest.fn(() => 1);
+    await expectCorrupt(bucket({ count: { valueOf } }));
+    expect(valueOf).not.toHaveBeenCalled();
+  });
+
+  test('denies a Proxy count without executing a trap', async () => {
+    const trap = jest.fn(() => {
+      throw new Error('count-proxy-canary');
+    });
+    const count = new Proxy({}, {
+      get: trap,
+      getPrototypeOf: trap,
+    });
+    await expectCorrupt(bucket({ count }));
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['future', Timestamp.fromMillis(NOW + 1)],
+    ['Date', new Date(NOW)],
+    ['null', null],
+    ['number', NOW],
+  ])('denies a %s window start', async (_label, windowStart) => {
+    await expectCorrupt(bucket({ windowStart }));
+  });
+
+  test('denies a window start one nanosecond after the current clock', async () => {
+    const now = Timestamp.fromMillis(NOW);
+    await expectCorrupt(bucket({
+      windowStart: new Timestamp(now.seconds, now.nanoseconds + 1),
+    }));
+  });
+
+  test('denies a pseudo Timestamp without invoking its throwing method', async () => {
+    const toMillis = jest.fn(() => {
+      throw new Error('toMillis-canary');
+    });
+    await expectCorrupt(bucket({ windowStart: { toMillis } }));
+    expect(toMillis).not.toHaveBeenCalled();
+  });
+
+  test('denies a Timestamp Proxy without executing a trap', async () => {
+    const trap = jest.fn(() => {
+      throw new Error('timestamp-proxy-canary');
+    });
+    const windowStart = new Proxy(Timestamp.fromMillis(NOW), {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    await expectCorrupt(bucket({ windowStart }));
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test('denies a revoked Timestamp Proxy without touching it', async () => {
+    const revocable = Proxy.revocable(Timestamp.fromMillis(NOW), {});
+    revocable.revoke();
+    await expectCorrupt(bucket({ windowStart: revocable.proxy }));
+  });
+
+  test.each([
+    ['extra key', (value) => { value.extra = true; }],
+    ['extra symbol', (value) => { value[Symbol('extra')] = true; }],
+    ['missing seconds', (value) => { delete value._seconds; }],
+    ['fractional seconds', (value) => { value._seconds = 1.5; }],
+    ['NaN seconds', (value) => { value._seconds = Number.NaN; }],
+    ['infinite seconds', (value) => { value._seconds = Number.POSITIVE_INFINITY; }],
+    ['negative infinite seconds', (value) => { value._seconds = Number.NEGATIVE_INFINITY; }],
+    ['seconds below SDK range', (value) => { value._seconds = -62_135_596_801; }],
+    ['seconds above SDK range', (value) => { value._seconds = 253_402_300_800; }],
+    ['NaN nanoseconds', (value) => { value._nanoseconds = Number.NaN; }],
+    ['infinite nanoseconds', (value) => { value._nanoseconds = Number.POSITIVE_INFINITY; }],
+    ['negative infinite nanoseconds', (value) => {
+      value._nanoseconds = Number.NEGATIVE_INFINITY;
+    }],
+    ['negative nanoseconds', (value) => { value._nanoseconds = -1; }],
+    ['excess nanoseconds', (value) => { value._nanoseconds = 1_000_000_000; }],
+  ])('denies a Timestamp with %s', async (_label, mutate) => {
+    const value = Timestamp.fromMillis(NOW);
+    mutate(value);
+    await expectCorrupt(bucket({ windowStart: value }));
+  });
+
+  test.each(['_seconds', '_nanoseconds'])(
+    'denies an accessor-backed Timestamp %s field without invoking it',
+    async (field) => {
+      const value = Timestamp.fromMillis(NOW);
+      const getter = jest.fn(() => {
+        throw new Error(`${field}-getter-canary`);
+      });
+      Object.defineProperty(value, field, {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+      await expectCorrupt(bucket({ windowStart: value }));
+      expect(getter).not.toHaveBeenCalled();
+    },
+  );
+
+  test('denies a Timestamp subclass', async () => {
+    class SubTimestamp extends Timestamp {}
+    await expectCorrupt(bucket({ windowStart: new SubTimestamp(1_800_000_000, 0) }));
+  });
+
+  test('keeps a window current one nanosecond after the expiry boundary', async () => {
+    const boundary = Timestamp.fromMillis(NOW - WINDOW_MS);
+    const windowStart = new Timestamp(boundary.seconds, boundary.nanoseconds + 1);
+    const harness = makeHarness(bucket({ count: 1, windowStart }));
+
+    await expect(invoke()).resolves.toBeUndefined();
+
+    expect(harness.tx.set).toHaveBeenCalledWith(harness.ref, expect.objectContaining({
+      count: 2,
+      windowStart,
+    }));
+  });
+
+  test('captures a fresh clock inside each Firestore transaction retry', async () => {
+    let clock = NOW;
+    const firstTx = {
+      get: jest.fn(async () => {
+        clock = NOW;
+        return snapshot(undefined, false);
+      }),
+      set: jest.fn(),
+    };
+    const concurrentStart = NOW + 1;
+    const secondTx = {
+      get: jest.fn(async () => {
+        clock = NOW + 2;
+        return snapshot(bucket({
+          count: 1,
+          windowStart: Timestamp.fromMillis(concurrentStart),
+        }));
+      }),
+      set: jest.fn(),
+    };
+    Date.now
+      .mockReset()
+      .mockImplementation(() => clock);
+    const harness = makeHarness(null, {
+      transaction: async (handler) => {
+        await handler(firstTx); // Firestore discards this attempt before retrying.
+        return handler(secondTx);
+      },
+    });
+
+    await expect(invoke()).resolves.toBeUndefined();
+
+    expect(Date.now).toHaveBeenCalledTimes(2);
+    expect(secondTx.set).toHaveBeenCalledWith(harness.ref, expect.objectContaining({
+      count: 2,
+      windowStart: Timestamp.fromMillis(concurrentStart),
+      updatedAt: Timestamp.fromMillis(NOW + 2),
+    }));
+  });
+
+  test.each([
+    ['missing scope', { scope: '' }],
+    ['missing key', { key: '' }],
+  ])('preserves the no-op for %s', async (_label, overrides) => {
+    await expect(invoke(overrides)).resolves.toBeUndefined();
+    expect(admin.firestore).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Outcome

A present malformed or mismatched server-only rate-limit bucket now fails closed before that transaction writes. A negative count can no longer reduce itself and buy extra requests.

Closes #317.

## Invariant and behavior

- Select only own enumerable data fields from a non-Proxy plain bucket.
- Require exact stored scope, raw key, and window length.
- Require a positive safe-integer count for every present bucket.
- Validate the exact supported Firebase Admin Timestamp scalar representation without calling stored methods, accessors, coercion hooks, or Proxy traps.
- Compare current/future/expiry boundaries at nanosecond precision.
- Capture the clock after each transaction read so a Firestore retry cannot treat a concurrent valid reset as future.
- Corrupt state returns fixed `internal / Rate limit state is unavailable.` with no write or log.
- A valid bucket at/over its limit keeps the existing fixed `resource-exhausted` result.
- Missing, below-limit, exact-limit, expired-reset, document identity, and exports remain compatible.

## RED / green evidence

Untouched source on exact base `c9aefc02743a1da3e728420e0b801e824bddd15f`:

- focused suite: 68 total; 10 compatibility passes and 58 intended safety failures;
- reproduced current genuine Timestamp + `count: -1000` resolving and writing instead of denying.

Exact reviewed head `ab13211399a7218900ea184f71f9b8e1fbe16c6b`:

- focused Node 20: 78/78;
- full Functions: 30 suites, 2,201 active passed, 64 skipped;
- Functions ESLint: passed;
- frontend Jest: 12 suites, 401/401;
- frontend lint ledger: 106 files / 123 reviewed errors / 7 warnings;
- repository/SPA/workflow/release/readback/artifact/dependency safety: 57/57;
- Firestore Rules emulator: 378/378;
- commerce-journal Firestore emulator: 63/63;
- diagnostic production build: passed;
- diff check: passed;
- three independent exact-commit reviews: passed.

Exact two-file diff SHA-256: `c1ebe20492b7af78b126cc8e300ea12e7d61f64c591bc546fafdef8a525e0d6f`.

## Residuals

This does not redesign raw rate keys, HMAC, trusted IP extraction, rotation, multi-scope policy, TTL/provider configuration, alerts, App Check, callers, or migration. Existing checkout callers run two rate checks in `Promise.all`; a valid sibling bucket may still commit when the corrupt sibling rejects. No later sequential business/provider work runs after the awaited rejection.

## Officer impact

Officer impact: None — this is an internal server-state safety boundary and adds no officer task or screen.

Officer documentation: None — no public content, navigation, admin duty, collected data, permission, deployment path, external account, payment/refund procedure, incident workflow, backup, or recovery procedure changes.

Deployment evidence: Source/test/commit evidence only. Website publication: not performed. `runmprc.com` verification: not performed. Firebase deployment: not performed. Outside provider configuration: not performed. Production data/migration: not performed. Live behavior: not verified.