### PR TITLE
PAY-001B1B: validate selected race price cents

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -196,6 +196,45 @@ Officer source-review steps:
 
 **Live-release gate: NOT AVAILABLE YET.** PAY-001B2 must first add immutable field, price, and waiver snapshots and prove compatibility without opening real registrations. A separate protected race-checkout release plan must explicitly name `createCheckoutSession`, the exact commit, an isolated staging project, Stripe test mode, owner approval, provider and Firebase readback, paid/free/volunteer checks, and rollback. No current release issue or workflow supplies that plan. Source review does not authorize deployment.
 
+## Race price format guard — SOURCE ONLY, NOT LIVE
+
+**Purpose:** stop an invalid selected race price before the server creates a registration identifier, a Stripe Product, or a Stripe Checkout Session.
+
+**Approver:** event lead plus treasurer and platform/security owner.
+
+**Prerequisites for source review:** issue [#327](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/327) is merged; the exact reviewed commit is named; and tests use made-up events and people. The private inventory in [#113](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/113) is required before any deployment, data repair, or live approval. This technical format guard is not an approved business price policy.
+
+```mermaid
+flowchart LR
+    A["Made-up event passes earlier checks"] --> B["Earlier request, rate, role, and capacity checks"]
+    B --> C["Select one price tier"]
+    C --> D{"Stored price is free or at least 50 cents, with at most eight digits?"}
+    D -- "No or unknown" --> E["Fixed unavailable message; no later registration or Stripe work"]
+    D -- "Yes" --> F["Later checkout safety checks may continue"]
+```
+
+In words: some earlier safety checks may already run, but an invalid selected price must stop before the server allocates a registration identifier or starts Stripe work.
+
+Officer source-review steps:
+
+1. Keep live race checkout unavailable.
+2. Ask the specialist for the exact pull request and synthetic test report.
+3. Confirm the report uses invented events and people only.
+4. Confirm missing, paid prices below 50 cents, negative, fractional, oversized, or otherwise malformed selected prices get one plain unavailable message.
+5. Confirm the denial creates no confirmation token, registration identifier, registration write, Stripe Product, or Checkout Session.
+6. Confirm the report states that earlier rate, role, membership, or capacity checks may already have run.
+7. Record the result as source proof only.
+
+**Expected result:** the helper admits free `0`, or a stored whole-number USD value from 50 cents through Stripe's eight-digit technical limit. These technical limits are not approval to charge any amount. An invalid selected value is unavailable and no raw value appears in a result or log.
+
+**Stop conditions:** real runner data, a real payment, a production test, a request to repair Firestore or Stripe by hand, a missing exact commit, a claim that the source is live, or evidence that a denial allocated a registration identifier or reached Stripe.
+
+**Success proof:** exact pull request and merge commit, green synthetic tests, independent review, and a written statement that the website, Firebase, Stripe, production data, and live behavior were not changed or verified. A future live release needs separate Firebase deployment, Stripe test-mode, and readback proof.
+
+**Undo:** use one reviewed source revert or safe roll-forward. Do not edit an event, registration, Product, Session, or payment record by hand.
+
+**Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if any submitted person or event detail appears in output.
+
 ## Profile permission error
 
 **Status: AUTOMATIC REPAIR NOT LIVE YET**

--- a/functions/checkoutPromotionPolicy.test.js
+++ b/functions/checkoutPromotionPolicy.test.js
@@ -7,6 +7,7 @@ const mockFirestoreWrite = jest.fn();
 const mockGenerateToken = jest.fn();
 const mockResolveCallerRole = jest.fn();
 const mockCountActiveRegistrations = jest.fn();
+const mockRegistrationAllocation = jest.fn();
 
 jest.mock('firebase-functions', () => {
   class HttpsError extends Error {
@@ -76,6 +77,7 @@ jest.mock('firebase-admin', () => {
     doc(id) {
       let resolvedId = id;
       if (!resolvedId && this.path.endsWith('/registrations')) {
+        mockRegistrationAllocation(this.path);
         registrationSequence += 1;
         resolvedId = `reg-new-${registrationSequence}`;
       } else if (!resolvedId && this.path === 'orders') {
@@ -110,6 +112,10 @@ jest.mock('firebase-admin', () => {
 
 jest.mock('./stripeHelpers', () => {
   const { resolveVerifiedCallerRole } = jest.requireActual('./verifiedRolePolicy');
+  const {
+    isEarlyBirdActive,
+    pickPriceCents,
+  } = jest.requireActual('./stripeHelpers');
   return {
     getStripe: mockGetStripe,
     generateToken: mockGenerateToken,
@@ -119,8 +125,8 @@ jest.mock('./stripeHelpers', () => {
     },
     requireAppCheck: () => {},
     validateRunner: () => [],
-    pickPriceCents: (event, tier) => event.pricing?.[`${tier}Cents`] ?? null,
-    isEarlyBirdActive: () => false,
+    pickPriceCents,
+    isEarlyBirdActive,
     isRegistrationOpen: () => true,
     countActiveRegistrations: mockCountActiveRegistrations,
     auditEntry: ({ action, note }) => ({ action, note }),
@@ -185,6 +191,7 @@ describe('Checkout promotion policy', () => {
     mockGenerateToken.mockReset();
     mockResolveCallerRole.mockReset();
     mockCountActiveRegistrations.mockReset();
+    mockRegistrationAllocation.mockReset();
     mockGetStripe.mockReturnValue({
       checkout: { sessions: { create: mockCheckoutCreate } },
       products: { create: mockProductCreate },
@@ -467,6 +474,62 @@ describe('Checkout promotion policy', () => {
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetStripe).not.toHaveBeenCalled();
     expect(mockCheckoutCreate).not.toHaveBeenCalled();
+  });
+
+  test('rejects a selected price accessor before token, registration allocation, or Stripe use', async () => {
+    const selectedPriceRead = jest.fn(() => Number.NaN);
+    const pricing = {};
+    Object.defineProperty(pricing, 'nonMemberCents', {
+      enumerable: true,
+      get: selectedPriceRead,
+    });
+    admin.__seed('events/race-1', {
+      checkoutEnabled: true,
+      title: 'Synthetic Race',
+      slug: 'synthetic-race',
+      status: 'open',
+      visibility: 'public',
+      pricing,
+      waiverVersion: 'synthetic-v1',
+    });
+    mockProductCreate.mockResolvedValueOnce({ id: 'prod_synthetic_generated' });
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => {}));
+
+    try {
+      await expect(createCheckoutSession({
+        eventId: 'race-1',
+        runner: {
+          firstName: 'Test',
+          lastName: 'Runner',
+          email: 'runner@example.test',
+        },
+        priceTier: 'nonMember',
+        acceptedWaiver: true,
+      }, { auth: null, rawRequest: {} })).rejects.toMatchObject({
+        code: 'failed-precondition',
+        message: 'Selected price tier is not available for this event',
+      });
+
+      expect(mockRateLimit).toHaveBeenCalledTimes(2);
+      expect(mockResolveCallerRole).toHaveBeenCalledTimes(1);
+      const lastRateLimitCall = Math.max(...mockRateLimit.mock.invocationCallOrder);
+      expect(lastRateLimitCall).toBeLessThan(
+        mockResolveCallerRole.mock.invocationCallOrder[0],
+      );
+      expect(mockCountActiveRegistrations).not.toHaveBeenCalled();
+      expect(selectedPriceRead).not.toHaveBeenCalled();
+      expect(mockGenerateToken).not.toHaveBeenCalled();
+      expect(mockRegistrationAllocation).not.toHaveBeenCalled();
+      expect(mockFirestoreWrite).not.toHaveBeenCalled();
+      expect(admin.__get('events/race-1/registrations/reg-new-1')).toBeUndefined();
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(mockProductCreate).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    } finally {
+      consoleSpies.forEach((spy) => spy.mockRestore());
+    }
   });
 
   test('race checkout sends the exact disabled-adjustment payload', async () => {

--- a/functions/stripeHelpers.js
+++ b/functions/stripeHelpers.js
@@ -24,9 +24,12 @@ const mathFloor = Math.floor;
 const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const objectGetPrototypeOf = Object.getPrototypeOf;
 const objectHasOwn = Object.hasOwn;
+const objectIs = Object.is;
 const objectPrototype = Object.prototype;
 const numberIsFinite = Number.isFinite;
 const numberIsSafeInteger = Number.isSafeInteger;
+const STRIPE_MINIMUM_USD_CENTS = 50;
+const STRIPE_UNIT_AMOUNT_MAX_CENTS = 99_999_999;
 const reflectOwnKeys = Reflect.ownKeys;
 const timestampPrototype = Timestamp.prototype;
 
@@ -98,12 +101,29 @@ function validateRunner(runner) {
 }
 
 function pickPriceCents(event, priceTier) {
-  const pricing = event.pricing || {};
-  if (priceTier === 'member') return pricing.memberCents;
-  if (priceTier === 'nonMember') return pricing.nonMemberCents;
-  if (priceTier === 'earlyBird') return pricing.earlyBirdCents;
   if (priceTier === 'free') return 0;
-  return null;
+
+  let selectedField;
+  if (priceTier === 'member') selectedField = 'memberCents';
+  else if (priceTier === 'nonMember') selectedField = 'nonMemberCents';
+  else if (priceTier === 'earlyBird') selectedField = 'earlyBirdCents';
+  else return null;
+
+  if (!isPlainEventRecord(event)) return null;
+  const pricing = selectedOwnDataValue(event, 'pricing', true);
+  if (!isPlainEventRecord(pricing)) return null;
+  const priceCents = selectedOwnDataValue(pricing, selectedField, true);
+  if (
+    typeof priceCents !== 'number'
+    || !numberIsSafeInteger(priceCents)
+    || objectIs(priceCents, -0)
+    || priceCents < 0
+    || (priceCents !== 0 && priceCents < STRIPE_MINIMUM_USD_CENTS)
+    || priceCents > STRIPE_UNIT_AMOUNT_MAX_CENTS
+  ) {
+    return null;
+  }
+  return priceCents;
 }
 
 function isEarlyBirdActive(event, now = Date.now()) {

--- a/functions/stripeHelpers.test.js
+++ b/functions/stripeHelpers.test.js
@@ -31,10 +31,12 @@ jest.mock('./serverConfig', () => ({
 
 const {
   isRegistrationOpen,
+  pickPriceCents,
   requireAdmin,
   resolveCallerRole,
   Timestamp,
 } = require('./stripeHelpers');
+const { MAX_CENTS } = require('./requestValidation');
 
 const NOW_MS = 1_735_689_600_000;
 
@@ -318,6 +320,219 @@ describe('registration-window validation', () => {
     expect(isRegistrationOpen(openEvent({
       registrationClosesAt: malformed,
     }), NOW_MS)).toBe(false);
+  });
+});
+
+describe('selected race-price validation', () => {
+  function eventWithPricing(pricing) {
+    return { pricing };
+  }
+
+  test('preserves fixed free zero and rejects unknown tiers without reading event data', () => {
+    const eventRead = jest.fn(() => {
+      throw new Error('synthetic event read must not run');
+    });
+    const event = new Proxy({}, { get: eventRead });
+    const tierHooks = {
+      toString: jest.fn(() => 'member'),
+      valueOf: jest.fn(() => 'member'),
+      [Symbol.toPrimitive]: jest.fn(() => 'member'),
+    };
+
+    expect(pickPriceCents(event, 'free')).toBe(0);
+    expect(pickPriceCents(event, 'unknown')).toBeNull();
+    expect(pickPriceCents(event, tierHooks)).toBeNull();
+    expect(eventRead).not.toHaveBeenCalled();
+    expect(tierHooks.toString).not.toHaveBeenCalled();
+    expect(tierHooks.valueOf).not.toHaveBeenCalled();
+    expect(tierHooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['member', 'memberCents'],
+    ['nonMember', 'nonMemberCents'],
+    ['earlyBird', 'earlyBirdCents'],
+  ])('preserves exact valid %s cent boundaries', (tier, field) => {
+    [0, 50, 99_999_999].forEach((value) => {
+      expect(pickPriceCents(eventWithPricing({ [field]: value }), tier)).toBe(value);
+    });
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['negative zero', -0],
+    ['negative integer', -1],
+    ['one cent, below the Stripe USD minimum', 1],
+    ['forty-nine cents, below the Stripe USD minimum', 49],
+    ['fractional cents', 1.5],
+    ['not-a-number', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['the shared generic ceiling, above the Stripe eight-digit limit', MAX_CENTS],
+    ['over the shared generic ceiling', MAX_CENTS + 1],
+    ['unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+    ['string', '5000'],
+    ['boolean', true],
+    ['bigint', BigInt(5000)],
+    ['boxed number', Object(5000)],
+    ['array', [5000]],
+    ['record', { cents: 5000 }],
+  ])('rejects selected %s', (_case, value) => {
+    expect(pickPriceCents(eventWithPricing({ nonMemberCents: value }), 'nonMember'))
+      .toBeNull();
+  });
+
+  test('rejects a missing selected price and missing pricing record', () => {
+    expect(pickPriceCents({}, 'nonMember')).toBeNull();
+    expect(pickPriceCents(eventWithPricing({}), 'nonMember')).toBeNull();
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['array', []],
+    ['Date', new Date(0)],
+    ['null-prototype record', Object.create(null)],
+    ['custom-prototype record', Object.create({ inherited: true })],
+  ])('rejects %s event containers without throwing', (_case, event) => {
+    expect(() => pickPriceCents(event, 'nonMember')).not.toThrow();
+    expect(pickPriceCents(event, 'nonMember')).toBeNull();
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['array', []],
+    ['Date', new Date(0)],
+    ['null-prototype record', Object.create(null)],
+    ['custom-prototype record', Object.create({ inherited: true })],
+  ])('rejects %s pricing containers without throwing', (_case, pricing) => {
+    expect(() => pickPriceCents(eventWithPricing(pricing), 'nonMember')).not.toThrow();
+    expect(pickPriceCents(eventWithPricing(pricing), 'nonMember')).toBeNull();
+  });
+
+  test.each([
+    ['event', (value) => value],
+    ['pricing', (value) => eventWithPricing(value)],
+  ])('rejects a live Proxy %s without invoking traps', (_case, wrap) => {
+    const trap = jest.fn(() => {
+      throw new Error('synthetic Proxy trap must not run');
+    });
+    const value = new Proxy({}, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      has: trap,
+      ownKeys: trap,
+    });
+
+    expect(pickPriceCents(wrap(value), 'nonMember')).toBeNull();
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['event', (value) => value],
+    ['pricing', (value) => eventWithPricing(value)],
+  ])('rejects a revoked Proxy %s without throwing', (_case, wrap) => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    expect(() => pickPriceCents(wrap(proxy), 'nonMember')).not.toThrow();
+    expect(pickPriceCents(wrap(proxy), 'nonMember')).toBeNull();
+  });
+
+  test('rejects selected accessors without invoking them', () => {
+    const pricingGetter = jest.fn(() => ({ nonMemberCents: 5000 }));
+    const event = {};
+    Object.defineProperty(event, 'pricing', {
+      enumerable: true,
+      get: pricingGetter,
+    });
+
+    const priceGetter = jest.fn(() => 5000);
+    const pricing = {};
+    Object.defineProperty(pricing, 'nonMemberCents', {
+      enumerable: true,
+      get: priceGetter,
+    });
+
+    expect(pickPriceCents(event, 'nonMember')).toBeNull();
+    expect(pickPriceCents(eventWithPricing(pricing), 'nonMember')).toBeNull();
+    expect(pricingGetter).not.toHaveBeenCalled();
+    expect(priceGetter).not.toHaveBeenCalled();
+  });
+
+  test('rejects inherited selected values without invoking prototype getters', () => {
+    const pricingGetter = jest.fn(() => ({ nonMemberCents: 5000 }));
+    const eventPrototype = {};
+    Object.defineProperty(eventPrototype, 'pricing', { get: pricingGetter });
+
+    const priceGetter = jest.fn(() => 5000);
+    const pricingPrototype = {};
+    Object.defineProperty(pricingPrototype, 'nonMemberCents', { get: priceGetter });
+
+    expect(pickPriceCents(Object.create(eventPrototype), 'nonMember')).toBeNull();
+    expect(pickPriceCents(eventWithPricing(Object.create(pricingPrototype)), 'nonMember'))
+      .toBeNull();
+    expect(pricingGetter).not.toHaveBeenCalled();
+    expect(priceGetter).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-enumerable selected data', () => {
+    const hiddenPricingEvent = {};
+    Object.defineProperty(hiddenPricingEvent, 'pricing', {
+      value: { nonMemberCents: 5000 },
+    });
+    const hiddenPrice = {};
+    Object.defineProperty(hiddenPrice, 'nonMemberCents', { value: 5000 });
+
+    expect(pickPriceCents(hiddenPricingEvent, 'nonMember')).toBeNull();
+    expect(pickPriceCents(eventWithPricing(hiddenPrice), 'nonMember')).toBeNull();
+  });
+
+  test('does not invoke selected-value coercion or JSON hooks', () => {
+    const hooks = {
+      toJSON: jest.fn(() => 5000),
+      toString: jest.fn(() => '5000'),
+      valueOf: jest.fn(() => 5000),
+      [Symbol.toPrimitive]: jest.fn(() => 5000),
+    };
+
+    expect(pickPriceCents(eventWithPricing({ nonMemberCents: hooks }), 'nonMember'))
+      .toBeNull();
+    expect(hooks.toJSON).not.toHaveBeenCalled();
+    expect(hooks.toString).not.toHaveBeenCalled();
+    expect(hooks.valueOf).not.toHaveBeenCalled();
+    expect(hooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+  });
+
+  test('ignores hostile unselected and unknown fields without enumeration', () => {
+    const eventGetter = jest.fn(() => {
+      throw new Error('synthetic event getter must not run');
+    });
+    const unselectedGetter = jest.fn(() => {
+      throw new Error('synthetic unselected getter must not run');
+    });
+    const unknownGetter = jest.fn(() => {
+      throw new Error('synthetic unknown getter must not run');
+    });
+    const symbolGetter = jest.fn(() => {
+      throw new Error('synthetic symbol getter must not run');
+    });
+    const pricing = { nonMemberCents: 5000 };
+    pricing.self = pricing;
+    Object.defineProperty(pricing, 'memberCents', { get: unselectedGetter });
+    Object.defineProperty(pricing, 'unknown', { get: unknownGetter });
+    Object.defineProperty(pricing, Symbol('unknown'), { get: symbolGetter });
+    const event = eventWithPricing(pricing);
+    Object.defineProperty(event, 'unknown', { get: eventGetter });
+
+    expect(pickPriceCents(event, 'nonMember')).toBe(5000);
+    expect(eventGetter).not.toHaveBeenCalled();
+    expect(unselectedGetter).not.toHaveBeenCalled();
+    expect(unknownGetter).not.toHaveBeenCalled();
+    expect(symbolGetter).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Outcome

Fail closed when a selected race price cannot be sent safely through the fixed-USD Stripe Checkout path.

- Free `0` remains the local no-Stripe path.
- A paid value must be a direct primitive whole number from `50` through `99,999,999` cents.
- Missing, malformed, coerced, accessor-backed, inherited, Proxy, sub-minimum, and nine-digit values become unavailable.
- The fixed public error remains unchanged and contains no stored value.
- After this denial, the server creates no confirmation token, registration ID/write, Stripe client, Product, or Checkout Session.

This is the atomic PAY-001B1B child of #219. It does not complete the immutable event/price snapshot or checkout saga.

## Changes

1. Harden `pickPriceCents` with fail-closed plain-record, own-data, type, USD minimum, and provider-maximum checks.
2. Add an exhaustive helper matrix for numeric bounds, wrong types, accessors, inheritance, Proxies, coercion hooks, and hostile unselected fields.
3. Wire the real helper and early-bird check into the existing callable harness.
4. Make Product creation and registration auto-ID allocation observable in the caller regression.
5. Add the complete plain-language `Race price format guard — SOURCE ONLY, NOT LIVE` officer procedure.

## Security boundary and residual risk

The exact selected-price helper and its later caller side effects are covered. Existing earlier `resolvePriceTier`, early-bird, and other event-record reads are explicitly outside this child and remain follow-up work. Earlier rate-limit, role, membership, and capacity checks may already run before this price denial.

No live record should be repaired by hand. Private inventory and any repair remain #113; later deployment requires a separately approved protected release, isolated Firebase proof, and Stripe test-mode/readback proof.

## Verification

Exact reviewed source commit: `62e6278a8af731303131a1f4846a75b6543fd009`

Exact four-file diff SHA-256: `cdcaabdfe82c8f3bc82f0097110688861472f1870492e9e58b9e5fa936486b06`

- RED test-only hash `296d78e...`: 41 intended failures; the old caller invoked the selected accessor and reached synthetic registration allocation, Product, and Session behavior.
- Focused selected-price/caller tests: 46/46.
- Full affected suites: 132/132.
- Node 20 Functions: 2,353 active passed; 64 intentionally skipped.
- Functions lint: passed.
- Real Firestore commerce emulator: 63/63 on demo-only project `demo-pay002b2-test` with Java 17.
- Frontend Jest: 487/487.
- Frontend lint ledger: 106 files / 123 reviewed errors / 7 reviewed warnings.
- SPA safety: 11/11.
- Workflow/release/artifact safety: 42/42; root dependency safety: 4/4.
- Firestore Rules emulator: 378/378 on demo-only project `demo-rules-test`.
- TypeScript, diagnostic build, and diff check: passed.
- Officer-guide relative links: 9/9.
- Three independent FINAL/STABLE reviews approved the exact hash with no findings.

Hosted PR checks are required before merge.

## Delivery truth

Officer impact: Backup officers gain one short stop-and-escalate source-review procedure. No verified live officer or runner behavior changes in this pull request.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — only `Race price format guard — SOURCE ONLY, NOT LIVE`.

Deployment evidence: Source and local synthetic checks only at PR creation. No website publication, `runmprc.com` verification, Firebase deployment, Stripe/provider action, production-data action, migration, or live-behavior proof occurred.

Closes #327
