### PR TITLE
DATA-001A1: isolate registration confirmation polling

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -861,6 +861,61 @@ Officer review steps after the source merge:
 
 No system-topology diagram changes for this source slice; the state-flow diagram above records the page's failure-display change, while data movement, permissions, account ownership, and deployment topology remain unchanged.
 
+## Registration confirmation route privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep one runner's confirmation details tied to the private confirmation address that requested them. Moving to another address must hide the earlier name, email, registration ID, and confirmation result at once.
+
+**Approver:** events lead plus platform/security and privacy owners. Add the treasurer before any future live review involving a paid registration.
+
+**Prerequisites:** issue [#319](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/319) must be merged for source review. Use only made-up events, runners, registration IDs, tokens, and mocked services. Do not open, copy, request, or test a real confirmation address. A later claim that the source was published requires a protected website publication and an exact `runmprc.com` revision check. Neither check authorizes a real confirmation-address test or proves the private route works in production.
+
+```mermaid
+flowchart TD
+    A["Made-up confirmation address A"] --> B["Mocked lookup A starts"]
+    B --> C["Move to made-up address B"]
+    C --> D["Hide A details at once; clear A timer"]
+    D --> E{"Which mocked result finishes?"}
+    E -- "Old A" --> F["Ignore it; no display or analytics-wrapper call"]
+    E -- "Current B is pending" --> G["Keep waiting; show no runner details"]
+    E -- "Current B is paid or complimentary (comp)" --> H["Show B confirmation; call disabled wrapper once"]
+```
+
+Text alternative: changing from made-up confirmation address A to B immediately hides A; only B may keep waiting or show its own current paid or complimentary (`comp`) result and call the disabled analytics wrapper once, while every late A result and timer does nothing and no analytics event is sent or stored.
+
+Officer source-review steps:
+
+1. Keep the confirmation-route repair marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #319 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm every test uses made-up runner details, made-up route values, and a mocked lookup.
+4. Confirm no test opens a real confirmation address or contacts a real Firebase, Stripe, analytics, or other outside service.
+5. Confirm moving from made-up address A to unresolved address B hides A's name, email, registration ID, and confirmed heading before B finishes.
+6. Confirm a pending B result keeps the waiting page and shows no runner details.
+7. Confirm a late A success cannot replace B or call the analytics wrapper.
+8. Confirm a late A failure is ignored without reading its private or hostile detail.
+9. Confirm A's old timer is cleared and cannot start another lookup after the move to B.
+10. Confirm a readiness, Firebase app, service, route, or page-close change makes the older work inactive and clears its timer.
+11. Confirm returning from A to B and back to A starts fresh work instead of reusing the first A result.
+12. Confirm only the current paid or comp result calls the disabled, provider-free analytics wrapper once.
+13. Confirm the wrapper sends and stores no analytics event.
+14. Confirm current pending, timeout, denied, error, not-ready, and missing-address results keep their existing plain displays.
+15. Record source, tests, merge, website publication, `runmprc.com` revision, Firebase deployment, provider configuration, production-data action, and live behavior as separate results.
+
+**Expected result:** only the current made-up address may decide what the page shows. An address or service change hides the preceding result immediately. Current pending work shows no runner details. Old results, failures, and timers do nothing. The current paid or comp result keeps the existing first name, email, and registration ID. Its source calls the disabled, provider-free analytics wrapper once. No analytics event is sent or stored. This changes reviewed source and tests only.
+
+**Stop conditions:** any real runner, event, registration, email, token, payment, confirmation address, screenshot, provider value, or production record; a request to paste a private address or detail into GitHub, email, chat, or an AI tool; a production Firebase, Stripe, analytics, or other provider action; an attempt to force a live failure or timing race; an old result appearing under a new address; a claim that the disabled wrapper sent or stored an event; or a claim that source, tests, merge, preview, or a green workflow proves the change is live.
+
+**Success proof:** for source completion, record the exact #319 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic route and timer tests, relevant full checks, and independent privacy, lifecycle, and officer reviews. The synthetic analytics mock may prove one current wrapper call, while source review proves the wrapper is disabled and provider-free; neither result is an analytics event or provider receipt. For release evidence, separately record the protected website publication and exact `runmprc.com` revision without opening a real confirmation address. Record Firebase deployment, Stripe or other provider configuration, analytics transmission or storage, real registration access, production-data action, and live route behavior as **not performed** unless a later approved non-production plan proves them safely.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision without opening a real confirmation address. Do not change or delete a registration, payment, account, database record, token, permission, Firebase setting, analytics setting, or Stripe setting.
+
+**Escalation:** events lead plus platform/security and privacy owners. Add the treasurer if a paid registration may be affected. Use the private incident path if one runner's details may have appeared under another address. Do not copy the address, token, runner details, screenshot, or provider value into an issue, message, email, or AI tool.
+
+This source slice does **not** make the current confirmation address safe. DATA-001A still owns replacing the private value in the address, storing that value safely, making it expire, preventing reuse, removing it from browser history, keeping it out of monitoring and links to other sites, verifying the Stripe Session or signed-in account, and reducing the server response. Firebase request checking (App Check) for this lookup remains deferred. The server may still return more runner data than the page needs. The current page still shows a current runner's first name, email, and registration ID. The current analytics wrapper remains disabled and provider-free; its source call sends and stores nothing. Data purpose, access, retention, deletion, and any future analytics approval remain open. Payment authority, Stripe behavior, confirmation email, Firebase and provider settings, deployment, production data, and live behavior are unchanged.
+
+No system-topology diagram changes for this source slice; the state-flow diagram above records the page's current-route display and timer boundary, while data movement, permissions, account ownership, and deployment topology remain unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -18,6 +18,7 @@ import {
   listEventRegistrations,
   listMemberEvents,
   listPublicEvents,
+  lookupRegistration,
 } from './services/events/eventsService';
 import {
   adminRegistrationAction,
@@ -74,6 +75,7 @@ jest.mock('./services/events/eventsService', () => {
     listEventRegistrations: jest.fn(),
     listMemberEvents: jest.fn(),
     listPublicEvents: jest.fn(),
+    lookupRegistration: jest.fn(),
   };
 });
 
