### PR TITLE
OAUTH-001A2D: isolate Strava account state

### DIFF
--- a/.github/lint-baseline.json
+++ b/.github/lint-baseline.json
@@ -31,7 +31,7 @@
     ".ts": 0,
     ".tsx": 7
   },
-  "fingerprint": "sha256:0662d9aa158d0f3be307fc479f869da954905e214bf3f196172c93b85af7a58b",
+  "fingerprint": "sha256:f13e11e28a21ee078931352287e4074e8e5e7d5e9b39c76b3f1337df207e76ea",
   "scannedFiles": [
     "src/App.jsx",
     "src/App.test.jsx",
@@ -195,9 +195,9 @@
     },
     {
       "file": "src/pages/account/StravaSection.tsx",
-      "line": 187,
+      "line": 305,
       "column": 11,
-      "endLine": 187,
+      "endLine": 305,
       "endColumn": 42,
       "severity": 2,
       "ruleId": "react/jsx-no-bind",
@@ -208,9 +208,9 @@
     },
     {
       "file": "src/pages/account/StravaSection.tsx",
-      "line": 191,
+      "line": 310,
       "column": 23,
-      "endLine": 191,
+      "endLine": 310,
       "endColumn": 48,
       "severity": 2,
       "ruleId": "react/jsx-no-bind",

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -494,6 +494,61 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Strava current-account privacy — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep one signed-in member from seeing a previous account's Strava name, activity, or totals when the website account or website service setup changes.
+
+**Approver:** membership lead plus platform/security and privacy owners.
+
+**Prerequisites:** issue [#323](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/323) must be merged for source review. Use only made-up accounts, made-up Strava activity, and made-up automated results from the website's data service and Strava. Calling the protection live also requires an approved website publication and an exact revision check on `runmprc.com`. This slice does not deploy Firebase, contact Strava, change provider settings, read or repair production records, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Current made-up website account and website service setup"] --> B["Start made-up connection check"]
+    B --> C{"Does the result still belong to this attempt?"}
+    C -- "No" --> D["Ignore it and show no earlier Strava data"]
+    C -- "Yes, connected" --> E["Show this account and start made-up activity check"]
+    C -- "Yes, no connection" --> F["Show Connect Strava"]
+    C -- "Yes, check failed" --> G["Show one unavailable message and no Connect button"]
+    E --> H{"Does activity still belong to this attempt?"}
+    H -- "No" --> D
+    H -- "Yes" --> I["Show only this account's activity"]
+```
+
+Text alternative: the page may show Strava identity or activity only when a made-up result still belongs to the current website account and current service check. An older result is ignored. A confirmed missing connection shows **Connect Strava**; an unknown connection shows one unavailable message instead.
+
+Officer review steps after the source merge:
+
+1. Keep this protection marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for issue #323, the reviewed pull request, the merged commit, and made-up automated website test results.
+3. Confirm every test uses made-up account names, made-up activity, and made-up service results.
+4. Confirm switching from made-up account A to B removes A's Strava name and activity in the first display for B.
+5. Confirm the same immediate clearing happens when the website service setup, data connection, or ready/not-ready state changes.
+6. Confirm a late result from A cannot replace B's name, activity, totals, loading state, or failure state.
+7. Confirm changing A to B to A starts a new A check; it must not restore the first A result.
+8. Confirm a failed current connection check shows `We could not check your Strava connection right now. Please refresh this page and try again.`
+9. Confirm that failure shows neither an earlier account nor **Connect Strava**. A failed check does not prove that no Strava connection exists.
+10. Confirm **Connect Strava** appears only after the current made-up check returns no connection.
+11. Confirm a late disconnect result from A cannot clear B or show an A warning in B.
+12. Confirm closing the page and the automated check that runs twice both leave late results unused.
+13. Confirm current made-up connection, activity, fixed activity failure, and fixed disconnect failure behavior still works.
+14. Confirm no made-up account, activity, outside-service detail, private web address, token-shaped value, or made-up private marker appears in the wrong page state or browser console.
+15. Record source, tests, merge, website publication, `runmprc.com`, Firebase, Strava/provider, production-data, and live-behavior evidence as separate results.
+
+**Expected result:** reviewed source gives each website account and website service setup a fresh Strava check. It immediately hides an earlier account, accepts only current connection, activity, and disconnect results, shows one fixed connection-unavailable alert for a failed current check, and shows **Connect Strava** only after a current check confirms no connection. Existing current-account success and fixed activity/disconnect failures remain available.
+
+**Stop conditions:** any real member or Strava account; a request for a name, activity, token, provider error, private account detail, or screenshot containing private values; a production Firebase or Strava call or change; earlier-account data in a later-account display; **Connect Strava** after an unknown check; a raw detail in the page or console; or a claim that source, tests, merge, or a green workflow proves the protection is live.
+
+**Success proof:** for source completion, record issue #323, the exact reviewed pull request and merge, the ten intended old-source failures, green made-up account-switch tests, relevant full checks, and independent privacy and officer reviews. For live availability, separately record the approved website publication, the published revision, and a dated `runmprc.com` check that uses approved test accounts and no private Strava data. Record Firebase deployment, Strava/provider configuration, production-data access, migration, and repair as **not performed** for this website-page change.
+
+**Undo:** before publication, use one reviewed website-and-guide revert or safe replacement. After any later approved publication, use the protected website release path and verify the replacement revision on `runmprc.com`. Never undo by changing a member account, Strava connection, Firebase record, permission, or provider setting.
+
+**Escalation:** membership lead plus platform/security owner. Add the privacy owner and use the private incident path if one account's Strava identity or activity appeared for another account. Do not copy the name, activity, account detail, screenshot, token, or provider error into an issue, message, email, or AI tool.
+
+No full-system map changes are required because services, permissions, and publication paths are unchanged. The diagram above shows which account may appear and when an older result must stop.
+
 ## Public Shop catalog failure privacy — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -538,6 +538,43 @@ function renderActualStravaSection() {
   return render(<ActualStravaSection uid={USER.uid} />);
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function stravaConnectionFor(label: string, athleteId: number) {
+  return {
+    ...STRAVA_CONNECTION,
+    athleteId,
+    firstName: label,
+    lastName: 'Athlete',
+    username: `${label.toLowerCase()}-athlete`,
+  };
+}
+
+function stravaStatsFor(label: string, athleteId: number) {
+  return {
+    ...STRAVA_STATS,
+    athlete: {
+      ...STRAVA_STATS.athlete,
+      id: athleteId,
+      firstName: label,
+      username: `${label.toLowerCase()}-athlete`,
+    },
+    recentActivities: [{
+      ...STRAVA_STATS.recentActivities[0],
+      id: athleteId * 10,
+      name: `${label} Morning Run`,
+    }],
+  };
+}
+
 describe('Strava activity browser failure boundary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -629,6 +666,514 @@ describe('Strava activity browser failure boundary', () => {
     expect(document.body).not.toHaveTextContent('message-getter-canary');
     expect(screen.queryByText('Loading recent activity...')).not.toBeInTheDocument();
     expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+});
+
+const STRAVA_CONNECTION_FAILURE = 'We could not check your Strava connection right now. Please refresh this page and try again.';
+
+describe('Strava current-account lifecycle privacy boundary', () => {
+  const userA = 'synthetic-user-a';
+  const userB = 'synthetic-user-b';
+  const connectionA = stravaConnectionFor('Alpha', 111111);
+  const connectionB = stravaConnectionFor('Bravo', 222222);
+  const statsA = stravaStatsFor('Alpha', 111111);
+  const statsB = stravaStatsFor('Bravo', 222222);
+  let appA: { name: string };
+  let appB: { name: string };
+  let firestoreA: { name: string };
+  let firestoreB: { name: string };
+  let locator: {
+    current: {
+      services: {
+        firebaseResources: {
+          app: { name: string };
+          firestore: { name: string };
+        };
+      };
+      isReady: boolean;
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appA = { name: 'synthetic-app-a' };
+    appB = { name: 'synthetic-app-b' };
+    firestoreA = { name: 'synthetic-firestore-a' };
+    firestoreB = { name: 'synthetic-firestore-b' };
+    locator = {
+      current: {
+        services: { firebaseResources: { app: appA, firestore: firestoreA } },
+        isReady: true,
+      },
+    };
+    (useServiceLocator as jest.Mock).mockImplementation(() => locator.current);
+    (stravaDisconnect as jest.Mock).mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    ['UID', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      rerender(<ActualStravaSection uid={userB} />);
+    }],
+    ['services', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      locator.current = {
+        ...locator.current,
+        services: { ...locator.current.services },
+      };
+      rerender(<ActualStravaSection uid={userA} />);
+    }],
+    ['Firebase resources', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      locator.current.services.firebaseResources = {
+        app: appA,
+        firestore: firestoreA,
+      };
+      rerender(<ActualStravaSection uid={userA} />);
+    }],
+    ['Firestore', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      locator.current.services.firebaseResources.firestore = firestoreB;
+      rerender(<ActualStravaSection uid={userA} />);
+    }],
+    ['Firebase app', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      locator.current.services.firebaseResources.app = appB;
+      rerender(<ActualStravaSection uid={userA} />);
+    }],
+    ['readiness', ({ rerender }: { rerender: (node: React.ReactElement) => void }) => {
+      locator.current.isReady = false;
+      rerender(<ActualStravaSection uid={userA} />);
+    }],
+  ])('hides prior account data in the first commit after a %s change', async (
+    _case,
+    changeContext,
+  ) => {
+    const commits: string[] = [];
+    (getStravaConnection as jest.Mock)
+      .mockResolvedValueOnce(connectionA)
+      .mockResolvedValue(connectionB);
+    (stravaFetchStats as jest.Mock)
+      .mockResolvedValueOnce(statsA)
+      .mockResolvedValue(statsB);
+    const onRender = () => {
+      commits.push(document.body.textContent || '');
+    };
+    const view = render(
+      <React.Profiler id="strava-attempt" onRender={onRender}>
+        <ActualStravaSection uid={userA} />
+      </React.Profiler>,
+    );
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+
+    commits.length = 0;
+    changeContext({
+      rerender: (node: React.ReactElement) => view.rerender(
+        <React.Profiler id="strava-attempt" onRender={onRender}>
+          {node}
+        </React.Profiler>,
+      ),
+    });
+
+    expect(commits[0]).not.toMatch(/Alpha Athlete|Alpha Morning Run/);
+    expect(commits[0]).not.toContain('Connect Strava');
+    if (_case !== 'readiness') {
+      expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+    }
+  });
+
+  test('keeps a rejected current connection unavailable without revealing prior account data', async () => {
+    const nextConnection = deferred<null>();
+    const messageGetter = jest.fn(() => {
+      throw new Error('connection-message-getter-canary');
+    });
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method as any).mockImplementation(() => undefined));
+    (getStravaConnection as jest.Mock)
+      .mockResolvedValueOnce(connectionA)
+      .mockReturnValueOnce(nextConnection.promise);
+    (stravaFetchStats as jest.Mock).mockResolvedValueOnce(statsA);
+    const view = render(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+
+    view.rerender(<ActualStravaSection uid={userB} />);
+    expect(document.body).not.toHaveTextContent(/Alpha Athlete|Alpha Morning Run/);
+    await act(async () => nextConnection.reject(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    ));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(STRAVA_CONNECTION_FAILURE);
+    expect(screen.queryByRole('button', { name: 'Connect Strava' })).not.toBeInTheDocument();
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('ignores an obsolete connection success after a different account becomes current', async () => {
+    const firstConnection = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const firstNameGetter = jest.fn(() => {
+      throw new Error('obsolete-connection-getter-canary');
+    });
+    const hostileConnection = Object.defineProperty(
+      { ...connectionA },
+      'firstName',
+      { configurable: true, get: firstNameGetter },
+    ) as ReturnType<typeof stravaConnectionFor>;
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => (uid === userA
+        ? firstConnection.promise
+        : Promise.resolve(connectionB)),
+    );
+    (stravaFetchStats as jest.Mock).mockResolvedValue(statsB);
+    const view = render(<ActualStravaSection uid={userA} />);
+
+    view.rerender(<ActualStravaSection uid={userB} />);
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+    await act(async () => firstConnection.resolve(hostileConnection));
+
+    expect(document.body).toHaveTextContent('Bravo Athlete');
+    expect(document.body).toHaveTextContent('Bravo Morning Run');
+    expect(document.body).not.toHaveTextContent(/Alpha Athlete|Alpha Morning Run/);
+    expect(firstNameGetter).not.toHaveBeenCalled();
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores an obsolete connection rejection while the current account is loading', async () => {
+    const firstConnection = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const currentConnection = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const messageGetter = jest.fn(() => {
+      throw new Error('obsolete-connection-rejection-canary');
+    });
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => (uid === userA
+        ? firstConnection.promise
+        : currentConnection.promise),
+    );
+    (stravaFetchStats as jest.Mock).mockResolvedValue(statsB);
+    const view = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(1));
+
+    view.rerender(<ActualStravaSection uid={userB} />);
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(2));
+    await act(async () => firstConnection.reject(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    ));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Connect Strava' })).not.toBeInTheDocument();
+    expect(messageGetter).not.toHaveBeenCalled();
+    await act(async () => currentConnection.resolve(connectionB));
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+  });
+
+  test('ignores obsolete activity success and failure after a different account becomes current', async () => {
+    const firstStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    const currentStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => Promise.resolve(
+        uid === userA ? connectionA : connectionB,
+      ),
+    );
+    (stravaFetchStats as jest.Mock).mockImplementation(
+      (activeApp: unknown) => (activeApp === appA ? firstStats.promise : currentStats.promise),
+    );
+    const view = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledWith(appA));
+
+    locator.current = {
+      services: { firebaseResources: { app: appB, firestore: firestoreB } },
+      isReady: true,
+    };
+    view.rerender(<ActualStravaSection uid={userB} />);
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledWith(appB));
+    expect(screen.getByText('Loading recent activity...')).toBeInTheDocument();
+
+    await act(async () => firstStats.resolve(statsA));
+    expect(document.body).not.toHaveTextContent('Alpha Morning Run');
+    expect(screen.getByText('Loading recent activity...')).toBeInTheDocument();
+
+    await act(async () => currentStats.resolve(statsB));
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('Alpha Morning Run');
+  });
+
+  test('keeps an obsolete activity rejection out of the current loading account', async () => {
+    const firstStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    const currentStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    const messageGetter = jest.fn(() => {
+      throw new Error('obsolete-stats-message-getter-canary');
+    });
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => Promise.resolve(
+        uid === userA ? connectionA : connectionB,
+      ),
+    );
+    (stravaFetchStats as jest.Mock).mockImplementation(
+      (activeApp: unknown) => (activeApp === appA ? firstStats.promise : currentStats.promise),
+    );
+    const view = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledWith(appA));
+
+    locator.current = {
+      services: { firebaseResources: { app: appB, firestore: firestoreB } },
+      isReady: true,
+    };
+    view.rerender(<ActualStravaSection uid={userB} />);
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledWith(appB));
+    await act(async () => firstStats.reject(
+      Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }),
+    ));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('Loading recent activity...')).toBeInTheDocument();
+    expect(messageGetter).not.toHaveBeenCalled();
+    await act(async () => currentStats.resolve(statsB));
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+  });
+
+  test('uses a new opaque generation when the account changes A to B to A', async () => {
+    const firstA = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const middleB = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const firstAGetter = jest.fn(() => {
+      throw new Error('first-a-generation-canary');
+    });
+    const middleBGetter = jest.fn(() => {
+      throw new Error('middle-b-generation-canary');
+    });
+    const currentConnection = stravaConnectionFor('Current Alpha', 333333);
+    const currentStats = stravaStatsFor('Current Alpha', 333333);
+    (getStravaConnection as jest.Mock)
+      .mockReturnValueOnce(firstA.promise)
+      .mockReturnValueOnce(middleB.promise)
+      .mockResolvedValueOnce(currentConnection);
+    (stravaFetchStats as jest.Mock).mockResolvedValue(currentStats);
+    const view = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(1));
+
+    view.rerender(<ActualStravaSection uid={userB} />);
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(2));
+    view.rerender(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Current Alpha Morning Run')).toBeInTheDocument();
+    expect(getStravaConnection).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      firstA.resolve(Object.defineProperty(
+        { ...connectionA },
+        'firstName',
+        { configurable: true, get: firstAGetter },
+      ) as ReturnType<typeof stravaConnectionFor>);
+      middleB.resolve(Object.defineProperty(
+        { ...connectionB },
+        'firstName',
+        { configurable: true, get: middleBGetter },
+      ) as ReturnType<typeof stravaConnectionFor>);
+    });
+
+    expect(firstAGetter).not.toHaveBeenCalled();
+    expect(middleBGetter).not.toHaveBeenCalled();
+    expect(document.body).toHaveTextContent('Current Alpha Athlete');
+    expect(document.body).toHaveTextContent('Current Alpha Morning Run');
+    expect(document.body).not.toHaveTextContent('Bravo Athlete');
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the first StrictMode effect replay inert after the current replay resolves', async () => {
+    const firstReplay = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const currentReplay = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const firstNameGetter = jest.fn(() => {
+      throw new Error('strict-replay-getter-canary');
+    });
+    (getStravaConnection as jest.Mock)
+      .mockReturnValueOnce(firstReplay.promise)
+      .mockReturnValueOnce(currentReplay.promise);
+    (stravaFetchStats as jest.Mock).mockResolvedValue(statsA);
+
+    render(
+      <React.StrictMode>
+        <ActualStravaSection uid={userA} />
+      </React.StrictMode>,
+    );
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(2));
+    await act(async () => currentReplay.resolve(connectionA));
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+    await act(async () => firstReplay.resolve(Object.defineProperty(
+      { ...connectionB },
+      'firstName',
+      { configurable: true, get: firstNameGetter },
+    ) as ReturnType<typeof stravaConnectionFor>));
+
+    expect(firstNameGetter).not.toHaveBeenCalled();
+    expect(document.body).toHaveTextContent('Alpha Athlete');
+    expect(document.body).not.toHaveTextContent('Bravo Athlete');
+    expect(stravaFetchStats).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not let an obsolete disconnect clear the current account', async () => {
+    const disconnect = deferred<{ ok: true }>();
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => Promise.resolve(
+        uid === userA ? connectionA : connectionB,
+      ),
+    );
+    (stravaFetchStats as jest.Mock).mockImplementation(
+      (activeApp: unknown) => Promise.resolve(activeApp === appA ? statsA : statsB),
+    );
+    (stravaDisconnect as jest.Mock).mockReturnValueOnce(disconnect.promise);
+    const view = render(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    locator.current = {
+      services: { firebaseResources: { app: appB, firestore: firestoreB } },
+      isReady: true,
+    };
+    view.rerender(<ActualStravaSection uid={userB} />);
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+    await act(async () => disconnect.resolve({ ok: true }));
+
+    expect(document.body).toHaveTextContent('Bravo Athlete');
+    expect(document.body).toHaveTextContent('Bravo Morning Run');
+    expect(screen.queryByRole('button', { name: 'Connect Strava' })).not.toBeInTheDocument();
+  });
+
+  test('does not let an obsolete disconnect rejection warn the current account', async () => {
+    const disconnect = deferred<{ ok: true }>();
+    const messageGetter = jest.fn(() => {
+      throw new Error('obsolete-disconnect-rejection-canary');
+    });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (getStravaConnection as jest.Mock).mockImplementation(
+      (_firestore: unknown, uid: string) => Promise.resolve(
+        uid === userA ? connectionA : connectionB,
+      ),
+    );
+    (stravaFetchStats as jest.Mock).mockImplementation(
+      (activeApp: unknown) => Promise.resolve(activeApp === appA ? statsA : statsB),
+    );
+    (stravaDisconnect as jest.Mock).mockReturnValueOnce(disconnect.promise);
+    const view = render(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    locator.current = {
+      services: { firebaseResources: { app: appB, firestore: firestoreB } },
+      isReady: true,
+    };
+    view.rerender(<ActualStravaSection uid={userB} />);
+    expect(await screen.findByText('Bravo Morning Run')).toBeInTheDocument();
+    await act(async () => disconnect.reject(Object.defineProperty({}, 'message', {
+      configurable: true,
+      get: messageGetter,
+    })));
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(document.body).toHaveTextContent('Bravo Athlete');
+    expect(document.body).toHaveTextContent('Bravo Morning Run');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('invalidates pending activity before a current disconnect success settles', async () => {
+    const pendingStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    const recentActivitiesGetter = jest.fn(() => {
+      throw new Error('post-disconnect-activity-getter-canary');
+    });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (getStravaConnection as jest.Mock).mockResolvedValue(connectionA);
+    (stravaFetchStats as jest.Mock).mockReturnValue(pendingStats.promise);
+    const view = render(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Loading recent activity...')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    expect(await screen.findByRole('button', { name: 'Connect Strava' })).toBeInTheDocument();
+    await act(async () => pendingStats.resolve(Object.defineProperty(
+      { ...statsA },
+      'recentActivities',
+      { configurable: true, get: recentActivitiesGetter },
+    ) as ReturnType<typeof stravaStatsFor>));
+
+    expect(recentActivitiesGetter).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Connect Strava' })).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/Alpha Athlete|Alpha Morning Run/);
+    view.unmount();
+  });
+
+  test('makes pending connection and activity work inert after unmount', async () => {
+    const pendingConnection = deferred<ReturnType<typeof stravaConnectionFor>>();
+    const connectionGetter = jest.fn(() => {
+      throw new Error('unmounted-connection-getter-canary');
+    });
+    (getStravaConnection as jest.Mock).mockReturnValueOnce(pendingConnection.promise);
+    const connectionView = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(getStravaConnection).toHaveBeenCalledTimes(1));
+    connectionView.unmount();
+    await act(async () => pendingConnection.resolve(Object.defineProperty(
+      { ...connectionA },
+      'firstName',
+      { configurable: true, get: connectionGetter },
+    ) as ReturnType<typeof stravaConnectionFor>));
+    expect(connectionGetter).not.toHaveBeenCalled();
+    expect(stravaFetchStats).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    const pendingStats = deferred<ReturnType<typeof stravaStatsFor>>();
+    const statsGetter = jest.fn(() => {
+      throw new Error('unmounted-stats-getter-canary');
+    });
+    (useServiceLocator as jest.Mock).mockImplementation(() => locator.current);
+    (getStravaConnection as jest.Mock).mockResolvedValueOnce(connectionA);
+    (stravaFetchStats as jest.Mock).mockReturnValueOnce(pendingStats.promise);
+    const statsView = render(<ActualStravaSection uid={userA} />);
+    await waitFor(() => expect(stravaFetchStats).toHaveBeenCalledTimes(1));
+    statsView.unmount();
+    await act(async () => pendingStats.resolve(Object.defineProperty(
+      { ...statsA },
+      'recentActivities',
+      { configurable: true, get: statsGetter },
+    ) as ReturnType<typeof stravaStatsFor>));
+    expect(statsGetter).not.toHaveBeenCalled();
+  });
+
+  test('makes a pending disconnect rejection inert after unmount', async () => {
+    const disconnect = deferred<{ ok: true }>();
+    const messageGetter = jest.fn(() => {
+      throw new Error('unmounted-disconnect-getter-canary');
+    });
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method as any).mockImplementation(() => undefined));
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    (getStravaConnection as jest.Mock).mockResolvedValue(connectionA);
+    (stravaFetchStats as jest.Mock).mockResolvedValue(statsA);
+    (stravaDisconnect as jest.Mock).mockReturnValueOnce(disconnect.promise);
+    const view = render(<ActualStravaSection uid={userA} />);
+    expect(await screen.findByText('Alpha Morning Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    view.unmount();
+
+    await act(async () => disconnect.reject(Object.defineProperty({}, 'message', {
+      configurable: true,
+      get: messageGetter,
+    })));
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('shows Connect only after the current account lookup confirms no connection', async () => {
+    (getStravaConnection as jest.Mock).mockResolvedValue(null);
+
+    render(<ActualStravaSection uid={userA} />);
+
+    expect(await screen.findByRole('button', { name: 'Connect Strava' })).toBeInTheDocument();
+    expect(stravaFetchStats).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/account/StravaSection.tsx
+++ b/src/pages/account/StravaSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import {
   buildStravaAuthorizeUrl,
@@ -10,6 +10,21 @@ import {
   StravaConnection,
   StravaStatsResult,
 } from '../../services/strava/stravaService';
+
+const STRAVA_CONNECTION_FAILURE = 'We could not check your Strava connection right now. Please refresh this page and try again.';
+const STRAVA_ACTIVITY_FAILURE = 'We could not load your Strava activity right now. Please try again later.';
+const STRAVA_DISCONNECT_FAILURE = 'We could not confirm the Strava disconnect. Please refresh this page before trying again.';
+const objectIdentities = new WeakMap<object, number>();
+let nextObjectIdentity = 1;
+
+function getObjectIdentity(value: object): number {
+  const existing = objectIdentities.get(value);
+  if (existing !== undefined) return existing;
+  const identity = nextObjectIdentity;
+  nextObjectIdentity += 1;
+  objectIdentities.set(value, identity);
+  return identity;
+}
 
 function Connected({
   conn, stats, loading, error, onDisconnect, disconnecting,
@@ -122,29 +137,115 @@ function Disconnected({ onConnect }: { onConnect: () => void }) {
   );
 }
 
-function StravaSection({ uid }: { uid: string }) {
-  const { services } = useServiceLocator();
-  const [conn, setConn] = useState<StravaConnection | null>(null);
-  const [stats, setStats] = useState<StravaStatsResult | null>(null);
-  const [loadingConn, setLoadingConn] = useState(true);
-  const [loadingStats, setLoadingStats] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [disconnectError, setDisconnectError] = useState<string | null>(null);
-  const [disconnecting, setDisconnecting] = useState(false);
-  useEffect(() => {
-    if (!services) return;
-    getStravaConnection(services.firebaseResources.firestore, uid)
-      .then((c) => { setConn(c); setLoadingConn(false); })
-      .catch(() => setLoadingConn(false));
-  }, [services, uid]);
+type StravaFirestore = Parameters<typeof getStravaConnection>[0];
+type StravaApp = Parameters<typeof stravaFetchStats>[0];
+
+type ConnectionState =
+  | { phase: 'loading' }
+  | { phase: 'unavailable' }
+  | { phase: 'disconnected' }
+  | { phase: 'connected'; connection: StravaConnection };
+
+type ActivityState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'unavailable' }
+  | { phase: 'resolved'; stats: StravaStatsResult };
+
+type DisconnectState = 'idle' | 'pending' | 'failed';
+
+function StravaAttempt({
+  uid,
+  firestore,
+  app,
+}: {
+  uid: string;
+  firestore: StravaFirestore;
+  app: StravaApp;
+}) {
+  const [connectionState, setConnectionState] = useState<ConnectionState>({ phase: 'loading' });
+  const [activityState, setActivityState] = useState<ActivityState>({ phase: 'idle' });
+  const [disconnectState, setDisconnectState] = useState<DisconnectState>('idle');
+  const lifetimeRunRef = useRef<symbol | null>(null);
+  const connectionRunRef = useRef<symbol | null>(null);
+  const activityRunRef = useRef<symbol | null>(null);
+  const disconnectRunRef = useRef<symbol | null>(null);
 
   useEffect(() => {
-    if (!services || !conn) return;
-    setLoadingStats(true);
-    stravaFetchStats(services.firebaseResources.app)
-      .then((s) => { setStats(s); setLoadingStats(false); })
-      .catch(() => { setError('We could not load your Strava activity right now. Please try again later.'); setLoadingStats(false); });
-  }, [services, conn]);
+    const run = Symbol('strava-lifetime');
+    lifetimeRunRef.current = run;
+    return () => {
+      if (lifetimeRunRef.current === run) lifetimeRunRef.current = null;
+      connectionRunRef.current = null;
+      activityRunRef.current = null;
+      disconnectRunRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const run = Symbol('strava-connection');
+    connectionRunRef.current = run;
+
+    async function loadConnection() {
+      try {
+        const nextConnection = await getStravaConnection(firestore, uid);
+        if (!active || connectionRunRef.current !== run) return;
+        setConnectionState(nextConnection === null
+          ? { phase: 'disconnected' }
+          : { phase: 'connected', connection: nextConnection });
+      } catch {
+        if (!active || connectionRunRef.current !== run) return;
+        setConnectionState({ phase: 'unavailable' });
+      }
+    }
+
+    loadConnection().catch(() => {
+      if (!active || connectionRunRef.current !== run) return;
+      setConnectionState({ phase: 'unavailable' });
+    });
+
+    return () => {
+      active = false;
+      if (connectionRunRef.current === run) connectionRunRef.current = null;
+    };
+  }, [firestore, uid]);
+
+  useEffect(() => {
+    let active = true;
+    const run = Symbol('strava-activity');
+    activityRunRef.current = run;
+
+    if (connectionState.phase !== 'connected') {
+      setActivityState({ phase: 'idle' });
+      return () => {
+        active = false;
+        if (activityRunRef.current === run) activityRunRef.current = null;
+      };
+    }
+
+    setActivityState({ phase: 'loading' });
+    async function loadActivity() {
+      try {
+        const nextStats = await stravaFetchStats(app);
+        if (!active || activityRunRef.current !== run) return;
+        setActivityState({ phase: 'resolved', stats: nextStats });
+      } catch {
+        if (!active || activityRunRef.current !== run) return;
+        setActivityState({ phase: 'unavailable' });
+      }
+    }
+
+    loadActivity().catch(() => {
+      if (!active || activityRunRef.current !== run) return;
+      setActivityState({ phase: 'unavailable' });
+    });
+
+    return () => {
+      active = false;
+      if (activityRunRef.current === run) activityRunRef.current = null;
+    };
+  }, [app, connectionState]);
 
   function handleConnect() {
     const clientId = process.env.REACT_APP_STRAVA_CLIENT_ID;
@@ -158,39 +259,86 @@ function StravaSection({ uid }: { uid: string }) {
   }
 
   async function handleDisconnect() {
-    if (!services) return;
     // eslint-disable-next-line no-alert
     if (!window.confirm('Disconnect your Strava account?')) return;
-    setDisconnecting(true);
+    const lifetimeRun = lifetimeRunRef.current;
+    if (lifetimeRun === null) return;
+    const disconnectRun = Symbol('strava-disconnect');
+    disconnectRunRef.current = disconnectRun;
+    setDisconnectState('pending');
     try {
-      await stravaDisconnect(services.firebaseResources.app);
-      setConn(null);
-      setStats(null);
+      await stravaDisconnect(app);
+      if (
+        lifetimeRunRef.current !== lifetimeRun
+        || disconnectRunRef.current !== disconnectRun
+      ) return;
+      activityRunRef.current = null;
+      setConnectionState({ phase: 'disconnected' });
+      setActivityState({ phase: 'idle' });
+      setDisconnectState('idle');
     } catch {
-      setDisconnectError('We could not confirm the Strava disconnect. Please refresh this page before trying again.');
-    } finally {
-      setDisconnecting(false);
+      if (
+        lifetimeRunRef.current !== lifetimeRun
+        || disconnectRunRef.current !== disconnectRun
+      ) return;
+      setDisconnectState('failed');
     }
   }
 
-  if (loadingConn) return null;
+  if (connectionState.phase === 'loading') return null;
+  let connectedError: string | null = null;
+  if (disconnectState === 'failed') {
+    connectedError = STRAVA_DISCONNECT_FAILURE;
+  } else if (activityState.phase === 'unavailable') {
+    connectedError = STRAVA_ACTIVITY_FAILURE;
+  }
 
   return (
     <section className="mt-6">
       <h2 className="text-lg font-semibold mb-3">Strava</h2>
-      {conn ? (
+      {connectionState.phase === 'connected' && (
         <Connected
-          conn={conn}
-          stats={stats}
-          loading={loadingStats}
-          error={disconnectError || error}
+          conn={connectionState.connection}
+          stats={activityState.phase === 'resolved' ? activityState.stats : null}
+          loading={activityState.phase === 'loading'}
+          error={connectedError}
           onDisconnect={handleDisconnect}
-          disconnecting={disconnecting}
+          disconnecting={disconnectState === 'pending'}
         />
-      ) : (
+      )}
+      {connectionState.phase === 'disconnected' && (
         <Disconnected onConnect={handleConnect} />
       )}
+      {connectionState.phase === 'unavailable' && (
+        <p role="alert" aria-live="assertive" aria-atomic="true" className="text-sm text-red-600">
+          {STRAVA_CONNECTION_FAILURE}
+        </p>
+      )}
     </section>
+  );
+}
+
+function StravaSection({ uid }: { uid: string }) {
+  const { services, isReady } = useServiceLocator();
+  if (!isReady || !services) return null;
+
+  const { firebaseResources } = services;
+  const { firestore, app } = firebaseResources;
+  const attemptKey = JSON.stringify([
+    uid,
+    getObjectIdentity(services),
+    getObjectIdentity(firebaseResources),
+    getObjectIdentity(firestore),
+    getObjectIdentity(app),
+  ]);
+
+  return (
+    <StravaAttempt
+      key={attemptKey}
+      uid={uid}
+      firestore={firestore}
+      app={app}
+    />
   );
 }
 


### PR DESCRIPTION
## Outcome

The My Account Strava panel now belongs to one current website account and one current service attempt. Changing account, service setup, database, app, or readiness unmounts the old attempt before it can display or publish identity, activity, total, or disconnect results into the new context.

Closes #323. This is one source/test/officer-document child of canonical #88; it keeps #88 open and incomplete.

## Security invariant

- Previous account data is absent in the first render after a context change.
- Only the exact current connection, activity, and disconnect attempt may publish state.
- Unavailable connection reads remain distinct from a confirmed disconnected state.
- Obsolete success and rejection values are inert and never inspected, logged, retained, or displayed.
- Current connection/activity/disconnect behavior and fixed privacy-safe failure text remain compatible.

## Exact scope

- `src/pages/account/StravaSection.tsx`
- one named lifecycle block/support in `src/pages/account/Account.test.tsx`
- one named source-only procedure and diagram in `docs/officers/EVENTS_SHOP_MEMBERS.md`
- mechanical fingerprint and two existing position updates in `.github/lint-baseline.json`

#310 paths and all Functions, Rules, service, package, workflow, provider, production-data, and release surfaces are excluded.

## Verification

- Old-runtime RED proof: 10 intended lifecycle/privacy failures and 1 compatibility pass.
- Focused Account suite: 55/55 passed.
- Full frontend: 12 suites, 487/487 passed.
- TypeScript typecheck passed.
- Lint ledger: 106 files / 123 errors / 7 warnings.
- SPA navigation: 11/11 passed.
- Repository safety: 46/46 passed.
- Diagnostic production build passed; bundle `main.4fd78ac2.js`.
- Functions lint passed.
- Functions: 2,201 active passed / 64 skipped.
- Firestore Rules: 378/378 passed.
- Commerce emulator: 63/63 passed.
- `git diff --check` passed.
- Exact four-path diff SHA-256: `ca742254bdda5f485204c307df9d5a43dad7d5fe3aa9bd5892c1cd8a7a813a4c`.
- Three independent exact-hash reviews approved security/design, lifecycle/tests, and officer clarity/scope.

## Compatibility and migration

No schema, provider, or data migration. The change only prevents obsolete browser-attempt results from being displayed. Current valid behavior remains available after the current attempt resolves.

Officer impact: Officers get a short made-up-data review that proves one signed-in account cannot inherit the preceding account's Strava panel. This is source only until a protected website release and `runmprc.com` verification occur.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`

Deployment evidence: Source committed and local tests passed. At PR creation, the change is not merged; the website is not published; `runmprc.com` is not verified; Firebase is not deployed; Strava/provider configuration is unchanged; no production data was read or changed; and live behavior is not proven. A green PR workflow or preview will not change those external states.
