### PR TITLE
OAUTH-001C1F — Atomically persist successful Strava exchange state

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -462,6 +462,54 @@ Officer review steps after the source merge:
 
 No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
 
+## Strava connection record pairing — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** keep the server-only Strava token record and its matching non-secret connection record together. A database failure must save both records or neither record.
+
+**Approver:** membership lead plus platform/security owner. Add the privacy owner if an earlier record may already be mismatched.
+
+**Prerequisites:** issue [#329](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/329) must be merged for source review. Use only a made-up website account, made-up athlete, mocked Strava response, and mocked database. Calling this protection live also requires an approved Firebase Functions deployment and a dated deployment readback. This source change does not contact Strava, inspect or repair production records, change provider settings, or prove live behavior.
+
+```mermaid
+flowchart LR
+    A["Validated made-up Strava exchange"] --> B["One Firestore batch"]
+    B -- "Commit is confirmed" --> C["Server-only token and matching connection metadata appear together"]
+    B -- "Confirmed before commit" --> D["Neither record changes; fixed failure result"]
+    B -- "Commit result is unavailable" --> F["Both or neither may be present; stop and verify safely"]
+    E["Strava provider exchange happened first"] -. "Not part of the Firestore batch" .-> B
+```
+
+Text alternative: after a made-up Strava response is validated, one Firestore batch saves the hidden token record and matching connection metadata together. A confirmed failure before commit changes neither record. If the commit result is unavailable, both records may be present or neither may be present; one record must never appear alone. Stop and use the normal safe connection check. The earlier Strava provider exchange is outside that local batch.
+
+Officer review steps after the source merge:
+
+1. Keep this protection marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for issue #329, the reviewed pull request, the merged commit, and synthetic test results.
+3. Confirm every test uses only made-up values and mocked Strava and database results.
+4. Confirm a successful mock creates one batch with exactly two paired record writes.
+5. Confirm a mocked failure before commit changes neither record.
+6. Confirm the same failure preserves an earlier matched pair without replacing only one side.
+7. Confirm a mocked lost commit result can leave both records together, never only one.
+8. Confirm every persistence failure gives only `Strava authorization could not be completed.`
+9. Confirm no token, athlete detail, database path, rejected value, or technical error appears in the result or logs.
+10. Confirm an unknown commit result says to stop and use the normal safe connection check. Do not repeat the old code.
+11. Confirm the browser never receives or edits the token record.
+12. Record source, tests, review, merge, Firebase deployment, provider configuration, production-data action, repair, and live behavior as separate results.
+
+**Expected result:** reviewed source uses one database batch for the two records, so Firestore applies both or neither. A confirmed failure before commit changes neither record. A lost or rejected commit result can leave the caller unsure whether both records changed or neither changed. It must never be described as proof of no change. Every returned persistence failure uses one fixed sentence. The officer stops and asks the platform owner to verify through the normal safe connection surface before any fresh connection start.
+
+This source slice does not make the provider exchange and Firestore one transaction. It does not make a repeated authorization code safe, decide which concurrent connection wins, verify one athlete per website account, approve scopes, repair an earlier mismatch, revoke access, add a durable audit, configure the provider, deploy Firebase, or prove live behavior. Those items remain under issue #88 and the private inventory in #113.
+
+**Stop conditions:** any real member, Strava account, athlete, token, authorization code, provider response, database record, or production data; a request to inspect or repair Firestore manually; a real provider call; a Firebase or Strava setting change; a raw detail in a result or log; an attempt to repeat a failed code; a claim that an unknown commit result proves no change; or a claim that source, tests, merge, preview, or green CI proves this protection is live.
+
+**Success proof:** for source completion, record issue #329, the exact reviewed pull request and merge, the old-source partial-write failure, green synthetic atomicity tests, relevant full checks, and independent security, test, and officer reviews. For live availability, separately record an approved Firebase Functions deployment and a dated exact-revision readback. Record website publication, `runmprc.com`, Strava/provider configuration, production-data access, migration, repair, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before deployment, use one reviewed Functions-and-guide revert or safe replacement. After any later approved deployment, use the protected Firebase rollback path and verify the replacement revision. Never undo by editing, deleting, copying, or recreating a token or connection record.
+
+**Escalation:** membership lead plus platform/security owner. Add the privacy owner and use the private incident path if a token, athlete detail, provider response, database path, or mismatched record may have appeared. Do not copy that detail into an issue, screenshot, message, email, or AI tool.
+
 ## Strava activity failure privacy — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/functions/strava.js
+++ b/functions/strava.js
@@ -516,14 +516,14 @@ function getStravaCreds() {
   return { clientId, clientSecret };
 }
 
-function connectionDocRef(uid) {
-  return admin.firestore()
+function connectionDocRef(uid, db = admin.firestore()) {
+  return db
     .collection('members').doc(uid)
     .collection('connections').doc('strava');
 }
 
-function secretDocRef(uid) {
-  return admin.firestore()
+function secretDocRef(uid, db = admin.firestore()) {
+  return db
     .collection('members').doc(uid)
     .collection('secrets').doc('strava');
 }
@@ -636,24 +636,30 @@ exports.stravaExchangeCode = functions
 
     const exchange = await exchangeCode(code);
 
-    await secretDocRef(uid).set({
-      access_token: exchange.accessToken,
-      refresh_token: exchange.refreshToken,
-      expires_at: exchange.expiresAt,
-      scope: exchange.scope,
-      updatedAt: Timestamp.now(),
-    }, { merge: true });
-
-    await connectionDocRef(uid).set({
-      provider: 'strava',
-      athleteId: exchange.athlete.id,
-      firstName: exchange.athlete.firstName,
-      lastName: exchange.athlete.lastName,
-      username: exchange.athlete.username,
-      profileUrl: exchange.athlete.profileUrl,
-      connectedAt: Timestamp.now(),
-      updatedAt: Timestamp.now(),
-    }, { merge: true });
+    try {
+      const db = admin.firestore();
+      const batch = db.batch();
+      batch.set(secretDocRef(uid, db), {
+        access_token: exchange.accessToken,
+        refresh_token: exchange.refreshToken,
+        expires_at: exchange.expiresAt,
+        scope: exchange.scope,
+        updatedAt: Timestamp.now(),
+      }, { merge: true });
+      batch.set(connectionDocRef(uid, db), {
+        provider: 'strava',
+        athleteId: exchange.athlete.id,
+        firstName: exchange.athlete.firstName,
+        lastName: exchange.athlete.lastName,
+        username: exchange.athlete.username,
+        profileUrl: exchange.athlete.profileUrl,
+        connectedAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      }, { merge: true });
+      await batch.commit();
+    } catch (_error) {
+      throw stravaAuthorizationError('internal');
+    }
 
     return { ok: true, athleteId: exchange.athlete.id };
   });

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -18,14 +18,28 @@ jest.mock('firebase-functions', () => {
 });
 
 jest.mock('firebase-admin', () => {
+  let batchCommitFailure;
+  let batchCommitPostApplyFailure;
+  let batchCreateAttempts = 0;
+  let batchCreationFailure;
+  const batchCommitAttempts = [];
+  const batchSetAttempts = [];
+  const batchSetFailures = new Map();
   const deleteFailures = new Map();
   const deletes = [];
+  const directSetAttempts = [];
   const documents = new Map();
   const reads = [];
+  const writeFailures = new Map();
   const writes = [];
+
+  function applyWrite(operation) {
+    writes.push(operation);
+  }
 
   function document(path) {
     return {
+      path,
       collection: (name) => ({
         doc: (id) => document(`${path}/${name}/${id}`),
       }),
@@ -45,29 +59,100 @@ jest.mock('firebase-admin', () => {
         };
       },
       set: async (data, options) => {
-        writes.push({ path, data, options });
+        const operation = { path, data, options };
+        directSetAttempts.push(operation);
+        if (writeFailures.has(path)) {
+          throw writeFailures.get(path);
+        }
+        applyWrite(operation);
       },
     };
   }
 
-  return {
-    firestore: () => ({
+  function firestore() {
+    return {
+      batch: () => {
+        batchCreateAttempts += 1;
+        if (batchCreationFailure) {
+          throw batchCreationFailure;
+        }
+        const staged = [];
+        const batch = {
+          set: (ref, data, options) => {
+            const operation = { path: ref.path, data, options };
+            batchSetAttempts.push(operation);
+            if (batchSetFailures.has(ref.path)) {
+              throw batchSetFailures.get(ref.path);
+            }
+            staged.push(operation);
+            return batch;
+          },
+          commit: async () => {
+            batchCommitAttempts.push([...staged]);
+            if (batchCommitFailure) {
+              throw batchCommitFailure;
+            }
+            for (const operation of staged) {
+              if (writeFailures.has(operation.path)) {
+                throw writeFailures.get(operation.path);
+              }
+            }
+            staged.forEach(applyWrite);
+            if (batchCommitPostApplyFailure) {
+              throw batchCommitPostApplyFailure;
+            }
+          },
+        };
+        return batch;
+      },
       collection: (name) => ({
         doc: (id) => document(`${name}/${id}`),
       }),
-    }),
+    };
+  }
+
+  return {
+    firestore,
     __clearDeletes: () => {
       deleteFailures.clear();
       deletes.splice(0, deletes.length);
     },
     __clearDocuments: () => documents.clear(),
     __clearReads: () => reads.splice(0, reads.length),
-    __clearWrites: () => writes.splice(0, writes.length),
+    __clearWrites: () => {
+      batchCommitFailure = undefined;
+      batchCommitPostApplyFailure = undefined;
+      batchCreateAttempts = 0;
+      batchCreationFailure = undefined;
+      batchCommitAttempts.splice(0, batchCommitAttempts.length);
+      batchSetAttempts.splice(0, batchSetAttempts.length);
+      batchSetFailures.clear();
+      directSetAttempts.splice(0, directSetAttempts.length);
+      writeFailures.clear();
+      writes.splice(0, writes.length);
+    },
+    __getBatchCommitAttempts: () => [...batchCommitAttempts],
+    __getBatchCreateAttempts: () => batchCreateAttempts,
+    __getBatchSetAttempts: () => [...batchSetAttempts],
     __getDeletes: () => [...deletes],
+    __getDirectSetAttempts: () => [...directSetAttempts],
+    __getDocument: (path) => documents.get(path),
     __getReads: () => [...reads],
     __getWrites: () => [...writes],
+    __hasDocument: (path) => documents.has(path),
+    __setBatchCommitFailure: (error) => {
+      batchCommitFailure = error;
+    },
+    __setBatchCommitPostApplyFailure: (error) => {
+      batchCommitPostApplyFailure = error;
+    },
+    __setBatchCreationFailure: (error) => {
+      batchCreationFailure = error;
+    },
+    __setBatchSetFailure: (path, error) => batchSetFailures.set(path, error),
     __setDeleteFailure: (path, error) => deleteFailures.set(path, error),
     __setDocument: (path, data) => documents.set(path, data),
+    __setWriteFailure: (path, error) => writeFailures.set(path, error),
   };
 });
 
@@ -191,6 +276,78 @@ describe('Strava authorization exchange failure boundary', () => {
 
   function mockSuccessfulExchange() {
     return mockExchangeResponse(validExchangeResponse());
+  }
+
+  function expectedExchangeWrites() {
+    return [
+      {
+        path: SECRET_PATH,
+        data: {
+          access_token: 'access_token_test',
+          refresh_token: 'refresh_token_test',
+          expires_at: 1_900_000_000,
+          scope: 'read',
+          updatedAt: expect.any(Object),
+        },
+        options: { merge: true },
+      },
+      {
+        path: CONNECTION_PATH,
+        data: {
+          provider: 'strava',
+          athleteId: 123456,
+          firstName: 'Synthetic',
+          lastName: 'Athlete',
+          username: 'synthetic-athlete',
+          profileUrl: 'https://images.example.test/synthetic-athlete.png',
+          connectedAt: expect.any(Object),
+          updatedAt: expect.any(Object),
+        },
+        options: { merge: true },
+      },
+    ];
+  }
+
+  function hostilePersistenceFailure() {
+    const failure = Object.create(null);
+    const probes = ['cause', 'code', 'details', 'message', 'stack', 'toString']
+      .map((key) => {
+        const probe = jest.fn(() => `persistence-canary-${key}`);
+        Object.defineProperty(failure, key, {
+          configurable: false,
+          enumerable: true,
+          get: probe,
+        });
+        return probe;
+      });
+    return { failure, probes };
+  }
+
+  async function expectFixedPersistenceFailure(configure) {
+    const { failure, probes } = hostilePersistenceFailure();
+    configure(failure);
+    const json = mockSuccessfulExchange();
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+    const exposed = publicError(error);
+
+    expect(exposed).toEqual({
+      code: 'internal',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(exposed)).not.toContain('persistence-canary');
+    probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(admin.__getDirectSetAttempts()).toEqual([]);
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__hasDocument(SECRET_PATH)).toBe(false);
+    expect(admin.__hasDocument(CONNECTION_PATH)).toBe(false);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   }
 
   async function expectInvalidSuccessfulResponse(response) {
@@ -855,6 +1012,109 @@ describe('Strava authorization exchange failure boundary', () => {
     });
   });
 
+  test.each([
+    [
+      'batch construction',
+      (failure) => admin.__setBatchCreationFailure(failure),
+    ],
+    [
+      'secret staging',
+      (failure) => admin.__setBatchSetFailure(SECRET_PATH, failure),
+    ],
+    [
+      'connection staging',
+      (failure) => admin.__setBatchSetFailure(CONNECTION_PATH, failure),
+    ],
+    [
+      'pre-apply batch commit',
+      (failure) => admin.__setBatchCommitFailure(failure),
+    ],
+  ])('maps %s failure to one fixed error and commits neither document', async (
+    _stage,
+    configure,
+  ) => {
+    await expectFixedPersistenceFailure(configure);
+  });
+
+  test.each([
+    ['a first connection', false],
+    ['a reconnect with an existing matched pair', true],
+  ])('keeps both records unchanged when %s has a pre-apply rejection', async (
+    _name,
+    seedExisting,
+  ) => {
+    const previousSecret = Object.freeze({ marker: 'previous-secret-record' });
+    const previousConnection = Object.freeze({ marker: 'previous-connection-record' });
+    if (seedExisting) {
+      admin.__setDocument(SECRET_PATH, previousSecret);
+      admin.__setDocument(CONNECTION_PATH, previousConnection);
+    }
+    const { failure, probes } = hostilePersistenceFailure();
+    admin.__setWriteFailure(CONNECTION_PATH, failure);
+    const json = mockSuccessfulExchange();
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+    const exposed = publicError(error);
+    const expectedWrites = expectedExchangeWrites();
+
+    expect(admin.__getWrites()).toEqual([]);
+    if (seedExisting) {
+      expect(admin.__getDocument(SECRET_PATH)).toBe(previousSecret);
+      expect(admin.__getDocument(CONNECTION_PATH)).toBe(previousConnection);
+    } else {
+      expect(admin.__hasDocument(SECRET_PATH)).toBe(false);
+      expect(admin.__hasDocument(CONNECTION_PATH)).toBe(false);
+    }
+    expect(exposed).toEqual({
+      code: 'internal',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(exposed)).not.toContain('persistence-canary');
+    probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(admin.__getBatchCreateAttempts()).toBe(1);
+    expect(admin.__getBatchSetAttempts()).toEqual(expectedWrites);
+    expect(admin.__getBatchCommitAttempts()).toEqual([expectedWrites]);
+    expect(admin.__getDirectSetAttempts()).toEqual([]);
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(Timestamp.now).toHaveBeenCalledTimes(3);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('keeps an acknowledgement-lost outcome atomic and returns one fixed error', async () => {
+    const { failure, probes } = hostilePersistenceFailure();
+    admin.__setBatchCommitPostApplyFailure(failure);
+    const json = mockSuccessfulExchange();
+
+    const error = await captureFailure(() => stravaExchangeCode({ code: CODE }, CONTEXT));
+    const exposed = publicError(error);
+    const expectedWrites = expectedExchangeWrites();
+
+    expect(admin.__getWrites()).toEqual(expectedWrites);
+    expect(admin.__getBatchCreateAttempts()).toBe(1);
+    expect(admin.__getBatchSetAttempts()).toEqual(expectedWrites);
+    expect(admin.__getBatchCommitAttempts()).toEqual([expectedWrites]);
+    expect(admin.__getDirectSetAttempts()).toEqual([]);
+    expect(exposed).toEqual({
+      code: 'internal',
+      message: FIXED_AUTHORIZATION_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(JSON.stringify(exposed)).not.toContain('persistence-canary');
+    probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(Timestamp.now).toHaveBeenCalledTimes(3);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
   test('preserves the successful server-only exchange, writes, and minimal result', async () => {
     const json = mockSuccessfulExchange();
 
@@ -877,33 +1137,12 @@ describe('Strava authorization exchange failure boundary', () => {
       },
     );
     expect(json).toHaveBeenCalledTimes(1);
-    expect(admin.__getWrites()).toEqual([
-      {
-        path: 'members/synthetic-member-000001/secrets/strava',
-        data: {
-          access_token: 'access_token_test',
-          refresh_token: 'refresh_token_test',
-          expires_at: 1_900_000_000,
-          scope: 'read',
-          updatedAt: expect.any(Object),
-        },
-        options: { merge: true },
-      },
-      {
-        path: 'members/synthetic-member-000001/connections/strava',
-        data: {
-          provider: 'strava',
-          athleteId: 123456,
-          firstName: 'Synthetic',
-          lastName: 'Athlete',
-          username: 'synthetic-athlete',
-          profileUrl: 'https://images.example.test/synthetic-athlete.png',
-          connectedAt: expect.any(Object),
-          updatedAt: expect.any(Object),
-        },
-        options: { merge: true },
-      },
-    ]);
+    const expectedWrites = expectedExchangeWrites();
+    expect(admin.__getBatchCreateAttempts()).toBe(1);
+    expect(admin.__getBatchSetAttempts()).toEqual(expectedWrites);
+    expect(admin.__getBatchCommitAttempts()).toEqual([expectedWrites]);
+    expect(admin.__getWrites()).toEqual(expectedWrites);
+    expect(admin.__getDirectSetAttempts()).toEqual([]);
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getDeletes()).toEqual([]);
     expect(Timestamp.now).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Outcome

A validated Strava exchange now persists its hidden token record and matching connection metadata in one Firestore batch. Firestore applies both writes or neither; the old secret-first partial-write path is removed.

A lost or rejected commit acknowledgement is still an unknown all-or-neither result. The client gets one fixed failure and must not replay the old authorization code.

## Changes

- Use one same-database WriteBatch for the two existing UID-derived merge writes.
- Map construction, staging, and commit failures to the fixed authorization error without reading or logging the caught value.
- Extend the Firebase Admin mock to distinguish staged operations, commit attempts, successfully applied writes, deterministic pre-apply rejection, and post-apply acknowledgement loss.
- Add RED/green first-connect, reconnect, redaction, and exact-success compatibility coverage.
- Add the plain-language source-only officer procedure and diagram.

## Verification

- Strava: 486/486
- Functions: 2,360 active pass / 64 skipped; lint pass
- Frontend: 487/487
- Rules emulator: 378/378
- Commerce Firestore emulator: 63/63
- SPA: 11/11
- Repository safety: 46/46
- Lint ledger: 106 files / 123 reviewed errors / 7 reviewed warnings
- TypeScript/build/diff-check: pass
- Three independent exact-diff reviews: approved

Exact source head: `2c817e678f5466400fc2e3ed818787045b42a7b1`  
Exact diff SHA-256: `56bbf4bef1173f95bbf3a32557f2b828f033d82b605bd949e8b848d3c0d3b084`

## Residual boundaries

The provider exchange happens before the Firestore batch and cannot be part of it. Lost-response reconciliation, replay/idempotency, concurrent exchange policy, state binding, athlete uniqueness, scope, refresh concurrency, revocation/audit, IAM/encryption, existing-record inventory/repair, provider configuration, deployment, and live proof remain with the canonical Strava tracker and private inventory work.

## Officer impact

Officers get a simple source-only explanation of the paired-record boundary, the unknown-result stop rule, and the instruction never to repair Firestore or replay an old code.

## Officer documentation

`docs/officers/EVENTS_SHOP_MEMBERS.md`

## Deployment evidence

Source, tests, reviews, and this pull request only. Website publication, `runmprc.com`, Firebase Functions deployment, Firestore/Strava provider configuration, production data, migration/repair, and live behavior were not performed or verified.

Closes #329