@@ -130,6 +132,7 @@ beforeEach(() => {
   listEventRegistrations.mockReset();
   listMemberEvents.mockReset();
   listPublicEvents.mockReset();
+  lookupRegistration.mockReset();
   adminRegistrationAction.mockReset();
   createEvent.mockReset();
   listAllEvents.mockReset();
@@ -280,6 +283,39 @@ function renderPublicEventDetail() {
 function renderPublicEventRegister() {
   window.history.pushState({}, '', '/events/synthetic-event/register');
   return render(<App />);
+}
+
+function registrationSuccessPath({
+  event = 'synthetic-confirmation-event',
+  reg = 'synthetic-confirmation-registration',
+  token = 'synthetic-confirmation-capability',
+} = {}) {
+  const params = new URLSearchParams();
+  if (event !== null) params.set('event', event);
+  if (reg !== null) params.set('reg', reg);
+  if (token !== null) params.set('token', token);
+  return `/register/success?${params.toString()}`;
+}
+
+function renderRegistrationSuccess(query) {
+  window.history.pushState({}, '', registrationSuccessPath(query));
+  return render(<App />);
+}
+
+let registrationHistoryKey = 0;
+
+function navigateRegistrationSuccess(query) {
+  registrationHistoryKey += 1;
+  const currentIndex = typeof window.history.state?.idx === 'number'
+    ? window.history.state.idx
+    : 0;
+  const nextState = {
+    usr: null,
+    key: `synthetic-registration-${registrationHistoryKey}`,
+    idx: currentIndex + 1,
+  };
+  window.history.pushState(nextState, '', registrationSuccessPath(query));
+  fireEvent(window, new PopStateEvent('popstate', { state: nextState }));
 }
 
 function renderAdminProducts() {
@@ -1234,6 +1270,840 @@ describe('public Event-registration submit failure boundary', () => {
     expect(screen.getByRole('button', { name: 'Continue to payment — $15.00' })).toBeEnabled();
     expect(window.location.pathname).toBe('/events/synthetic-event/register');
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});
+
+describe('DATA-001A1 registration confirmation attempt isolation', () => {
+  const routeA = {
+    event: 'synthetic-route-a-event',
+    reg: 'synthetic-route-a-registration',
+    token: 'synthetic-route-a-capability',
+  };
+  const routeB = {
+    event: 'synthetic-route-b-event',
+    reg: 'synthetic-route-b-registration',
+    token: 'synthetic-route-b-capability',
+  };
+
+  function readyLocator(app = firebaseApp) {
+    return {
+      services: { firebaseResources: { app } },
+      isReady: true,
+    };
+  }
+
+  function registrationResult({
+    status = 'pending',
+    id = 'synthetic-confirmation-registration',
+    eventId = 'synthetic-confirmation-event',
+    firstName = 'Synthetic',
+    email = 'synthetic-runner@example.test',
+    amountCents = 1500,
+  } = {}) {
+    return {
+      id,
+      status,
+      priceTier: 'nonMember',
+      amountCents,
+      currency: 'usd',
+      runner: {
+        firstName,
+        lastName: 'Runner',
+        email,
+        shirtSize: null,
+      },
+      eventId,
+      paidAt: null,
+      createdAt: null,
+    };
+  }
+
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  async function flushRegistrationWork() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  async function resolveDeferred(job, value) {
+    await act(async () => {
+      job.resolve(value);
+      await job.promise;
+      await Promise.resolve();
+    });
+  }
+
+  async function rejectDeferred(job, reason) {
+    await act(async () => {
+      job.reject(reason);
+      await job.promise.catch(() => undefined);
+      await Promise.resolve();
+    });
+  }
+
+  async function advancePollIntervals(remaining) {
+    if (remaining === 0) return;
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    await advancePollIntervals(remaining - 1);
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2030-01-12T16:00:00Z'));
+    useServiceLocator.mockReturnValue(readyLocator());
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('hides route A immediately and keeps a pending route B unconfirmed', async () => {
+    const routeBLookup = deferred();
+    lookupRegistration
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeA.reg,
+        eventId: routeA.event,
+        firstName: 'Prior',
+        email: 'prior-runner@example.test',
+      }))
+      .mockReturnValueOnce(routeBLookup.promise);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('prior-runner@example.test');
+
+    navigateRegistrationSuccess(routeB);
+    const immediateRouteText = document.body.textContent;
+
+    await resolveDeferred(routeBLookup, registrationResult({
+      status: 'pending',
+      id: routeB.reg,
+      eventId: routeB.event,
+      firstName: 'Pending',
+      email: 'pending-runner@example.test',
+    }));
+    const pendingRouteText = document.body.textContent;
+
+    expect(immediateRouteText).toContain('Processing your registration...');
+    expect(immediateRouteText).not.toMatch(
+      /Prior|prior-runner@example\.test|synthetic-route-a-registration|You're in!/,
+    );
+    expect(pendingRouteText).toContain('Processing your registration...');
+    expect(pendingRouteText).not.toMatch(
+      /Pending|pending-runner@example\.test|synthetic-route-b-registration|You're in!/,
+    );
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    'route',
+    'services identity',
+    'Firebase app identity',
+    'readiness',
+  ])('hides confirmed details in the first %s-change commit', async (changedBoundary) => {
+    const initialLocator = readyLocator();
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    const profiledApp = () => (
+      <React.Profiler id="registration-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>
+    );
+    useServiceLocator.mockReturnValue(initialLocator);
+    lookupRegistration.mockResolvedValueOnce(registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Prior',
+      email: 'prior-commit@example.test',
+    }));
+    window.history.pushState({}, '', registrationSuccessPath(routeA));
+    const view = render(profiledApp());
+    await flushRegistrationWork();
+    expect(document.body).toHaveTextContent('prior-commit@example.test');
+
+    commits.length = 0;
+    lookupRegistration.mockReturnValueOnce(new Promise(() => {}));
+    if (changedBoundary === 'route') {
+      navigateRegistrationSuccess(routeB);
+    } else {
+      let nextLocator = readyLocator();
+      if (changedBoundary === 'Firebase app identity') {
+        initialLocator.services.firebaseResources.app = {
+          name: 'synthetic-confirmation-app-b',
+        };
+        nextLocator = initialLocator;
+      } else if (changedBoundary === 'readiness') {
+        nextLocator = { services: initialLocator.services, isReady: false };
+      }
+      useServiceLocator.mockReturnValue(nextLocator);
+      view.rerender(profiledApp());
+    }
+
+    expect(commits).not.toHaveLength(0);
+    expect(commits[0]).toContain('Processing your registration...');
+    expect(commits[0]).not.toMatch(
+      /Prior|prior-commit@example\.test|synthetic-route-a-registration|You're in!/,
+    );
+  });
+
+  test('keeps one attempt when the router republishes the same history entry', async () => {
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    lookupRegistration.mockResolvedValueOnce(registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Current',
+      email: 'same-history-entry@example.test',
+    }));
+    window.history.pushState({}, '', registrationSuccessPath(routeA));
+    render(
+      <React.Profiler id="registration-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>,
+    );
+    await flushRegistrationWork();
+    expect(document.body).toHaveTextContent('same-history-entry@example.test');
+
+    commits.length = 0;
+    const sameEntryState = {
+      ...window.history.state,
+      usr: { syntheticObjectRefresh: true },
+    };
+    window.history.replaceState(
+      sameEntryState,
+      '',
+      registrationSuccessPath(routeA),
+    );
+    fireEvent(window, new PopStateEvent('popstate', { state: sameEntryState }));
+    await flushRegistrationWork();
+
+    expect(commits).not.toHaveLength(0);
+    expect(document.body).toHaveTextContent('same-history-entry@example.test');
+    expect(lookupRegistration).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ['event', { ...routeA, event: routeB.event }],
+    ['registration', { ...routeA, reg: routeB.reg }],
+    ['token', { ...routeA, token: routeB.token }],
+  ])('hides confirmed details when one history key changes only %s', async (
+    _changedField,
+    changedRoute,
+  ) => {
+    const routeBLookup = deferred();
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    lookupRegistration
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeA.reg,
+        eventId: routeA.event,
+        firstName: 'Prior',
+        email: 'prior-same-key@example.test',
+      }))
+      .mockReturnValueOnce(routeBLookup.promise);
+    window.history.pushState({}, '', registrationSuccessPath(routeA));
+    render(
+      <React.Profiler id="registration-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>,
+    );
+    await flushRegistrationWork();
+    expect(document.body).toHaveTextContent('prior-same-key@example.test');
+    expect(track).toHaveBeenCalledTimes(1);
+
+    commits.length = 0;
+    const preservedHistoryState = { ...window.history.state };
+    const preservedHistoryKey = window.history.state?.key;
+    window.history.replaceState(
+      preservedHistoryState,
+      '',
+      registrationSuccessPath(changedRoute),
+    );
+    fireEvent(window, new PopStateEvent('popstate', { state: preservedHistoryState }));
+
+    expect(window.history.state?.key).toBe(preservedHistoryKey);
+    expect(commits).not.toHaveLength(0);
+    expect(commits[0]).toContain('Processing your registration...');
+    expect(commits[0]).not.toMatch(
+      /Prior|prior-same-key@example\.test|synthetic-route-a-registration|You're in!/,
+    );
+    expect(lookupRegistration).toHaveBeenNthCalledWith(2, firebaseApp, {
+      eventId: changedRoute.event,
+      registrationId: changedRoute.reg,
+      token: changedRoute.token,
+    });
+
+    await resolveDeferred(routeBLookup, registrationResult({
+      status: 'pending',
+      id: changedRoute.reg,
+      eventId: changedRoute.event,
+      firstName: 'Pending',
+      email: 'pending-same-key@example.test',
+    }));
+
+    expect(screen.getByRole('heading', { name: 'Processing your registration...' }))
+      .toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(
+      /prior-same-key@example\.test|pending-same-key@example\.test|You're in!/,
+    );
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores a stale route success before inspecting it or emitting analytics', async () => {
+    const staleLookup = deferred();
+    lookupRegistration
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeB.reg,
+        eventId: routeB.event,
+        firstName: 'Current',
+        email: 'current-runner@example.test',
+      }));
+
+    renderRegistrationSuccess(routeA);
+    navigateRegistrationSuccess(routeB);
+    await flushRegistrationWork();
+
+    const statusGetter = jest.fn(() => 'paid');
+    const staleResult = registrationResult({
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Obsolete',
+      email: 'obsolete-runner@example.test',
+    });
+    delete staleResult.status;
+    Object.defineProperty(staleResult, 'status', {
+      configurable: true,
+      enumerable: true,
+      get: statusGetter,
+    });
+    await resolveDeferred(staleLookup, staleResult);
+
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('current-runner@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-runner@example.test');
+    expect(statusGetter).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith(analyticsEvents.registrationConfirmed, {
+      eventId: routeB.event,
+      status: 'paid',
+      amount_cents: 1500,
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores a stale hostile rejection before reading code or details', async () => {
+    const staleLookup = deferred();
+    lookupRegistration
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(registrationResult({
+        status: 'comp',
+        id: routeB.reg,
+        eventId: routeB.event,
+        firstName: 'Current',
+        email: 'current-comp@example.test',
+        amountCents: 0,
+      }));
+
+    renderRegistrationSuccess(routeA);
+    navigateRegistrationSuccess(routeB);
+    await flushRegistrationWork();
+
+    const codeGetter = jest.fn(() => '');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const hostileRejection = {};
+    Object.defineProperties(hostileRejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    await rejectDeferred(staleLookup, hostileRejection);
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('current-comp@example.test');
+    expect(screen.queryByText("Can't confirm this registration")).not.toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears a route-owned poll timer and prevents another old lookup', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const routeBLookup = deferred();
+    const neverSettles = new Promise(() => {});
+    lookupRegistration
+      .mockResolvedValueOnce(registrationResult({
+        status: 'pending',
+        id: routeA.reg,
+        eventId: routeA.event,
+      }))
+      .mockReturnValueOnce(routeBLookup.promise)
+      .mockReturnValue(neverSettles);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+    const pollTimerIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 2000);
+    expect(pollTimerIndex).toBeGreaterThanOrEqual(0);
+    const pollTimerId = setTimeoutSpy.mock.results[pollTimerIndex].value;
+
+    navigateRegistrationSuccess(routeB);
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    const routeACalls = lookupRegistration.mock.calls.filter(([, args]) => (
+      args.registrationId === routeA.reg
+    ));
+    expect(routeACalls).toHaveLength(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(pollTimerId);
+    expect(lookupRegistration).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    'services identity',
+    'Firebase app identity',
+  ])('invalidates an in-flight lookup when %s changes', async (changedIdentity) => {
+    const appA = { name: 'synthetic-confirmation-app-a' };
+    const appB = changedIdentity === 'Firebase app identity'
+      ? { name: 'synthetic-confirmation-app-b' }
+      : appA;
+    const initialLocator = readyLocator(appA);
+    const staleLookup = deferred();
+    lookupRegistration
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeA.reg,
+        eventId: routeA.event,
+        firstName: 'Current',
+        email: 'current-service@example.test',
+      }));
+    useServiceLocator.mockReturnValue(initialLocator);
+
+    const view = renderRegistrationSuccess(routeA);
+    if (changedIdentity === 'Firebase app identity') {
+      initialLocator.services.firebaseResources.app = appB;
+      useServiceLocator.mockReturnValue(initialLocator);
+    } else {
+      useServiceLocator.mockReturnValue(readyLocator(appB));
+    }
+    view.rerender(<App />);
+    await flushRegistrationWork();
+    await resolveDeferred(staleLookup, registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Obsolete',
+      email: 'obsolete-service@example.test',
+    }));
+
+    expect(lookupRegistration).toHaveBeenNthCalledWith(1, appA, {
+      eventId: routeA.event,
+      registrationId: routeA.reg,
+      token: routeA.token,
+    });
+    expect(lookupRegistration).toHaveBeenNthCalledWith(2, appB, {
+      eventId: routeA.event,
+      registrationId: routeA.reg,
+      token: routeA.token,
+    });
+    expect(document.body).toHaveTextContent('current-service@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-service@example.test');
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('invalidates an in-flight lookup when readiness is lost', async () => {
+    const staleLookup = deferred();
+    lookupRegistration.mockReturnValueOnce(staleLookup.promise);
+    const view = renderRegistrationSuccess(routeA);
+
+    useServiceLocator.mockReturnValue({ services: null, isReady: false });
+    view.rerender(<App />);
+    await resolveDeferred(staleLookup, registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Obsolete',
+      email: 'obsolete-readiness@example.test',
+    }));
+
+    expect(screen.getByRole('heading', { name: 'Processing your registration...' }))
+      .toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-readiness@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('treats A to B to A as three generations', async () => {
+    const firstRouteALookup = deferred();
+    const routeBLookup = deferred();
+    lookupRegistration
+      .mockReturnValueOnce(firstRouteALookup.promise)
+      .mockReturnValueOnce(routeBLookup.promise)
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeA.reg,
+        eventId: routeA.event,
+        firstName: 'Current',
+        email: 'current-returned-route@example.test',
+      }));
+
+    renderRegistrationSuccess(routeA);
+    navigateRegistrationSuccess(routeB);
+    navigateRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+    await resolveDeferred(firstRouteALookup, registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Obsolete',
+      email: 'obsolete-first-route@example.test',
+    }));
+
+    expect(document.body).toHaveTextContent('current-returned-route@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-first-route@example.test');
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the second StrictMode effect current and ignores the first effect', async () => {
+    const firstEffectLookup = deferred();
+    const secondEffectLookup = deferred();
+    lookupRegistration
+      .mockReturnValueOnce(firstEffectLookup.promise)
+      .mockReturnValueOnce(secondEffectLookup.promise);
+    window.history.pushState({}, '', registrationSuccessPath(routeA));
+
+    render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    );
+    expect(lookupRegistration).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(secondEffectLookup, registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Current',
+      email: 'current-strict-mode@example.test',
+    }));
+    const statusGetter = jest.fn(() => 'paid');
+    const firstEffectResult = registrationResult({
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Obsolete',
+      email: 'obsolete-strict-mode@example.test',
+    });
+    delete firstEffectResult.status;
+    Object.defineProperty(firstEffectResult, 'status', {
+      configurable: true,
+      enumerable: true,
+      get: statusGetter,
+    });
+    await resolveDeferred(firstEffectLookup, firstEffectResult);
+
+    expect(statusGetter).not.toHaveBeenCalled();
+    expect(document.body).toHaveTextContent('current-strict-mode@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-strict-mode@example.test');
+    expect(track).toHaveBeenCalledWith(analyticsEvents.registrationConfirmed, {
+      eventId: routeA.event,
+      status: 'paid',
+      amount_cents: 1500,
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not emit analytics when a lookup resolves after unmount', async () => {
+    const staleLookup = deferred();
+    lookupRegistration.mockReturnValueOnce(staleLookup.promise);
+    const view = renderRegistrationSuccess(routeA);
+
+    view.unmount();
+    await resolveDeferred(staleLookup, registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Unmounted',
+      email: 'unmounted-runner@example.test',
+    }));
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('does not inspect a rejection that arrives after unmount', async () => {
+    const staleLookup = deferred();
+    lookupRegistration.mockReturnValueOnce(staleLookup.promise);
+    const view = renderRegistrationSuccess(routeA);
+    const codeGetter = jest.fn(() => '');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const hostileRejection = {};
+    Object.defineProperties(hostileRejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+
+    view.unmount();
+    await rejectDeferred(staleLookup, hostileRejection);
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['paid', 1500],
+    ['comp', 0],
+  ])('preserves a current %s confirmation and bounded analytics', async (status, amountCents) => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    lookupRegistration.mockResolvedValueOnce(registrationResult({
+      status,
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Confirmed',
+      email: 'confirmed-runner@example.test',
+      amountCents,
+    }));
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('Confirmed');
+    expect(document.body).toHaveTextContent('confirmed-runner@example.test');
+    expect(document.body).toHaveTextContent(routeA.reg);
+    expect(track).toHaveBeenCalledWith(analyticsEvents.registrationConfirmed, {
+      eventId: routeA.event,
+      status,
+      amount_cents: amountCents,
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(track.mock.calls)).not.toContain(routeA.token);
+    expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 2000)).toBe(false);
+  });
+
+  test('preserves current pending polling before a paid confirmation', async () => {
+    lookupRegistration
+      .mockResolvedValueOnce(registrationResult({
+        status: 'pending',
+        id: routeA.reg,
+        eventId: routeA.event,
+      }))
+      .mockResolvedValueOnce(registrationResult({
+        status: 'paid',
+        id: routeA.reg,
+        eventId: routeA.event,
+        firstName: 'Polled',
+        email: 'polled-runner@example.test',
+      }));
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+    expect(screen.getByRole('heading', { name: 'Processing your registration...' }))
+      .toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+
+    await advancePollIntervals(1);
+
+    expect(screen.getByRole('heading', { name: "You're in!" })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('polled-runner@example.test');
+    expect(lookupRegistration).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves the current pending timeout outcome', async () => {
+    lookupRegistration.mockResolvedValue(registrationResult({
+      status: 'pending',
+      id: routeA.reg,
+      eventId: routeA.event,
+    }));
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+    await advancePollIntervals(15);
+
+    expect(screen.getByRole('heading', { name: 'Processing your registration...' }))
+      .toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+
+    await advancePollIntervals(1);
+
+    expect(screen.getByRole('heading', { name: 'Still processing...' })).toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['top-level', { code: 'permission-denied' }],
+    ['nested', { details: { code: 'permission-denied' } }],
+    ['nested after an empty direct code', { code: '', details: { code: 'permission-denied' } }],
+  ])('preserves the current %s permission-denied outcome', async (_shape, rejection) => {
+    lookupRegistration.mockRejectedValueOnce(rejection);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(screen.getByRole('heading', { name: "Can't confirm this registration" }))
+      .toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('preserves a truthy malformed direct code ahead of nested permission denial', async () => {
+    lookupRegistration.mockRejectedValueOnce({
+      code: {},
+      details: { code: 'permission-denied' },
+    });
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this registration")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('classifies current accessor error fields without invoking them', async () => {
+    const codeGetter = jest.fn(() => 'permission-denied');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const rejection = {};
+    Object.defineProperties(rejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    lookupRegistration.mockRejectedValueOnce(rejection);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this registration")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('classifies inherited error fields without invoking them', async () => {
+    const codeGetter = jest.fn(() => 'permission-denied');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const prototype = {};
+    Object.defineProperties(prototype, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    const rejection = Object.create(prototype);
+    lookupRegistration.mockRejectedValueOnce(rejection);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this registration")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('contains a throwing descriptor trap while classifying a current error', async () => {
+    const descriptorTrap = jest.fn(() => {
+      throw new Error('synthetic-descriptor-trap-private-canary');
+    });
+    const valueReadTrap = jest.fn(() => {
+      throw new Error('synthetic-value-read-trap-private-canary');
+    });
+    const rejection = new Proxy({}, {
+      get: valueReadTrap,
+      getOwnPropertyDescriptor: descriptorTrap,
+    });
+    lookupRegistration.mockRejectedValueOnce(rejection);
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(descriptorTrap).toHaveBeenCalledTimes(2);
+    expect(valueReadTrap).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(
+      /synthetic-(descriptor|value-read)-trap-private-canary/,
+    );
+    expect(screen.queryByText("Can't confirm this registration")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('preserves a generic current lookup error without exposing its message', async () => {
+    lookupRegistration.mockRejectedValueOnce(
+      new Error('synthetic-registration-provider-private-canary'),
+    );
+
+    renderRegistrationSuccess(routeA);
+    await flushRegistrationWork();
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(
+      'synthetic-registration-provider-private-canary',
+    );
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('waits for services and then uses the current Firebase app and capability', async () => {
+    useServiceLocator.mockReturnValue({ services: null, isReady: false });
+    lookupRegistration.mockResolvedValueOnce(registrationResult({
+      status: 'paid',
+      id: routeA.reg,
+      eventId: routeA.event,
+      firstName: 'Ready',
+      email: 'ready-runner@example.test',
+    }));
+
+    const view = renderRegistrationSuccess(routeA);
+    expect(screen.getByRole('heading', { name: 'Processing your registration...' }))
+      .toBeInTheDocument();
+    expect(lookupRegistration).not.toHaveBeenCalled();
+
+    useServiceLocator.mockReturnValue(readyLocator());
+    view.rerender(<App />);
+    await flushRegistrationWork();
+
+    expect(lookupRegistration).toHaveBeenCalledWith(firebaseApp, {
+      eventId: routeA.event,
+      registrationId: routeA.reg,
+      token: routeA.token,
+    });
+    expect(lookupRegistration).toHaveBeenCalledTimes(1);
+    expect(document.body).toHaveTextContent('ready-runner@example.test');
+  });
+
+  test('preserves the missing-parameter error without starting a lookup', () => {
+    renderRegistrationSuccess({ ...routeA, token: null });
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(lookupRegistration).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/events/RegisterSuccess.tsx
+++ b/src/pages/events/RegisterSuccess.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import React, {
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import SEO from '../../components/SEO';
 import { lookupRegistration, LookupResult } from '../../services/events/eventsService';
@@ -7,70 +11,166 @@ import { track, events as analyticsEvents } from '../../services/analytics/analy
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 30_000;
+const objectIdentities = new WeakMap<object, number>();
+let nextObjectIdentity = 1;
 
-function RegisterSuccess() {
-  const [params] = useSearchParams();
-  const { services, isReady } = useServiceLocator();
-  const eventId = params.get('event');
-  const regId = params.get('reg');
-  const token = params.get('token');
+function getObjectIdentity(value: object | null): number {
+  if (value === null) return 0;
+  const existing = objectIdentities.get(value);
+  if (existing !== undefined) return existing;
+  const identity = nextObjectIdentity;
+  nextObjectIdentity += 1;
+  objectIdentities.set(value, identity);
+  return identity;
+}
 
-  const [reg, setReg] = useState<LookupResult | null>(null);
-  const [state, setState] = useState<'waiting' | 'confirmed' | 'timeout' | 'error' | 'denied'>(
-    'waiting',
-  );
-  const stopRef = useRef(false);
+function getOwnDataValue(value: unknown, key: string): unknown {
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
-  useEffect(() => {
-    if (!isReady || !services || !regId || !token || !eventId) {
-      if (isReady && (!regId || !token || !eventId)) setState('error');
-      return undefined;
+function getLookupErrorCode(error: unknown): string {
+  const directCode = getOwnDataValue(error, 'code');
+  if (directCode) return typeof directCode === 'string' ? directCode : '';
+  const details = getOwnDataValue(error, 'details');
+  const nestedCode = getOwnDataValue(details, 'code');
+  return typeof nestedCode === 'string' ? nestedCode : '';
+}
+
+type LookupApp = Parameters<typeof lookupRegistration>[0];
+type ViewPhase = 'waiting' | 'confirmed' | 'timeout' | 'error' | 'denied';
+
+type RegisterSuccessAttemptProps = {
+  app: LookupApp | null;
+  isReady: boolean;
+  eventId: string | null;
+  regId: string | null;
+  token: string | null;
+};
+
+type CommittedRoute = {
+  eventId: string | null;
+  regId: string | null;
+  token: string | null;
+  epoch: number;
+};
+
+function isSameRoute(
+  committed: CommittedRoute,
+  eventId: string | null,
+  regId: string | null,
+  token: string | null,
+): boolean {
+  return committed.eventId === eventId
+    && committed.regId === regId
+    && committed.token === token;
+}
+
+function RegisterSuccessAttempt({
+  app,
+  isReady,
+  eventId,
+  regId,
+  token,
+}: RegisterSuccessAttemptProps) {
+  const hasRequiredParams = Boolean(eventId && regId && token);
+  const [view, setView] = useState<{
+    phase: ViewPhase;
+    registration: LookupResult | null;
+  }>(() => ({
+    phase: isReady && !hasRequiredParams ? 'error' : 'waiting',
+    registration: null,
+  }));
+  const { phase, registration: reg } = view;
+
+  useLayoutEffect(() => {
+    let active = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const activeApp = app;
+
+    function settle(
+      nextPhase: ViewPhase,
+      registration: LookupResult | null = null,
+    ) {
+      if (!active) return;
+      setView({ phase: nextPhase, registration });
     }
-    stopRef.current = false;
+
+    function stop() {
+      active = false;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    }
+
+    if (!isReady || !activeApp || !hasRequiredParams) {
+      settle(isReady && !hasRequiredParams ? 'error' : 'waiting');
+      return stop;
+    }
+
+    settle('waiting');
+    const lookupApp = activeApp;
     const started = Date.now();
 
     async function tick() {
-      if (stopRef.current) return;
+      if (!active) return;
+      timer = null;
       try {
         const result = await lookupRegistration(
-          services!.firebaseResources.app,
+          lookupApp,
           { eventId: eventId!, registrationId: regId!, token: token! },
         );
-        setReg(result);
+        if (!active) return;
         if (result.status === 'paid' || result.status === 'comp') {
-          setState('confirmed');
+          settle('confirmed', result);
           track(analyticsEvents.registrationConfirmed, {
             eventId, status: result.status, amount_cents: result.amountCents,
           });
           return;
         }
         if (Date.now() - started > POLL_TIMEOUT_MS) {
-          setState('timeout');
+          settle('timeout');
           return;
         }
-        setTimeout(tick, POLL_INTERVAL_MS);
-      } catch (err: any) {
-        const code = err?.code || err?.details?.code || '';
+        settle('waiting');
+        if (!active) return;
+        timer = setTimeout(() => {
+          tick().catch(() => {
+            settle('error');
+          });
+        }, POLL_INTERVAL_MS);
+      } catch (err: unknown) {
+        if (!active) return;
+        const code = getLookupErrorCode(err);
         if (code === 'permission-denied') {
-          setState('denied');
+          settle('denied');
         } else {
-          setState('error');
+          settle('error');
         }
       }
     }
 
-    tick();
-
-    return () => {
-      stopRef.current = true;
-    };
-  }, [isReady, services, eventId, regId, token]);
+    tick().catch(() => {
+      settle('error');
+    });
+    return stop;
+  }, [app, eventId, hasRequiredParams, isReady, regId, token]);
 
   return (
     <>
       <SEO title="Registration complete" noindex />
       <div className="container mx-auto p-6 max-w-xl text-center">
-        {state === 'waiting' && (
+        {phase === 'waiting' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Processing your registration...</h1>
             <p className="text-gray-600">
@@ -78,7 +178,7 @@ function RegisterSuccess() {
             </p>
           </>
         )}
-        {state === 'confirmed' && reg && (
+        {phase === 'confirmed' && reg && (
           <>
             <h1 className="text-3xl font-bold mb-2">You&apos;re in!</h1>
             <p className="text-gray-800">
@@ -97,7 +197,7 @@ function RegisterSuccess() {
             </p>
           </>
         )}
-        {state === 'timeout' && (
+        {phase === 'timeout' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Still processing...</h1>
             <p className="text-gray-700">
@@ -106,7 +206,7 @@ function RegisterSuccess() {
             </p>
           </>
         )}
-        {state === 'denied' && (
+        {phase === 'denied' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Can&apos;t confirm this registration</h1>
             <p className="text-gray-700">
@@ -115,7 +215,7 @@ function RegisterSuccess() {
             </p>
           </>
         )}
-        {state === 'error' && (
+        {phase === 'error' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
             <p className="text-gray-700">
@@ -129,6 +229,91 @@ function RegisterSuccess() {
         </Link>
       </div>
     </>
+  );
+}
+
+function RegisterSuccess() {
+  const [params] = useSearchParams();
+  const location = useLocation();
+  const { services, isReady } = useServiceLocator();
+  const eventId = params.get('event');
+  const regId = params.get('reg');
+  const token = params.get('token');
+  const app = services?.firebaseResources.app ?? null;
+  const committedRouteRef = useRef<CommittedRoute | null>(null);
+  const [, setRouteCommitVersion] = useState(0);
+
+  if (committedRouteRef.current === null) {
+    committedRouteRef.current = {
+      eventId,
+      regId,
+      token,
+      epoch: 1,
+    };
+  }
+
+  const committedRoute = committedRouteRef.current;
+  const routeIsCommitted = isSameRoute(committedRoute, eventId, regId, token);
+
+  useLayoutEffect(() => {
+    const { current } = committedRouteRef;
+    if (current && isSameRoute(current, eventId, regId, token)) return;
+    committedRouteRef.current = {
+      eventId,
+      regId,
+      token,
+      epoch: (current?.epoch ?? 0) + 1,
+    };
+    setRouteCommitVersion((version) => version + 1);
+  }, [eventId, regId, token]);
+
+  if (!routeIsCommitted) {
+    const hasRequiredParams = Boolean(eventId && regId && token);
+    return (
+      <>
+        <SEO title="Registration complete" noindex />
+        <div className="container mx-auto p-6 max-w-xl text-center">
+          {isReady && !hasRequiredParams ? (
+            <>
+              <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+              <p className="text-gray-700">
+                We couldn&apos;t load your registration. Please contact us with your email and
+                event name.
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="text-2xl font-bold mb-2">Processing your registration...</h1>
+              <p className="text-gray-600">
+                Hang tight — we&apos;re confirming your payment with Stripe.
+              </p>
+            </>
+          )}
+          <Link to="/events" className="inline-block mt-6 text-blue-600 hover:underline">
+            ← Back to events
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const attemptKey = JSON.stringify([
+    location.key,
+    committedRoute.epoch,
+    getObjectIdentity(services),
+    getObjectIdentity(app),
+    isReady ? 1 : 0,
+  ]);
+
+  return (
+    <RegisterSuccessAttempt
+      key={attemptKey}
+      app={app}
+      isReady={isReady}
+      eventId={eventId}
+      regId={regId}
+      token={token}
+    />
   );
 }
 


### PR DESCRIPTION
## Outcome

A changed registration-confirmation route, service wrapper, Firebase app, or readiness state now hides the previous result in the same commit and starts one isolated current attempt. Stale promises, timers, and hostile error objects cannot replace the current view, expose an earlier runner result, or emit confirmation analytics.

Officer impact: Officers get a short synthetic-only check for this privacy boundary. This source change is not live until a protected website release publishes this exact revision and runmprc.com is verified.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`

Deployment evidence: Source and tests only. The website was not published, runmprc.com was not verified, Firebase was not deployed, provider settings were not changed, and production data or live registration links were not used.

## Safety design

- The first commit after a route capability changes renders only a safe waiting or error shell.
- React identity contains only opaque generation and service/app identity values, never event, registration, token, runner, or confirmation values.
- Layout-synchronous cleanup invalidates the old attempt and clears its timer in the same commit.
- Post-await guards prevent stale fulfillment or rejection values from being inspected.
- Error classification reads only bounded own data descriptors and contains hostile accessors, inherited values, proxies, and descriptor traps.
- Current paid, complimentary, pending, timeout, permission-denied, generic-error, and disabled analytics behavior remains compatible.

## Verification

- Focused DATA-001A1 suite: 33/33
- Full frontend Jest: 434/434
- TypeScript: pass
- Targeted ESLint: pass
- Lint ledger: unchanged at 106 files / 123 legacy errors / 7 legacy warnings
- SPA navigation: 11/11
- Repository safety tests: 46/46
- Diagnostic production build: pass
- Diff check: pass
- Three independent exact-diff reviews: approved, no P0/P1/P2 findings
- Hosted CI will rerun frontend, Functions, Firestore Rules, and commerce-journal gates on this exact head

## Residual work

This is a source-only containment slice. DATA-001A still owns the minimal server projection and capability contract; App Check, retention, authorization, deployment, production verification, and provider/data work remain separate.

Closes #319