### PR TITLE
DATA-001A2: isolate purchase confirmation polling

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -916,6 +916,64 @@ This source slice does **not** make the current confirmation address safe. DATA-
 
 No system-topology diagram changes for this source slice; the state-flow diagram above records the page's current-route display and timer boundary, while data movement, permissions, account ownership, and deployment topology remain unchanged.
 
+## Shop purchase confirmation route privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep one buyer's purchase details tied to the private confirmation address that requested them. Moving to another address must hide the earlier name, email, item, total, order ID, and confirmation result at once.
+
+**Approver:** merchandise lead, treasurer, platform/security owner, and privacy owner.
+
+**Prerequisites:** issue [#321](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/321) must be merged for source review. Issue [#319](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/319) is the separate registration-route source boundary; it does not cover shop purchases and is not live. Use only made-up buyers, orders, products, amounts, route values, and mocked services. Do not open, copy, request, or test a real purchase confirmation address. A later publication claim requires a protected website publication and a separate exact `runmprc.com` revision check without opening a real confirmation address. Neither result proves that the private route works in production.
+
+```mermaid
+flowchart TD
+    A["Made-up purchase address A"] --> B["Mocked order lookup A starts"]
+    B --> C["Move to made-up address B"]
+    C --> D["Hide A details at once; clear A timer"]
+    D --> E{"Which mocked result finishes?"}
+    E -- "Old A" --> F["Ignore it; show nothing from A"]
+    E -- "Current B is pending" --> G["Keep waiting; show no buyer or order details"]
+    E -- "Current B is paid or fulfilled" --> H["Show only B purchase details"]
+```
+
+Text alternative: changing from made-up purchase address A to B immediately hides A and clears its timer; every late A result does nothing, while only current B may keep waiting or show its own paid or fulfilled purchase details.
+
+Officer source-review steps:
+
+1. Keep the shop purchase route marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #321 issue, pull request, merged commit, and synthetic frontend test result.
+3. Confirm every test uses made-up buyers, orders, products, amounts, route values, and a mocked order lookup.
+4. Confirm no test opens a real confirmation address or contacts real Firebase, Stripe, analytics, or another outside service.
+5. Confirm moving from made-up address A to unresolved address B hides A's name, email, item, size, color, total, order ID, and confirmed heading before B finishes.
+6. Confirm a pending B result keeps the waiting page and shows no buyer or order details.
+7. Confirm a late A success cannot replace B or show any A detail.
+8. Confirm a late A failure is ignored without reading its private or hostile detail.
+9. Confirm A's old timer is cleared and cannot start another lookup after the move to B.
+10. Confirm a readiness, Firebase app, service, route, or page-close change makes the older work inactive and clears its timer.
+11. Confirm returning from A to B and back to A starts fresh work instead of reusing the first A result.
+12. Confirm only the current paid or fulfilled result shows the existing made-up buyer and order details.
+13. Confirm current pending, timeout, denied, error, not-ready, and missing-address results keep their existing plain displays.
+14. Record these as separate results: source changed, tests passed, code merged, website published, exact `runmprc.com` revision verified, Firebase deployed, Stripe or another provider configured, production data changed, and live route behavior verified.
+
+**Expected result:** only the current made-up address may decide what the page shows. An address or service change hides the preceding result immediately. Current pending work shows no buyer or order details. Old results, failures, and timers do nothing. The current paid or fulfilled result keeps the existing made-up name, email, item, total, and order ID. This changes reviewed source, tests, and this guide only.
+
+**Stop conditions:** any real buyer, order, email, item, amount, payment, Stripe payment session, confirmation address, token, screenshot, provider value, or production record; a request to paste a private address or detail into GitHub, email, chat, or an AI tool; a production Firebase, Stripe, analytics, or other provider action; an attempt to force a live failure or timing race; an old result appearing under a new address; or a claim that source, tests, merge, preview, or a green workflow proves the change is published or live.
+
+**Success proof:** for source completion, record the exact #321 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic route and timer tests, relevant full checks, and independent privacy, lifecycle, and officer reviews. Record #319 as separate registration-route source evidence only. The intended #321 completion states are: source changed, tests passed, and code merged. Website publication, `runmprc.com` verification, Firebase deployment, Stripe or other provider configuration or calls, real order or payment access, production-data action, and live route behavior remain **not performed**. A later release must record its protected website publication and exact `runmprc.com` revision separately without opening a real confirmation address.
+
+**Undo:** before publication, use one reviewed frontend and guide revert or safe roll-forward. After publication, use the same protected website release path and verify the replacement revision without opening a real confirmation address. Do not change or delete an order, payment, account, database record, token, permission, Firebase setting, analytics setting, or Stripe/provider setting.
+
+**Escalation:** merchandise lead, treasurer, platform/security owner, and privacy owner. Use the private incident path if one buyer's details may have appeared under another address. Do not copy the address, token, buyer or order details, screenshot, payment value, or provider value into an issue, message, email, or AI tool.
+
+This #321 source slice does **not** make the current purchase confirmation address safe. The separate #319 registration source boundary does not cover this route and is still not live.
+
+The remaining DATA-001A work still owns replacing private values in confirmation addresses with a verified Stripe payment session or signed-in account handoff. For visitors who are not signed in, it must store the private value safely, make it expire, and prevent reuse. It must also remove the value from browser history, keep it out of monitoring and links to other sites, and reduce the server response to the minimum approved fields.
+
+Firebase request checking (App Check) for the shop lookup (`lookupOrder`) remains deferred until that safe handoff and its matching safety tests are complete. The server may still return more buyer and order data than the page needs. The current page still shows the current buyer's name, email, item, total, and order ID. Data purpose, access, retention, deletion, payment authority, Stripe behavior, confirmation email, Firebase and provider settings, deployment, production data, and live behavior remain open or unchanged.
+
+No system-topology diagram changes for this source slice; the state-flow diagram above records only the shop page's current-route display and timer boundary, while data movement, permissions, account ownership, and deployment topology remain unchanged.
+
 ## Refund amount and returned-result guards — SOURCE ONLY, NOT LIVE
 
 **Purpose:** make an invalid partial amount stop, and record a refund complete only when Stripe returns a matching final success.

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -40,6 +40,7 @@ import {
   listActiveProducts,
   listAllOrders,
   listAllProducts,
+  lookupOrder,
 } from './services/shop/shopService';
 import App from './App';
 
@@ -63,6 +64,7 @@ jest.mock('./services/shop/shopService', () => {
     listActiveProducts: jest.fn(),
     listAllOrders: jest.fn(),
     listAllProducts: jest.fn(),
+    lookupOrder: jest.fn(),
   };
 });
 
