### PR TITLE
PAY-001D1A: fail closed on malformed late-registration amounts

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -235,6 +235,50 @@ Officer source-review steps:
 
 **Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if any submitted person or event detail appears in output.
 
+## Late-registration amount format guard — SOURCE ONLY, NOT LIVE
+
+**Purpose:** stop a missing, malformed, or out-of-range late-registration amount before the server allocates a registration identifier, writes a paid record, or asks Stripe to create a Product, Price, or Payment Link.
+
+**Approver:** event lead plus treasurer and platform/security owner.
+
+**Prerequisites for source review:** issue [#331](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/331) is merged; the exact reviewed commit is named; and tests use only an invented event, invented runner, and mocked Stripe methods. The complete Admin screens remain **NOT AVAILABLE YET**. The private inventory in [#113](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/113) is required before any deployment or data repair. PAY-001D still owns the complete admin request schema, and PAY-004C still owns replacement of reusable late-registration Payment Links. This format guard does not approve a price or make that flow safe.
+
+```mermaid
+flowchart LR
+    A["Made-up late-registration request passes earlier access and availability checks"] --> B["Read the amount without conversion"]
+    B --> C{"Exact whole-number cents?"}
+    C -- "No, below 50 unless zero, or over eight digits" --> D["Fixed stop result; no identifier, registration write, or Stripe method"]
+    C -- "Exact zero" --> E["Existing path creates a local record marked paid without Stripe"]
+    C -- "50 through 99,999,999" --> F["Existing unfinished paid path may continue"]
+    E -. "Not payment, free, or comp authority; not live" .-> G["PAY-001D and PAY-004 remain open"]
+    F -. "Reusable Payment Link remains unsafe" .-> G
+```
+
+Text alternative: after earlier access and availability checks, the server accepts only exact whole-number cents: zero, or 50 through 99,999,999. Anything else stops before an identifier, registration write, or Stripe method. Exact zero still creates a local record marked paid without Stripe; that is not proof of payment or authority to call the registration free or comp. Both accepted branches are unfinished and unavailable for officer use.
+
+Officer source-review steps:
+
+1. Keep late registration and every Admin registration action marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #331 pull request, merge commit, and synthetic test result.
+3. Confirm the test uses only an invented event and runner plus mocked Stripe methods.
+4. Confirm missing values, text or objects that only look like numbers, values from 1 through 49 cents, fractions, negative values, and values over eight digits receive exactly `Invalid late registration amount`.
+5. Confirm a rejected amount is not opened, transformed, printed, or copied into the result. Ask the specialist to keep the detailed object-safety proof in the synthetic test report.
+6. Confirm a rejection allocates no registration identifier, writes no event or registration record, and calls no Stripe Product, Price, or Payment Link method.
+7. Confirm exact zero, 50 cents, and 99,999,999 cents keep their current source behavior. Exact zero still creates a local record marked paid without Stripe. Do not treat that record as payment evidence, call it free or comp without approved authority, or treat any technical boundary as an approved price.
+8. Record source change, tests, merge, website publication, `runmprc.com`, Firebase deployment, Stripe/provider state, production data, and live behavior as separate results.
+
+**Expected result:** malformed late-registration amounts fail closed with one plain result and no registration or provider side effect. Exact zero and exact whole-number values from 50 through 99,999,999 retain the current source behavior. The zero-amount path still creates a local record marked paid without Stripe and is not payment, free, or comp authority. This guard neither proves an approved business price nor fixes reusable Payment Links, capacity, idempotency, reconciliation, authorization, or deployment.
+
+**Stop conditions:** any real runner, event, price, payment, Firebase record, Stripe object, provider call, or production test; a request to enter or repair a value directly in Firestore or Stripe; a missing exact commit; an amount derived from an unapproved browser choice; a rejection that allocates or writes anything; or a claim that source, tests, merge, preview, or a green workflow proves late registration is safe or live.
+
+**Success proof:** exact #331 pull request and merge commit; the recorded old-source failures; green synthetic boundary, Functions, Rules, commerce-emulator, frontend, safety, and build checks; independent security, compatibility, and backup-officer reviews; and a written statement that website publication, `runmprc.com`, Firebase, Stripe, provider configuration, production data, and live behavior were not changed or verified. Any future live release needs separate approved price authority, one-off payment design, Firebase deployment/readback, Stripe test-mode proof, reconciliation, and rollback evidence.
+
+**Undo:** before any Firebase deployment, use one reviewed source-and-guide revert or safe roll-forward. After any Firebase Function deployment, use the protected backend release path or a reviewed safe roll-forward, then verify the exact Function revision, provider readback boundary, and made-up test-mode behavior. Record website publication, `runmprc.com`, Stripe/provider state, and production-data state separately. Never undo by changing an event, registration, paid status, Product, Price, Payment Link, or payment record by hand.
+
+**Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if runner or event details appeared. Use the private incident path if a malformed request might have created a registration or provider object. Do not copy private details or provider identifiers into an issue, screenshot, email, message, or AI tool.
+
+No system-topology map changes are required because this source slice adds one validation stop and changes no account, permission, data-store, provider, or deployment topology. The small diagram above records the new stop boundary and the two still-unfinished accepted branches.
+
 ## Profile permission error
 
 **Status: AUTOMATIC REPAIR NOT LIVE YET**

--- a/functions/adminRegistrationAction.js
+++ b/functions/adminRegistrationAction.js
@@ -25,6 +25,13 @@ const {
   validateSucceededRefundResponse,
 } = require('./refundResponseValidation');
 
+const numberIsSafeInteger = Number.isSafeInteger;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwn = Object.hasOwn;
+const objectIs = Object.is;
+const STRIPE_MINIMUM_USD_CENTS = 50;
+const STRIPE_UNIT_AMOUNT_MAX_CENTS = 99_999_999;
+
 const ACTIONS = new Set([
   'refund_full',
   'refund_partial',
@@ -39,6 +46,24 @@ function regRef(eventId, registrationId) {
   return admin.firestore()
     .collection('events').doc(eventId)
     .collection('registrations').doc(registrationId);
+}
+
+function readLateRegistrationAmountCents(registration) {
+  const descriptor = objectGetOwnPropertyDescriptor(registration, 'amountCents');
+  if (!descriptor || !objectHasOwn(descriptor, 'value')) return null;
+
+  const amountCents = descriptor.value;
+  if (
+    typeof amountCents !== 'number'
+    || !numberIsSafeInteger(amountCents)
+    || objectIs(amountCents, -0)
+    || amountCents < 0
+    || (amountCents !== 0 && amountCents < STRIPE_MINIMUM_USD_CENTS)
+    || amountCents > STRIPE_UNIT_AMOUNT_MAX_CENTS
+  ) {
+    return null;
+  }
+  return amountCents;
 }
 
 async function refund({
@@ -193,7 +218,13 @@ async function addLateRegistration({
   if (!registration || !isValidEmail(registration.runner?.email)) {
     throw new functions.https.HttpsError('invalid-argument', 'registration.runner.email required');
   }
-  const amountCents = Number(registration.amountCents) || 0;
+  const amountCents = readLateRegistrationAmountCents(registration);
+  if (amountCents === null) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'Invalid late registration amount',
+    );
+  }
   const priceTier = registration.priceTier || 'nonMember';
 
   const event = eventSnap.data();

--- a/functions/commerceControlEntryPoints.test.js
+++ b/functions/commerceControlEntryPoints.test.js
@@ -98,6 +98,7 @@ jest.mock('firebase-admin', () => {
     },
     __seed: (path, data) => store.set(path, { ...data }),
     __get: (path) => store.get(path),
+    __getAutoIdCount: () => autoId,
   };
 });
 
@@ -147,6 +148,70 @@ function registrationInput(amountCents) {
     priceTier: amountCents === 0 ? 'comp' : 'nonMember',
   };
 }
+
+function lateRegistrationCase(amountCents) {
+  return {
+    registration: registrationInput(amountCents),
+    assertUninspected: () => {},
+  };
+}
+
+const INVALID_LATE_REGISTRATION_AMOUNTS = [
+  ['missing', () => {
+    const registration = registrationInput(0);
+    delete registration.amountCents;
+    return { registration, assertUninspected: () => {} };
+  }],
+  ['undefined', () => lateRegistrationCase(undefined)],
+  ['null', () => lateRegistrationCase(null)],
+  ['false', () => lateRegistrationCase(false)],
+  ['empty string', () => lateRegistrationCase('')],
+  ['whitespace string', () => lateRegistrationCase('   ')],
+  ['nonnumeric string', () => lateRegistrationCase('fifty')],
+  ['numeric string', () => lateRegistrationCase('50')],
+  ['negative zero', () => lateRegistrationCase(-0)],
+  ['negative integer', () => lateRegistrationCase(-1)],
+  ['one cent', () => lateRegistrationCase(1)],
+  ['forty-nine cents', () => lateRegistrationCase(49)],
+  ['fraction', () => lateRegistrationCase(50.5)],
+  ['NaN', () => lateRegistrationCase(Number.NaN)],
+  ['positive infinity', () => lateRegistrationCase(Number.POSITIVE_INFINITY)],
+  ['negative infinity', () => lateRegistrationCase(Number.NEGATIVE_INFINITY)],
+  ['over the eight-digit ceiling', () => lateRegistrationCase(100_000_000)],
+  ['unsafe integer', () => lateRegistrationCase(Number.MAX_SAFE_INTEGER + 1)],
+  ['BigInt', () => lateRegistrationCase(BigInt(50))],
+  ['boxed number', () => lateRegistrationCase(Object(50))],
+  ['array', () => lateRegistrationCase([50])],
+  ['plain record', () => lateRegistrationCase({ cents: 50 })],
+  ['accessor-backed amount field', () => {
+    const amountGetter = jest.fn(() => 50);
+    const registration = registrationInput(0);
+    Object.defineProperty(registration, 'amountCents', {
+      enumerable: true,
+      get: amountGetter,
+    });
+    return {
+      registration,
+      assertUninspected: () => expect(amountGetter).not.toHaveBeenCalled(),
+    };
+  }],
+  ['coercible amount object', () => {
+    const coercionHook = jest.fn(() => 50);
+    const amount = { [Symbol.toPrimitive]: coercionHook };
+    return {
+      registration: registrationInput(amount),
+      assertUninspected: () => expect(coercionHook).not.toHaveBeenCalled(),
+    };
+  }],
+  ['proxied amount object', () => {
+    const getTrap = jest.fn((target, key, receiver) => Reflect.get(target, key, receiver));
+    const amount = new Proxy({ valueOf: () => 50 }, { get: getTrap });
+    return {
+      registration: registrationInput(amount),
+      assertUninspected: () => expect(getTrap).not.toHaveBeenCalled(),
+    };
+  }],
+];
 
 const REFUND_ENTRY_POINTS = [
   {
@@ -413,6 +478,7 @@ describe('commerce admission at admin entry points', () => {
     ['mark_comp', registrationInput(0)],
     ['add_late_registration', registrationInput(0)],
     ['add_late_registration', registrationInput(2500)],
+    ['add_late_registration', registrationInput(undefined)],
   ])('blocks admin %s before registration or Stripe work', async (action, registration) => {
     admin.__seed('systemConfig/commerce', control({ newCommerceEnabled: false }));
     admin.__seed('events/race-1', {
@@ -470,6 +536,130 @@ describe('commerce admission at admin entry points', () => {
     expect(mockProductCreate).toHaveBeenCalledTimes(expectedProviderCreates);
     expect(mockPriceCreate).toHaveBeenCalledTimes(expectedProviderCreates);
     expect(mockPaymentLinkCreate).toHaveBeenCalledTimes(expectedProviderCreates);
+  });
+
+  test.each(INVALID_LATE_REGISTRATION_AMOUNTS)(
+    'rejects %s late-registration amount before allocation, writes, or provider methods',
+    async (_caseName, buildCase) => {
+      admin.__seed('systemConfig/commerce', control());
+      admin.__seed('events/race-1', {
+        checkoutEnabled: true,
+        title: 'Synthetic Race',
+        slug: 'synthetic-race',
+        stripeProductId: 'prod_synthetic',
+      });
+      const { registration, assertUninspected } = buildCase();
+      const consoleSpies = ['debug', 'error', 'info', 'log', 'warn'].map((method) => (
+        jest.spyOn(console, method).mockImplementation(() => {})
+      ));
+      const randomBytesSpy = jest.spyOn(require('crypto'), 'randomBytes')
+        .mockReturnValue(Buffer.alloc(24, 1));
+
+      try {
+        let rejectedError;
+        try {
+          await adminRegistrationAction({
+            eventId: 'race-1',
+            action: 'add_late_registration',
+            payload: { registration },
+          }, adminContext());
+        } catch (error) {
+          rejectedError = error;
+        }
+
+        assertUninspected();
+        expect(rejectedError).toMatchObject({
+          code: 'invalid-argument',
+          message: 'Invalid late registration amount',
+        });
+        expect(admin.__getAutoIdCount()).toBe(0);
+        expect(randomBytesSpy).not.toHaveBeenCalled();
+        expect(mockBusinessWrite).not.toHaveBeenCalled();
+        expect(mockProductCreate).not.toHaveBeenCalled();
+        expect(mockPriceCreate).not.toHaveBeenCalled();
+        expect(mockPaymentLinkCreate).not.toHaveBeenCalled();
+        consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+      } finally {
+        randomBytesSpy.mockRestore();
+        consoleSpies.forEach((spy) => spy.mockRestore());
+      }
+    },
+  );
+
+  test.each([
+    ['free zero', 0, null],
+    ['Stripe minimum', 50, 'https://buy.stripe.test/synthetic'],
+    ['eight-digit ceiling', 99_999_999, 'https://buy.stripe.test/synthetic'],
+  ])('preserves exact valid late-registration %s amount', async (
+    _caseName,
+    amountCents,
+    expectedPaymentLink,
+  ) => {
+    admin.__seed('systemConfig/commerce', control());
+    admin.__seed('events/race-1', {
+      checkoutEnabled: true,
+      title: 'Synthetic Race',
+      slug: 'synthetic-race',
+      stripeProductId: 'prod_synthetic',
+      waiverVersion: 'synthetic-v1',
+    });
+
+    await expect(adminRegistrationAction({
+      eventId: 'race-1',
+      action: 'add_late_registration',
+      payload: { registration: registrationInput(amountCents) },
+    }, adminContext())).resolves.toEqual({
+      ok: true,
+      registrationId: 'auto-1',
+      paymentLink: expectedPaymentLink,
+    });
+
+    expect(admin.__getAutoIdCount()).toBe(1);
+    expect(admin.__get('events/race-1/registrations/auto-1')).toMatchObject({
+      eventId: 'race-1',
+      amountCents,
+      status: amountCents === 0 ? 'paid' : 'pending',
+    });
+    expect(mockBusinessWrite).toHaveBeenCalledTimes(1);
+    expect(mockBusinessWrite).toHaveBeenCalledWith(
+      'set',
+      'events/race-1/registrations/auto-1',
+      expect.objectContaining({
+        eventId: 'race-1',
+        amountCents,
+        priceTier: amountCents === 0 ? 'comp' : 'nonMember',
+        stripePaymentLinkId: amountCents === 0 ? null : 'plink_synthetic',
+      }),
+    );
+    expect(mockProductCreate).not.toHaveBeenCalled();
+    expect(mockPriceCreate).toHaveBeenCalledTimes(amountCents === 0 ? 0 : 1);
+    expect(mockPaymentLinkCreate).toHaveBeenCalledTimes(amountCents === 0 ? 0 : 1);
+    if (amountCents !== 0) {
+      const metadata = {
+        eventId: 'race-1',
+        registrationId: 'auto-1',
+        priceTier: 'nonMember',
+        late_add: 'true',
+      };
+      expect(mockPriceCreate).toHaveBeenCalledWith({
+        unit_amount: amountCents,
+        currency: 'usd',
+        product: 'prod_synthetic',
+        metadata,
+      });
+      expect(mockPaymentLinkCreate).toHaveBeenCalledWith({
+        line_items: [{ price: 'price_synthetic', quantity: 1 }],
+        metadata,
+        after_completion: {
+          type: 'redirect',
+          redirect: {
+            url: expect.stringMatching(
+              /^https:\/\/runmprc\.test\/register\/success\?reg=auto-1&token=[A-Za-z0-9_-]{32}$/,
+            ),
+          },
+        },
+      });
+    }
   });
 
   test.each([


### PR DESCRIPTION
## Outcome

Malformed late-registration amounts now fail closed before registration-ID allocation, token generation, business writes, or Stripe Product, Price, and Payment Link methods.

The previous `Number(value) || 0` coercion could silently turn missing or malformed input into a locally paid zero registration, or send unchecked/coerced amounts into Stripe.

Closes #331.

## Security contract

For `add_late_registration` only:

- accept exact primitive `0`;
- accept primitive safe-integer USD cents from `50` through `99_999_999`;
- reject `-0`, missing/null/wrong types, text, values from 1–49, fractions, non-finite/unsafe/oversized numbers, BigInt, boxed values, arrays, records, accessor-backed fields, coercible objects, and Proxy values;
- read only an own data descriptor and captured safe intrinsics;
- never call rejected-value accessors, conversion hooks, or Proxy traps;
- return fixed `invalid-argument / Invalid late registration amount`;
- preserve existing App Check, verified-admin, typed-config, and fresh-admission precedence.

Exact source head: `a5a7e83d024cf9a4689f825bebd982671b7c4a1b`  
Exact three-path diff SHA-256: `435eb5d7cd36776a8f7858fb85599a51dbb2720c777d77b34714cdbf19131487`

## Changes

- `functions/adminRegistrationAction.js`
  - adds the narrow no-coercion amount guard;
  - replaces the unsafe `Number(...) || 0` fallback.
- `functions/commerceControlEntryPoints.test.js`
  - records 25 hostile/malformed cases;
  - proves no ID, token, write, log, or Stripe method on rejection;
  - preserves exact zero, 50-cent, and eight-digit boundary behavior;
  - pins the exact existing registration write and Price/Payment Link arguments.
- `docs/officers/EVENTS_SHOP_MEMBERS.md`
  - adds a plain-language source-only review and diagram;
  - states that exact zero still creates a local record marked paid without Stripe and is not payment, free, or comp authority;
  - points undo to the protected Firebase backend release/readback boundary.

## RED proof

Test-only diff SHA-256: `726c8e04f3fafd0af648e3578372f6da812232d2e743ecbe858c8441dc66a0d5`.

Against base `2af3154`, all 25 new rejection cases failed as intended:

- zero-like malformed values resolved as a locally paid zero registration;
- malformed numeric/coercible values reached mocked Payment Link work;
- the amount accessor ran once;
- the conversion hook ran once;
- the Proxy get trap ran twice.

Only synthetic inputs and mocks were used.

## Verification

Node 20:

- focused late-registration tests: 28/28
- full commerce entry-point file: 156/156
- Functions Jest: 2,389 active passed; 64 skipped
- Functions lint: pass
- frontend Jest: 487/487
- Firestore Rules emulator: 378/378
- commerce journal Firestore emulator: 63/63
- SPA navigation: 11/11
- repository safety: 46/46
- frontend lint ledger: 106 files / 123 errors / 7 warnings
- TypeScript: pass
- diagnostic build: pass
- relative Markdown links and diff check: pass

Three independent exact-head reviews approved security, test/compatibility, and officer continuity.

## Compatibility and residual risk

Accepted zero and paid boundary paths keep the current result, write, metadata, Product/Price reference, line items, and redirect shape.

This PR does **not** approve a browser-selected or officer-selected price. It does not make the zero path payment/free/comp authority. It does not replace reusable Payment Links, add idempotency, capacity, provider-result validation, reconciliation, authorization upgrades, migration, or deployment. PAY-001D and PAY-004 remain open.

Officer impact: Future source stops malformed late-registration amounts from being recorded as paid or passed into Stripe. The complete Admin workflow remains NOT AVAILABLE YET.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`

Deployment evidence: Source and synthetic tests only. Website publication, `runmprc.com`, Firebase Functions/Rules deployment and readback, Stripe/provider configuration, production data, and live behavior were not changed or verified.