@@ -127,6 +129,7 @@ beforeEach(() => {
   listActiveProducts.mockReset();
   listAllOrders.mockReset();
   listAllProducts.mockReset();
+  lookupOrder.mockReset();
   createCheckoutSession.mockReset();
   getEventBySlug.mockReset();
   listEventRegistrations.mockReset();
@@ -315,6 +318,37 @@ function navigateRegistrationSuccess(query) {
     idx: currentIndex + 1,
   };
   window.history.pushState(nextState, '', registrationSuccessPath(query));
+  fireEvent(window, new PopStateEvent('popstate', { state: nextState }));
+}
+
+function purchaseSuccessPath({
+  order = 'synthetic-confirmation-order',
+  token = 'synthetic-order-capability',
+} = {}) {
+  const params = new URLSearchParams();
+  if (order !== null) params.set('order', order);
+  if (token !== null) params.set('token', token);
+  return `/shop/purchase/success?${params.toString()}`;
+}
+
+function renderPurchaseSuccess(query) {
+  window.history.pushState({}, '', purchaseSuccessPath(query));
+  return render(<App />);
+}
+
+let purchaseHistoryKey = 0;
+
+function navigatePurchaseSuccess(query) {
+  purchaseHistoryKey += 1;
+  const currentIndex = typeof window.history.state?.idx === 'number'
+    ? window.history.state.idx
+    : 0;
+  const nextState = {
+    usr: null,
+    key: `synthetic-purchase-${purchaseHistoryKey}`,
+    idx: currentIndex + 1,
+  };
+  window.history.pushState(nextState, '', purchaseSuccessPath(query));
   fireEvent(window, new PopStateEvent('popstate', { state: nextState }));
 }
 
@@ -2103,6 +2137,847 @@ describe('DATA-001A1 registration confirmation attempt isolation', () => {
 
     expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
     expect(lookupRegistration).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+});
+
+describe('DATA-001A2 purchase confirmation attempt isolation', () => {
+  const routeA = {
+    order: 'synthetic-route-a-order',
+    token: 'synthetic-route-a-order-capability',
+  };
+  const routeB = {
+    order: 'synthetic-route-b-order',
+    token: 'synthetic-route-b-order-capability',
+  };
+
+  function readyLocator(app = firebaseApp) {
+    return {
+      services: { firebaseResources: { app } },
+      isReady: true,
+    };
+  }
+
+  function orderResult({
+    status = 'pending',
+    id = 'synthetic-confirmation-order',
+    firstName = 'Synthetic',
+    email = 'synthetic-buyer@example.test',
+    productTitle = 'Synthetic Club Jacket',
+    amountCents = 1500,
+    size = 'M',
+    color = 'Navy',
+  } = {}) {
+    return {
+      id,
+      status,
+      amountCents,
+      currency: 'usd',
+      productSlug: 'synthetic-club-jacket',
+      productTitle,
+      size,
+      color,
+      buyer: {
+        firstName,
+        lastName: 'Buyer',
+        email,
+      },
+      paidAt: null,
+      createdAt: null,
+    };
+  }
+
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  async function flushPurchaseWork() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  async function resolveDeferred(job, value) {
+    await act(async () => {
+      job.resolve(value);
+      await job.promise;
+      await Promise.resolve();
+    });
+  }
+
+  async function rejectDeferred(job, reason) {
+    await act(async () => {
+      job.reject(reason);
+      await job.promise.catch(() => undefined);
+      await Promise.resolve();
+    });
+  }
+
+  async function advancePollIntervals(remaining) {
+    if (remaining === 0) return;
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    await advancePollIntervals(remaining - 1);
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2030-01-12T16:00:00Z'));
+    useServiceLocator.mockReturnValue(readyLocator());
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('hides order A immediately and keeps a pending order B private', async () => {
+    const routeBLookup = deferred();
+    lookupOrder
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Prior',
+        email: 'prior-buyer@example.test',
+      }))
+      .mockReturnValueOnce(routeBLookup.promise);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+    expect(screen.getByRole('heading', { name: 'Order confirmed!' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('prior-buyer@example.test');
+
+    navigatePurchaseSuccess(routeB);
+    const immediateRouteText = document.body.textContent;
+
+    await resolveDeferred(routeBLookup, orderResult({
+      status: 'pending',
+      id: routeB.order,
+      firstName: 'Pending',
+      email: 'pending-buyer@example.test',
+    }));
+    const pendingRouteText = document.body.textContent;
+
+    expect(immediateRouteText).toContain('Processing your order...');
+    expect(immediateRouteText).not.toMatch(
+      /Prior|prior-buyer@example\.test|synthetic-route-a-order|Order confirmed!|Synthetic Club Jacket/,
+    );
+    expect(pendingRouteText).toContain('Processing your order...');
+    expect(pendingRouteText).not.toMatch(
+      /Pending|pending-buyer@example\.test|synthetic-route-b-order|Order confirmed!|Synthetic Club Jacket/,
+    );
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'route',
+    'services identity',
+    'Firebase app identity',
+    'readiness',
+  ])('hides confirmed order details in the first %s-change commit', async (changedBoundary) => {
+    const initialLocator = readyLocator();
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    const profiledApp = () => (
+      <React.Profiler id="purchase-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>
+    );
+    useServiceLocator.mockReturnValue(initialLocator);
+    lookupOrder.mockResolvedValueOnce(orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Prior',
+      email: 'prior-order-commit@example.test',
+    }));
+    window.history.pushState({}, '', purchaseSuccessPath(routeA));
+    const view = render(profiledApp());
+    await flushPurchaseWork();
+    expect(document.body).toHaveTextContent('prior-order-commit@example.test');
+
+    commits.length = 0;
+    lookupOrder.mockReturnValueOnce(new Promise(() => {}));
+    if (changedBoundary === 'route') {
+      navigatePurchaseSuccess(routeB);
+    } else {
+      let nextLocator = readyLocator();
+      if (changedBoundary === 'Firebase app identity') {
+        initialLocator.services.firebaseResources.app = {
+          name: 'synthetic-purchase-app-b',
+        };
+        nextLocator = initialLocator;
+      } else if (changedBoundary === 'readiness') {
+        nextLocator = { services: initialLocator.services, isReady: false };
+      }
+      useServiceLocator.mockReturnValue(nextLocator);
+      view.rerender(profiledApp());
+    }
+
+    expect(commits).not.toHaveLength(0);
+    expect(commits[0]).toContain('Processing your order...');
+    expect(commits[0]).not.toMatch(
+      /Prior|prior-order-commit@example\.test|synthetic-route-a-order|Order confirmed!|Synthetic Club Jacket/,
+    );
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('keeps one attempt when the router republishes the same purchase entry', async () => {
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    lookupOrder.mockResolvedValueOnce(orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Current',
+      email: 'same-purchase-entry@example.test',
+    }));
+    window.history.pushState({}, '', purchaseSuccessPath(routeA));
+    render(
+      <React.Profiler id="purchase-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>,
+    );
+    await flushPurchaseWork();
+    expect(document.body).toHaveTextContent('same-purchase-entry@example.test');
+
+    commits.length = 0;
+    const sameEntryState = {
+      ...window.history.state,
+      usr: { syntheticObjectRefresh: true },
+    };
+    window.history.replaceState(
+      sameEntryState,
+      '',
+      purchaseSuccessPath(routeA),
+    );
+    fireEvent(window, new PopStateEvent('popstate', { state: sameEntryState }));
+    await flushPurchaseWork();
+
+    expect(commits).not.toHaveLength(0);
+    expect(document.body).toHaveTextContent('same-purchase-entry@example.test');
+    expect(lookupOrder).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['order', { ...routeA, order: routeB.order }],
+    ['token', { ...routeA, token: routeB.token }],
+  ])('hides confirmed details when one history key changes only %s', async (
+    _changedField,
+    changedRoute,
+  ) => {
+    const routeBLookup = deferred();
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    lookupOrder
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Prior',
+        email: 'prior-same-key-order@example.test',
+      }))
+      .mockReturnValueOnce(routeBLookup.promise);
+    window.history.pushState({}, '', purchaseSuccessPath(routeA));
+    render(
+      <React.Profiler id="purchase-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>,
+    );
+    await flushPurchaseWork();
+    expect(document.body).toHaveTextContent('prior-same-key-order@example.test');
+
+    commits.length = 0;
+    const preservedHistoryState = { ...window.history.state };
+    const preservedHistoryKey = window.history.state?.key;
+    window.history.replaceState(
+      preservedHistoryState,
+      '',
+      purchaseSuccessPath(changedRoute),
+    );
+    fireEvent(window, new PopStateEvent('popstate', { state: preservedHistoryState }));
+
+    expect(window.history.state?.key).toBe(preservedHistoryKey);
+    expect(commits).not.toHaveLength(0);
+    expect(commits[0]).toContain('Processing your order...');
+    expect(commits[0]).not.toMatch(
+      /Prior|prior-same-key-order@example\.test|synthetic-route-a-order|Order confirmed!|Synthetic Club Jacket/,
+    );
+    expect(lookupOrder).toHaveBeenNthCalledWith(2, firebaseApp, {
+      orderId: changedRoute.order,
+      token: changedRoute.token,
+    });
+
+    await resolveDeferred(routeBLookup, orderResult({
+      status: 'pending',
+      id: changedRoute.order,
+      firstName: 'Pending',
+      email: 'pending-same-key-order@example.test',
+    }));
+
+    expect(screen.getByRole('heading', { name: 'Processing your order...' })).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(
+      /prior-same-key-order@example\.test|pending-same-key-order@example\.test|Order confirmed!/,
+    );
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('starts a new attempt when a new history entry repeats the same purchase tuple', async () => {
+    const commits = [];
+    const captureCommit = () => {
+      commits.push(document.querySelector('main')?.textContent ?? '');
+    };
+    lookupOrder
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Prior',
+        email: 'prior-new-key-order@example.test',
+      }))
+      .mockReturnValueOnce(new Promise(() => {}));
+    window.history.pushState({}, '', purchaseSuccessPath(routeA));
+    render(
+      <React.Profiler id="purchase-confirmation" onRender={captureCommit}>
+        <App />
+      </React.Profiler>,
+    );
+    await flushPurchaseWork();
+
+    commits.length = 0;
+    navigatePurchaseSuccess(routeA);
+
+    expect(commits).not.toHaveLength(0);
+    expect(commits[0]).toContain('Processing your order...');
+    expect(commits[0]).not.toMatch(
+      /Prior|prior-new-key-order@example\.test|synthetic-route-a-order|Order confirmed!|Synthetic Club Jacket/,
+    );
+    expect(lookupOrder).toHaveBeenCalledTimes(2);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('ignores a stale route success before inspecting it', async () => {
+    const staleLookup = deferred();
+    lookupOrder
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeB.order,
+        firstName: 'Current',
+        email: 'current-order@example.test',
+      }));
+
+    renderPurchaseSuccess(routeA);
+    navigatePurchaseSuccess(routeB);
+    await flushPurchaseWork();
+
+    const statusGetter = jest.fn(() => 'paid');
+    const staleResult = orderResult({
+      id: routeA.order,
+      firstName: 'Obsolete',
+      email: 'obsolete-order@example.test',
+    });
+    delete staleResult.status;
+    Object.defineProperty(staleResult, 'status', {
+      configurable: true,
+      enumerable: true,
+      get: statusGetter,
+    });
+    await resolveDeferred(staleLookup, staleResult);
+
+    expect(statusGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Order confirmed!' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('current-order@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('ignores a stale hostile rejection before reading code or details', async () => {
+    const staleLookup = deferred();
+    lookupOrder
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(orderResult({
+        status: 'fulfilled',
+        id: routeB.order,
+        firstName: 'Current',
+        email: 'current-fulfilled-order@example.test',
+      }));
+
+    renderPurchaseSuccess(routeA);
+    navigatePurchaseSuccess(routeB);
+    await flushPurchaseWork();
+
+    const codeGetter = jest.fn(() => '');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const hostileRejection = {};
+    Object.defineProperties(hostileRejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    await rejectDeferred(staleLookup, hostileRejection);
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Order confirmed!' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('current-fulfilled-order@example.test');
+    expect(screen.queryByText("Can't confirm this order")).not.toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('clears an order-owned poll timer and prevents another old lookup', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const routeBLookup = deferred();
+    const neverSettles = new Promise(() => {});
+    lookupOrder
+      .mockResolvedValueOnce(orderResult({
+        status: 'pending',
+        id: routeA.order,
+      }))
+      .mockReturnValueOnce(routeBLookup.promise)
+      .mockReturnValue(neverSettles);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+    const pollTimerIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 2000);
+    expect(pollTimerIndex).toBeGreaterThanOrEqual(0);
+    const pollTimerId = setTimeoutSpy.mock.results[pollTimerIndex].value;
+
+    navigatePurchaseSuccess(routeB);
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    const routeACalls = lookupOrder.mock.calls.filter(([, args]) => (
+      args.orderId === routeA.order
+    ));
+    expect(routeACalls).toHaveLength(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(pollTimerId);
+    expect(lookupOrder).toHaveBeenCalledTimes(2);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'services identity',
+    'Firebase app identity',
+  ])('invalidates an in-flight order lookup when %s changes', async (changedIdentity) => {
+    const appA = { name: 'synthetic-purchase-app-a' };
+    const appB = changedIdentity === 'Firebase app identity'
+      ? { name: 'synthetic-purchase-app-b' }
+      : appA;
+    const initialLocator = readyLocator(appA);
+    const staleLookup = deferred();
+    lookupOrder
+      .mockReturnValueOnce(staleLookup.promise)
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Current',
+        email: 'current-service-order@example.test',
+      }));
+    useServiceLocator.mockReturnValue(initialLocator);
+
+    const view = renderPurchaseSuccess(routeA);
+    if (changedIdentity === 'Firebase app identity') {
+      initialLocator.services.firebaseResources.app = appB;
+      useServiceLocator.mockReturnValue(initialLocator);
+    } else {
+      useServiceLocator.mockReturnValue(readyLocator(appB));
+    }
+    view.rerender(<App />);
+    await flushPurchaseWork();
+    await resolveDeferred(staleLookup, orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Obsolete',
+      email: 'obsolete-service-order@example.test',
+    }));
+
+    expect(lookupOrder).toHaveBeenNthCalledWith(1, appA, {
+      orderId: routeA.order,
+      token: routeA.token,
+    });
+    expect(lookupOrder).toHaveBeenNthCalledWith(2, appB, {
+      orderId: routeA.order,
+      token: routeA.token,
+    });
+    expect(document.body).toHaveTextContent('current-service-order@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-service-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('invalidates an in-flight order lookup when readiness is lost', async () => {
+    const staleLookup = deferred();
+    lookupOrder.mockReturnValueOnce(staleLookup.promise);
+    const view = renderPurchaseSuccess(routeA);
+
+    useServiceLocator.mockReturnValue({ services: null, isReady: false });
+    view.rerender(<App />);
+    await resolveDeferred(staleLookup, orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Obsolete',
+      email: 'obsolete-readiness-order@example.test',
+    }));
+
+    expect(screen.getByRole('heading', { name: 'Processing your order...' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-readiness-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('treats purchase A to B to A as three generations', async () => {
+    const firstRouteALookup = deferred();
+    const routeBLookup = deferred();
+    lookupOrder
+      .mockReturnValueOnce(firstRouteALookup.promise)
+      .mockReturnValueOnce(routeBLookup.promise)
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Current',
+        email: 'current-returned-order@example.test',
+      }));
+
+    renderPurchaseSuccess(routeA);
+    navigatePurchaseSuccess(routeB);
+    navigatePurchaseSuccess(routeA);
+    await flushPurchaseWork();
+    await resolveDeferred(firstRouteALookup, orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Obsolete',
+      email: 'obsolete-first-order@example.test',
+    }));
+
+    expect(document.body).toHaveTextContent('current-returned-order@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-first-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('keeps the second StrictMode purchase effect current', async () => {
+    const firstEffectLookup = deferred();
+    const secondEffectLookup = deferred();
+    lookupOrder
+      .mockReturnValueOnce(firstEffectLookup.promise)
+      .mockReturnValueOnce(secondEffectLookup.promise);
+    window.history.pushState({}, '', purchaseSuccessPath(routeA));
+
+    render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    );
+    expect(lookupOrder).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(secondEffectLookup, orderResult({
+      status: 'fulfilled',
+      id: routeA.order,
+      firstName: 'Current',
+      email: 'current-strict-order@example.test',
+    }));
+    const statusGetter = jest.fn(() => 'paid');
+    const firstEffectResult = orderResult({
+      id: routeA.order,
+      firstName: 'Obsolete',
+      email: 'obsolete-strict-order@example.test',
+    });
+    delete firstEffectResult.status;
+    Object.defineProperty(firstEffectResult, 'status', {
+      configurable: true,
+      enumerable: true,
+      get: statusGetter,
+    });
+    await resolveDeferred(firstEffectLookup, firstEffectResult);
+
+    expect(statusGetter).not.toHaveBeenCalled();
+    expect(document.body).toHaveTextContent('current-strict-order@example.test');
+    expect(document.body).not.toHaveTextContent('obsolete-strict-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('does not inspect an order result after unmount', async () => {
+    const staleLookup = deferred();
+    lookupOrder.mockReturnValueOnce(staleLookup.promise);
+    const view = renderPurchaseSuccess(routeA);
+    const statusGetter = jest.fn(() => 'paid');
+    const staleResult = orderResult({
+      id: routeA.order,
+      firstName: 'Unmounted',
+      email: 'unmounted-order@example.test',
+    });
+    delete staleResult.status;
+    Object.defineProperty(staleResult, 'status', {
+      configurable: true,
+      enumerable: true,
+      get: statusGetter,
+    });
+
+    view.unmount();
+    await resolveDeferred(staleLookup, staleResult);
+
+    expect(statusGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('does not inspect an order rejection after unmount', async () => {
+    const staleLookup = deferred();
+    lookupOrder.mockReturnValueOnce(staleLookup.promise);
+    const view = renderPurchaseSuccess(routeA);
+    const codeGetter = jest.fn(() => '');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const hostileRejection = {};
+    Object.defineProperties(hostileRejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+
+    view.unmount();
+    await rejectDeferred(staleLookup, hostileRejection);
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'paid',
+    'fulfilled',
+  ])('preserves a current %s order without analytics', async (status) => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    lookupOrder.mockResolvedValueOnce(orderResult({
+      status,
+      id: routeA.order,
+      firstName: 'Confirmed',
+      email: 'confirmed-order@example.test',
+    }));
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(screen.getByRole('heading', { name: 'Order confirmed!' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('Confirmed');
+    expect(document.body).toHaveTextContent('confirmed-order@example.test');
+    expect(document.body).toHaveTextContent('Synthetic Club Jacket');
+    expect(document.body).toHaveTextContent('size M');
+    expect(document.body).toHaveTextContent('Navy');
+    expect(document.body).toHaveTextContent('$15.00');
+    expect(document.body).toHaveTextContent(routeA.order);
+    expect(screen.getByRole('link', { name: '← Back to shop' })).toHaveAttribute('href', '/shop');
+    expect(lookupOrder).toHaveBeenCalledWith(firebaseApp, {
+      orderId: routeA.order,
+      token: routeA.token,
+    });
+    expect(lookupOrder).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+    expect(JSON.stringify(track.mock.calls)).not.toContain(routeA.token);
+    expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 2000)).toBe(false);
+  });
+
+  test('preserves current pending polling before a paid order', async () => {
+    lookupOrder
+      .mockResolvedValueOnce(orderResult({
+        status: 'pending',
+        id: routeA.order,
+        firstName: 'Pending',
+        email: 'pending-current-order@example.test',
+      }))
+      .mockResolvedValueOnce(orderResult({
+        status: 'paid',
+        id: routeA.order,
+        firstName: 'Polled',
+        email: 'polled-order@example.test',
+      }));
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+    expect(screen.getByRole('heading', { name: 'Processing your order...' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('pending-current-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+
+    await advancePollIntervals(1);
+
+    expect(screen.getByRole('heading', { name: 'Order confirmed!' })).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('polled-order@example.test');
+    expect(lookupOrder).toHaveBeenCalledTimes(2);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('preserves the current pending order timeout outcome', async () => {
+    lookupOrder.mockResolvedValue(orderResult({
+      status: 'pending',
+      id: routeA.order,
+    }));
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+    await advancePollIntervals(15);
+
+    expect(screen.getByRole('heading', { name: 'Processing your order...' })).toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+
+    await advancePollIntervals(1);
+
+    expect(screen.getByRole('heading', { name: 'Still processing...' })).toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['top-level', { code: 'permission-denied' }],
+    ['nested', { details: { code: 'permission-denied' } }],
+    ['nested after an empty direct code', { code: '', details: { code: 'permission-denied' } }],
+  ])('preserves the current %s order permission-denied outcome', async (_shape, rejection) => {
+    lookupOrder.mockRejectedValueOnce(rejection);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(screen.getByRole('heading', { name: "Can't confirm this order" }))
+      .toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('preserves a malformed direct order code ahead of nested permission denial', async () => {
+    lookupOrder.mockRejectedValueOnce({
+      code: {},
+      details: { code: 'permission-denied' },
+    });
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this order")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('classifies current order accessor fields without invoking them', async () => {
+    const codeGetter = jest.fn(() => 'permission-denied');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const rejection = {};
+    Object.defineProperties(rejection, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    lookupOrder.mockRejectedValueOnce(rejection);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this order")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('classifies inherited order error fields without invoking them', async () => {
+    const codeGetter = jest.fn(() => 'permission-denied');
+    const detailsGetter = jest.fn(() => ({ code: 'permission-denied' }));
+    const prototype = {};
+    Object.defineProperties(prototype, {
+      code: { configurable: true, get: codeGetter },
+      details: { configurable: true, get: detailsGetter },
+    });
+    const rejection = Object.create(prototype);
+    lookupOrder.mockRejectedValueOnce(rejection);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(detailsGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.queryByText("Can't confirm this order")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('contains a descriptor trap while classifying a current order error', async () => {
+    const descriptorTrap = jest.fn(() => {
+      throw new Error('synthetic-order-descriptor-trap-private-canary');
+    });
+    const valueReadTrap = jest.fn((_target, key) => {
+      if (key === 'code') return 'permission-denied';
+      return undefined;
+    });
+    const rejection = new Proxy({}, {
+      get: valueReadTrap,
+      getOwnPropertyDescriptor: descriptorTrap,
+    });
+    lookupOrder.mockRejectedValueOnce(rejection);
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(descriptorTrap).toHaveBeenCalledTimes(2);
+    expect(valueReadTrap).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('synthetic-order-descriptor-trap-private-canary');
+    expect(screen.queryByText("Can't confirm this order")).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('preserves a generic current order error without exposing its message', async () => {
+    lookupOrder.mockRejectedValueOnce(
+      new Error('synthetic-order-provider-private-canary'),
+    );
+
+    renderPurchaseSuccess(routeA);
+    await flushPurchaseWork();
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('synthetic-order-provider-private-canary');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('waits for services and then uses the current app and order capability', async () => {
+    useServiceLocator.mockReturnValue({ services: null, isReady: false });
+    lookupOrder.mockResolvedValueOnce(orderResult({
+      status: 'paid',
+      id: routeA.order,
+      firstName: 'Ready',
+      email: 'ready-order@example.test',
+    }));
+
+    const view = renderPurchaseSuccess(routeA);
+    expect(screen.getByRole('heading', { name: 'Processing your order...' })).toBeInTheDocument();
+    expect(lookupOrder).not.toHaveBeenCalled();
+
+    useServiceLocator.mockReturnValue(readyLocator());
+    view.rerender(<App />);
+    await flushPurchaseWork();
+
+    expect(lookupOrder).toHaveBeenCalledWith(firebaseApp, {
+      orderId: routeA.order,
+      token: routeA.token,
+    });
+    expect(lookupOrder).toHaveBeenCalledTimes(1);
+    expect(document.body).toHaveTextContent('ready-order@example.test');
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['order', { ...routeA, order: null }],
+    ['token', { ...routeA, token: null }],
+  ])('preserves the missing-%s error without starting an order lookup', (_field, route) => {
+    renderPurchaseSuccess(route);
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(lookupOrder).not.toHaveBeenCalled();
     expect(track).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/shop/PurchaseSuccess.tsx
+++ b/src/pages/shop/PurchaseSuccess.tsx
@@ -1,65 +1,166 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import React, {
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import SEO from '../../components/SEO';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { lookupOrder, OrderLookupResult, formatPrice } from '../../services/shop/shopService';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 30_000;
+const objectIdentities = new WeakMap<object, number>();
+let nextObjectIdentity = 1;
 
-function PurchaseSuccess() {
-  const [params] = useSearchParams();
-  const { services, isReady } = useServiceLocator();
-  const orderId = params.get('order');
-  const token = params.get('token');
+function getObjectIdentity(value: object | null): number {
+  if (value === null) return 0;
+  const existing = objectIdentities.get(value);
+  if (existing !== undefined) return existing;
+  const identity = nextObjectIdentity;
+  nextObjectIdentity += 1;
+  objectIdentities.set(value, identity);
+  return identity;
+}
 
-  const [order, setOrder] = useState<OrderLookupResult | null>(null);
-  const [state, setState] = useState<'waiting' | 'confirmed' | 'timeout' | 'error' | 'denied'>(
-    'waiting',
-  );
-  const stopRef = useRef(false);
+function getOwnDataValue(value: unknown, key: string): unknown {
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
-  useEffect(() => {
-    if (!isReady || !services || !orderId || !token) {
-      if (isReady && (!orderId || !token)) setState('error');
-      return undefined;
+function getLookupErrorCode(error: unknown): string {
+  const directCode = getOwnDataValue(error, 'code');
+  if (directCode) return typeof directCode === 'string' ? directCode : '';
+  const details = getOwnDataValue(error, 'details');
+  const nestedCode = getOwnDataValue(details, 'code');
+  return typeof nestedCode === 'string' ? nestedCode : '';
+}
+
+type LookupApp = Parameters<typeof lookupOrder>[0];
+type ViewPhase = 'waiting' | 'confirmed' | 'timeout' | 'error' | 'denied';
+
+type PurchaseSuccessAttemptProps = {
+  app: LookupApp | null;
+  isReady: boolean;
+  orderId: string | null;
+  token: string | null;
+};
+
+type CommittedRoute = {
+  orderId: string | null;
+  token: string | null;
+  epoch: number;
+};
+
+function isSameRoute(
+  committed: CommittedRoute,
+  orderId: string | null,
+  token: string | null,
+): boolean {
+  return committed.orderId === orderId && committed.token === token;
+}
+
+function PurchaseSuccessAttempt({
+  app,
+  isReady,
+  orderId,
+  token,
+}: PurchaseSuccessAttemptProps) {
+  const hasRequiredParams = Boolean(orderId && token);
+  const [view, setView] = useState<{
+    phase: ViewPhase;
+    order: OrderLookupResult | null;
+  }>(() => ({
+    phase: isReady && !hasRequiredParams ? 'error' : 'waiting',
+    order: null,
+  }));
+  const { phase, order } = view;
+
+  useLayoutEffect(() => {
+    let active = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const activeApp = app;
+
+    function settle(
+      nextPhase: ViewPhase,
+      nextOrder: OrderLookupResult | null = null,
+    ) {
+      if (!active) return;
+      setView({ phase: nextPhase, order: nextOrder });
     }
-    stopRef.current = false;
-    const started = Date.now();
 
-    async function tick() {
-      if (stopRef.current) return;
-      try {
-        const result = await lookupOrder(services!.firebaseResources.app, {
-          orderId: orderId!,
-          token: token!,
-        });
-        setOrder(result);
-        if (result.status === 'paid' || result.status === 'fulfilled') {
-          setState('confirmed');
-          return;
-        }
-        if (Date.now() - started > POLL_TIMEOUT_MS) {
-          setState('timeout');
-          return;
-        }
-        setTimeout(tick, POLL_INTERVAL_MS);
-      } catch (err: any) {
-        const code = err?.code || err?.details?.code || '';
-        if (code === 'permission-denied') setState('denied');
-        else setState('error');
+    function stop() {
+      active = false;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
       }
     }
 
-    tick();
-    return () => { stopRef.current = true; };
-  }, [isReady, services, orderId, token]);
+    if (!isReady || !activeApp || !hasRequiredParams) {
+      settle(isReady && !hasRequiredParams ? 'error' : 'waiting');
+      return stop;
+    }
+
+    settle('waiting');
+    const lookupApp = activeApp;
+    const started = Date.now();
+
+    async function tick() {
+      if (!active) return;
+      timer = null;
+      try {
+        const result = await lookupOrder(lookupApp, {
+          orderId: orderId!,
+          token: token!,
+        });
+        if (!active) return;
+        if (result.status === 'paid' || result.status === 'fulfilled') {
+          settle('confirmed', result);
+          return;
+        }
+        if (Date.now() - started > POLL_TIMEOUT_MS) {
+          settle('timeout');
+          return;
+        }
+        settle('waiting');
+        if (!active) return;
+        timer = setTimeout(() => {
+          tick().catch(() => {
+            settle('error');
+          });
+        }, POLL_INTERVAL_MS);
+      } catch (err: unknown) {
+        if (!active) return;
+        const code = getLookupErrorCode(err);
+        if (code === 'permission-denied') {
+          settle('denied');
+        } else {
+          settle('error');
+        }
+      }
+    }
+
+    tick().catch(() => {
+      settle('error');
+    });
+    return stop;
+  }, [app, hasRequiredParams, isReady, orderId, token]);
 
   return (
     <>
       <SEO title="Purchase complete" noindex />
       <div className="container mx-auto p-6 max-w-xl text-center">
-        {state === 'waiting' && (
+        {phase === 'waiting' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Processing your order...</h1>
             <p className="text-gray-600">
@@ -67,7 +168,7 @@ function PurchaseSuccess() {
             </p>
           </>
         )}
-        {state === 'confirmed' && order && (
+        {phase === 'confirmed' && order && (
           <>
             <h1 className="text-3xl font-bold mb-2">Order confirmed!</h1>
             <p className="text-gray-800">
@@ -100,7 +201,7 @@ function PurchaseSuccess() {
             </div>
           </>
         )}
-        {state === 'timeout' && (
+        {phase === 'timeout' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Still processing...</h1>
             <p className="text-gray-700">
@@ -108,13 +209,13 @@ function PurchaseSuccess() {
             </p>
           </>
         )}
-        {state === 'denied' && (
+        {phase === 'denied' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Can&apos;t confirm this order</h1>
             <p className="text-gray-700">This confirmation link isn&apos;t valid.</p>
           </>
         )}
-        {state === 'error' && (
+        {phase === 'error' && (
           <>
             <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
             <p className="text-gray-700">Please contact us with your email.</p>
@@ -125,6 +226,84 @@ function PurchaseSuccess() {
         </Link>
       </div>
     </>
+  );
+}
+
+function PurchaseSuccess() {
+  const [params] = useSearchParams();
+  const location = useLocation();
+  const { services, isReady } = useServiceLocator();
+  const orderId = params.get('order');
+  const token = params.get('token');
+  const app = services?.firebaseResources.app ?? null;
+  const committedRouteRef = useRef<CommittedRoute | null>(null);
+  const [, setRouteCommitVersion] = useState(0);
+
+  if (committedRouteRef.current === null) {
+    committedRouteRef.current = {
+      orderId,
+      token,
+      epoch: 1,
+    };
+  }
+
+  const committedRoute = committedRouteRef.current;
+  const routeIsCommitted = isSameRoute(committedRoute, orderId, token);
+
+  useLayoutEffect(() => {
+    const { current } = committedRouteRef;
+    if (current && isSameRoute(current, orderId, token)) return;
+    committedRouteRef.current = {
+      orderId,
+      token,
+      epoch: (current?.epoch ?? 0) + 1,
+    };
+    setRouteCommitVersion((version) => version + 1);
+  }, [orderId, token]);
+
+  if (!routeIsCommitted) {
+    const hasRequiredParams = Boolean(orderId && token);
+    return (
+      <>
+        <SEO title="Purchase complete" noindex />
+        <div className="container mx-auto p-6 max-w-xl text-center">
+          {isReady && !hasRequiredParams ? (
+            <>
+              <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+              <p className="text-gray-700">Please contact us with your email.</p>
+            </>
+          ) : (
+            <>
+              <h1 className="text-2xl font-bold mb-2">Processing your order...</h1>
+              <p className="text-gray-600">
+                Confirming your payment with Stripe.
+              </p>
+            </>
+          )}
+          <Link to="/shop" className="inline-block mt-6 text-blue-600 hover:underline">
+            ← Back to shop
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const attemptKey = JSON.stringify([
+    location.key,
+    committedRoute.epoch,
+    getObjectIdentity(services ?? null),
+    getObjectIdentity(app),
+    isReady ? 1 : 0,
+  ]);
+
+  return (
+    <PurchaseSuccessAttempt
+      key={attemptKey}
+      app={app}
+      isReady={isReady}
+      orderId={orderId}
+      token={token}
+    />
   );
 }
 


### PR DESCRIPTION
## Outcome

A changed shop confirmation address, service wrapper, Firebase app, history entry, or readiness state now hides the previous result in the same commit and starts one isolated current attempt. Stale promises, timers, and hostile error objects cannot replace the current view or expose an earlier buyer or order result.

Officer impact: Officers get a short synthetic-only check for this privacy boundary. This source change is not live until a protected website release publishes this exact revision and `runmprc.com` is verified.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`

Deployment evidence: Source and tests only. The website was not published, `runmprc.com` was not verified, Firebase was not deployed, Stripe or provider settings were not changed, and production data or live confirmation links were not used.

## Safety design

- The first commit after the order capability changes renders only a safe waiting or error shell.
- React identity contains only opaque generation and service or app identity values, never order ID, token, buyer, price, product, or confirmation values.
- Layout-synchronous cleanup invalidates the old attempt and clears its timer in the same commit.
- Post-await guards prevent stale fulfillment or rejection values from being inspected.
- Pending, timeout, denied, and failed results retain no order projection.
- Error classification reads only own data descriptors and contains hostile accessors, inherited values, ordinary Proxy value traps, and throwing descriptor traps.
- Current paid, fulfilled, pending, timeout, permission-denied, generic-error, not-ready, and missing-parameter behavior remains compatible.
- The page still makes zero analytics-wrapper calls.

## Verification

- Untouched-runtime RED proof: 13 compatibility pass / 21 intended safety fail
- Focused DATA-001A2 suite: 34/34
- Full frontend Jest: 468/468
- TypeScript and targeted ESLint: pass
- Lint ledger: unchanged at 106 files / 123 legacy errors / 7 legacy warnings
- SPA navigation: 11/11
- Repository safety: 46/46
- Diagnostic production build: pass
- Functions lint and unit tests: 2,201 active passed / 64 skipped
- Firestore Rules emulator: 378/378
- Commerce command-journal emulator: 63/63
- Diff check: pass
- Three independent exact-hash reviews: approved, no P0/P1/P2 findings
- Hosted CI will rerun frontend, Functions, Firestore Rules, commerce-journal, and artifact gates on this exact head

## Residual work

This is a source-only containment slice. DATA-001A still owns the verified Session or UID handoff, hashed expiring anonymous capability, replay and browser-history controls, minimal server projection, authorization, retention, and deletion. App Check remains deferred for `lookupOrder`. Payment authority, fulfillment, Stripe/provider configuration, deployment, production data, and live verification are unchanged.

Closes #321