### PR TITLE
WEB-PRIVACY-001R: stop repeat Admin order actions after an unknown result

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -1493,7 +1493,7 @@ Officer review steps after the source merge:
 
 **Expected result:** the reviewed source shows order-derived content only after the current mocked list read succeeds. Loading shows no order-derived content. A rejection shows one fixed accessible stop sentence and no rejected detail, false zero, old row, or action button. Older results are inert. Successful empty and made-up populated results keep their existing displays. The fixed sentence tells the officer to stop because a failed refresh can follow an action that may already have completed.
 
-The existing Fulfill, Refund, and Cancel requests, prompts, action responses, raw action-error text, idempotency, reconciliation, and audit behavior are separate unfinished work. This slice does not make Admin Orders or its actions safe.
+The existing Fulfill, Refund, and Cancel requests, prompts, and action responses remain unfinished work. Issue [#333](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/333) contains only rejected-value privacy and a current-page repeat-click guard. Repeat safety, record comparison, audit, and live action safety remain open. Neither slice makes Admin Orders safe for officer use.
 
 **Stop conditions:** any real officer, buyer, address, phone, email, order, tracking number, product, payment, refund, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; a zero, stale row, buyer detail, or action button during loading or failure; an attempted order action; a Firebase, Rules, provider, permission, or record change; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or screen is live.
 
@@ -1504,6 +1504,58 @@ The existing Fulfill, Refund, and Cancel requests, prompts, action responses, ra
 **Escalation:** treasurer plus platform/security owner. Add the shop lead and privacy owner. Use the private incident path if any personal, order, payment, provider, endpoint, token-shaped, or technical detail appeared, or if an action might have completed without a current readback. Do not copy private details into an issue, message, screenshot, email, or AI tool.
 
 No system-topology diagram changes for this source slice because page hierarchy, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected list-result display and current-request behavior.
+
+### Admin order-action unknown result — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** give an officer one safe instruction after a Fulfill, Refund, or Cancel request has an unknown result. The page must not show a private technical detail or invite another action that could duplicate money or fulfillment work.
+
+**Approver:** treasurer plus shop lead, platform/security owner, and privacy owner. All four roles must approve any future live review. This source slice does not provide that approval.
+
+**Prerequisites:** issues [#303](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/303) and [#333](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/333) must be merged for source review. Use only a made-up admin identity, mocked database reference, made-up orders, mocked prompts, and a mocked action request. Do not open the Admin screen or test an action on the production website. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply.
+
+```mermaid
+flowchart LR
+    A["Made-up known order row"] --> B["One mocked action request"]
+    B -- "Resolved" --> C["Existing mocked list reload"]
+    B -- "Rejected" --> D["Fixed unknown-result alert"]
+    D --> E["All order-action buttons disabled on this page"]
+    E --> F["Stop; contact treasurer and platform owner"]
+    G["Complete rejected value"] -. "Discarded" .-> H["No page, analytics, or console detail"]
+```
+
+Text alternative: a successful mocked action keeps the existing one-time list reload. A rejected action discards the complete rejected value, shows one fixed alert, disables every order-action button on the current page, and tells the officer to stop.
+
+Officer review steps after the source merge:
+
+1. Keep the complete Admin Orders screen marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #333 issue, reviewed pull request, merged commit, and synthetic test result.
+3. Confirm the review used only a made-up admin identity, made-up orders, mocked prompts, and a mocked action request.
+4. Confirm the old-source test recorded eight intended failures and one successful-action compatibility result.
+5. Confirm the green tests cover Fulfill, full Refund, partial Refund, and Cancel with their existing made-up request shapes.
+6. Confirm every mocked rejection shows exactly `We could not confirm that order action. Do not repeat it. Stop and contact the treasurer and platform owner.`
+7. Confirm assistive technology receives the complete sentence immediately as one alert.
+8. Confirm the complete rejected value is not inspected, coerced, logged, stored, sent to analytics, or displayed.
+9. Confirm a mocked rejection starts no automatic retry or list reload and leaves the last known made-up row visible.
+10. Confirm every visible Fulfill, Refund, and Cancel button is disabled after the unknown result, including buttons on other rows.
+11. Confirm another click on that page cannot start a second mocked request.
+12. Confirm one successful mocked action still performs exactly one existing list reload and shows no alert.
+13. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, Stripe, permissions, order records, production data, Admin-screen approval, and live behavior as separate results.
+
+**Expected result:** a rejected mocked action shows one fixed accessible instruction with no rejected detail. The current made-up order list stays visible, every order-action button is disabled for that open page, and no automatic retry or reload runs. A resolved mocked action keeps the existing single reload. The alert says the result is unknown; it does not claim the action failed.
+
+Refreshing, closing, or reopening the page can restore the action buttons. It does not prove what happened and never makes a repeat safe. Stop and contact the treasurer and platform owner instead.
+
+**Stop conditions:** any real officer, buyer, address, phone, email, order, tracking number, product, payment, refund, Firebase, Stripe, provider, endpoint, credential, or production record used; an attempt to force a production failure; a raw detail in the page, analytics, console, screenshot, issue, email, or AI tool; an automatic retry or reload after rejection; an enabled order-action button after the alert; a repeated action; or a claim that a browser button lock, source change, test, merge, preview, or green workflow proves financial safety or live behavior.
+
+**Success proof:** for source completion, record the exact #333 issue, reviewed pull request, merged commit, eight intended old-source failures, ten green focused tests, relevant full checks, and independent privacy/security, compatibility, and officer-continuity reviews. The safe officer review stops at those records. A later live process still needs authorization, repeat safety, durable audit, record comparison, backup, rollback, provider, deployment, and exact-revision evidence.
+
+**Undo:** before publication, use one reviewed frontend-and-guide revert or safe roll-forward. After any later approved publication, use the protected website release path and verify the replacement revision. Do not undo by refreshing the page, repeating an order action, or changing or deleting an order, payment, refund, shipment, account, permission, database record, or provider setting.
+
+**Escalation:** stop and contact the treasurer plus platform/security owner. Add the shop lead and privacy owner. Use the private incident path if an action might have completed, any private or technical detail appeared, or another request was attempted. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+
+No system-topology diagram changes for this source slice because page hierarchy, data movement, permissions, account ownership, and deployment topology are unchanged. The diagram above records only the current page's action-result display and repeat-click guard.
 
 ### Admin website-account role-list load failure privacy — SOURCE ONLY, NOT LIVE
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6358,6 +6358,323 @@ describe('Admin Orders list-load failure boundary', () => {
   });
 });
 
+describe('Admin Orders action unknown-outcome boundary', () => {
+  const ACTION_FAILURE = 'We could not confirm that order action. Do not repeat it. Stop and contact the treasurer and platform owner.';
+
+  function syntheticTimestamp(value) {
+    const date = new Date(value);
+    return { toDate: () => date };
+  }
+
+  function syntheticOrder({
+    id = 'synthetic-action-order',
+    title = 'Synthetic Action Shirt',
+    status = 'paid',
+    amountCents = 2500,
+  } = {}) {
+    return {
+      id,
+      productTitle: title,
+      buyer: {
+        firstName: 'Synthetic',
+        lastName: id,
+        email: `${id}@example.test`,
+      },
+      shipping: null,
+      size: 'M',
+      color: 'Blue',
+      amountCents,
+      currency: 'usd',
+      status,
+      trackingNumber: null,
+      createdAt: syntheticTimestamp('2030-01-12T20:00:00Z'),
+    };
+  }
+
+  function spyOnBrowserConsole() {
+    return ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  }
+
+  function mockDialogs({ prompts = [], confirmations = [] }) {
+    const promptSpy = jest.spyOn(window, 'prompt');
+    prompts.forEach((answer) => promptSpy.mockReturnValueOnce(answer));
+    const confirmSpy = jest.spyOn(window, 'confirm');
+    confirmations.forEach((answer) => confirmSpy.mockReturnValueOnce(answer));
+    return { promptSpy, confirmSpy };
+  }
+
+  async function renderActionableOrders(orders = [
+    syntheticOrder(),
+    syntheticOrder({
+      id: 'synthetic-other-order',
+      title: 'Synthetic Other Order',
+      status: 'fulfilled',
+      amountCents: 3500,
+    }),
+  ]) {
+    listAllOrders.mockResolvedValueOnce(orders);
+    renderAdminOrders();
+    expect(await screen.findByText(orders[0].productTitle)).toBeInTheDocument();
+    return orders;
+  }
+
+  function expectEveryOrderActionDisabled() {
+    const buttons = screen.getAllByRole('button', {
+      name: /^(Fulfill|Refund|Cancel)$/,
+    });
+    expect(buttons.length).toBeGreaterThan(3);
+    buttons.forEach((button) => expect(button).toBeDisabled());
+  }
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app: firebaseApp, firestore } },
+      isReady: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    {
+      label: 'fulfillment',
+      buttonName: 'Fulfill',
+      prompts: ['SYNTHETIC-TRACKING', 'Synthetic fulfillment note'],
+      confirmations: [],
+      expected: {
+        orderId: 'synthetic-action-order',
+        action: 'mark_fulfilled',
+        payload: {
+          trackingNumber: 'SYNTHETIC-TRACKING',
+          note: 'Synthetic fulfillment note',
+        },
+      },
+    },
+    {
+      label: 'full refund',
+      buttonName: 'Refund',
+      prompts: [''],
+      confirmations: [true],
+      expected: {
+        orderId: 'synthetic-action-order',
+        action: 'refund_full',
+        payload: undefined,
+      },
+    },
+    {
+      label: 'partial refund',
+      buttonName: 'Refund',
+      prompts: ['12.34'],
+      confirmations: [],
+      expected: {
+        orderId: 'synthetic-action-order',
+        action: 'refund_partial',
+        payload: { amountCents: 1234 },
+      },
+    },
+    {
+      label: 'cancellation',
+      buttonName: 'Cancel',
+      prompts: ['Synthetic cancellation reason'],
+      confirmations: [true],
+      expected: {
+        orderId: 'synthetic-action-order',
+        action: 'cancel',
+        payload: { note: 'Synthetic cancellation reason' },
+      },
+    },
+  ])('redacts an unconfirmed $label and locks every order action', async ({
+    label,
+    buttonName,
+    prompts,
+    confirmations,
+    expected,
+  }) => {
+    const consoleSpies = spyOnBrowserConsole();
+    const canary = `admin-order-${label.replace(' ', '-')}-private@example.test`;
+    adminOrderAction.mockRejectedValueOnce(Object.assign(new Error(canary), {
+      code: `functions/admin-order-${label.replace(' ', '-')}-private-canary`,
+      endpoint: 'https://provider.example.test/?token=admin-order-secret-canary',
+    }));
+    const orders = await renderActionableOrders();
+    mockDialogs({ prompts, confirmations });
+
+    const actionButton = screen.getAllByRole('button', { name: buttonName })[0];
+    fireEvent.click(actionButton);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ACTION_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(adminOrderAction).toHaveBeenCalledWith(firebaseApp, expected);
+    expect(adminOrderAction).toHaveBeenCalledTimes(1);
+    expect(listAllOrders).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(orders[0].productTitle)).toBeInTheDocument();
+    expect(screen.getByText(orders[1].productTitle)).toBeInTheDocument();
+    expectEveryOrderActionDisabled();
+    expect(document.body).not.toHaveTextContent(
+      /admin-order-.*private|provider\.example|admin-order-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /admin-order-.*private|provider\.example|admin-order-secret-canary/i,
+    );
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+
+    fireEvent.click(actionButton);
+    await act(async () => { await Promise.resolve(); });
+    expect(adminOrderAction).toHaveBeenCalledTimes(1);
+    expect(listAllOrders).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    {
+      label: 'an accessor-backed rejection',
+      makeRejectedValue() {
+        const messageGetter = jest.fn(() => 'admin-order-accessor-private-canary');
+        return {
+          value: Object.defineProperty({}, 'message', {
+            configurable: true,
+            get: messageGetter,
+          }),
+          probes: [messageGetter],
+        };
+      },
+    },
+    {
+      label: 'a Proxy rejection',
+      makeRejectedValue() {
+        const getTrap = jest.fn(() => 'admin-order-proxy-private-canary');
+        const ownKeysTrap = jest.fn(() => []);
+        const descriptorTrap = jest.fn(() => undefined);
+        return {
+          value: new Proxy({}, {
+            get: getTrap,
+            ownKeys: ownKeysTrap,
+            getOwnPropertyDescriptor: descriptorTrap,
+          }),
+          probes: [getTrap, ownKeysTrap, descriptorTrap],
+        };
+      },
+    },
+    {
+      label: 'a coercible rejection',
+      makeRejectedValue() {
+        const toString = jest.fn(() => 'admin-order-coercion-private-canary');
+        const valueOf = jest.fn(() => 7);
+        return { value: { toString, valueOf }, probes: [toString, valueOf] };
+      },
+    },
+    {
+      label: 'a primitive rejection',
+      makeRejectedValue() {
+        return { value: 'admin-order-primitive-private-canary', probes: [] };
+      },
+    },
+  ])('does not inspect or render $label', async ({ makeRejectedValue }) => {
+    const consoleSpies = spyOnBrowserConsole();
+    const { value, probes } = makeRejectedValue();
+    adminOrderAction.mockRejectedValueOnce(value);
+    await renderActionableOrders();
+    mockDialogs({
+      prompts: ['SYNTHETIC-TRACKING', 'Synthetic fulfillment note'],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fulfill' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe(ACTION_FAILURE);
+    probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+    expect(document.body).not.toHaveTextContent(/admin-order-.*private-canary/i);
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(/admin-order-.*private-canary/i);
+    expect(adminOrderAction).toHaveBeenCalledTimes(1);
+    expect(listAllOrders).toHaveBeenCalledTimes(1);
+    expectEveryOrderActionDisabled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('keeps the stop state terminal across a same-page Firestore change', async () => {
+    const orders = [syntheticOrder()];
+    listAllOrders.mockResolvedValueOnce(orders);
+    adminOrderAction.mockRejectedValueOnce(new Error('admin-order-transition-private-canary'));
+    const view = renderAdminOrders();
+    expect(await screen.findByText(orders[0].productTitle)).toBeInTheDocument();
+    mockDialogs({
+      prompts: ['SYNTHETIC-TRACKING', 'Synthetic fulfillment note'],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Fulfill' }));
+    expect((await screen.findByRole('alert')).textContent).toBe(ACTION_FAILURE);
+
+    const changedFirestore = { name: 'synthetic-firestore-after-unknown-action' };
+    useServiceLocator.mockReturnValue({
+      services: {
+        firebaseResources: { app: firebaseApp, firestore: changedFirestore },
+      },
+      isReady: true,
+    });
+    view.rerender(<App />);
+    await act(async () => { await Promise.resolve(); });
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toBe(ACTION_FAILURE);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText(orders[0].productTitle)).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^(Fulfill|Refund|Cancel)$/ }))
+      .not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('admin-order-transition-private-canary');
+    expect(listAllOrders).toHaveBeenCalledTimes(1);
+    expect(adminOrderAction).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves one successful action and its existing list reload', async () => {
+    const initialOrder = syntheticOrder();
+    const updatedOrder = syntheticOrder({
+      title: 'Synthetic Reloaded Shirt',
+      status: 'fulfilled',
+    });
+    listAllOrders
+      .mockResolvedValueOnce([initialOrder])
+      .mockResolvedValueOnce([updatedOrder]);
+    adminOrderAction.mockResolvedValueOnce({ ok: true });
+    renderAdminOrders();
+    expect(await screen.findByText(initialOrder.productTitle)).toBeInTheDocument();
+    mockDialogs({
+      prompts: ['SYNTHETIC-TRACKING', 'Synthetic fulfillment note'],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fulfill' }));
+
+    expect(await screen.findByText(updatedOrder.productTitle)).toBeInTheDocument();
+    expect(adminOrderAction).toHaveBeenCalledWith(firebaseApp, {
+      orderId: 'synthetic-action-order',
+      action: 'mark_fulfilled',
+      payload: {
+        trackingNumber: 'SYNTHETIC-TRACKING',
+        note: 'Synthetic fulfillment note',
+      },
+    });
+    expect(adminOrderAction).toHaveBeenCalledTimes(1);
+    expect(listAllOrders).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    screen.getAllByRole('button', { name: /^(Refund|Cancel)$/ })
+      .forEach((button) => expect(button).not.toBeDisabled());
+  });
+});
+
 describe('Admin website-account role-list load failure boundary', () => {
   function syntheticTimestamp(value) {
     const date = new Date(value);

--- a/src/pages/admin/shop/AdminOrders.tsx
+++ b/src/pages/admin/shop/AdminOrders.tsx
@@ -47,7 +47,7 @@ function Inner() {
   currentFirestoreRef.current = firestore;
   const requestSequence = useRef(0);
   const [loadOutcome, setLoadOutcome] = useState<OrdersLoadOutcome | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -57,12 +57,12 @@ function Inner() {
   const orders = currentOutcome?.status === 'resolved' ? currentOutcome.orders : [];
 
   async function reload() {
-    if (!firestore || currentFirestoreRef.current !== firestore) return;
+    if (actionError || !firestore || currentFirestoreRef.current !== firestore) return;
     requestSequence.current += 1;
     const requestId = requestSequence.current;
     const outcomeKey = { firestore };
     setLoadOutcome({ ...outcomeKey, status: 'loading', orders: [] });
-    setError(null);
+    // An unconfirmed action remains locked until this page is left.
     try {
       const all = await listAllOrders(firestore);
       if (requestId !== requestSequence.current
@@ -86,13 +86,13 @@ function Inner() {
   }, [firestore]);
 
   async function run(orderId: string, action: AdminOrderAction, payload?: Record<string, unknown>) {
-    if (!services) return;
+    if (!services || actionError) return;
     setBusy(orderId);
     try {
       await adminOrderAction(services.firebaseResources.app, { orderId, action, payload });
       await reload();
-    } catch (err: any) {
-      setError(err?.message || 'Action failed');
+    } catch {
+      setActionError('We could not confirm that order action. Do not repeat it. Stop and contact the treasurer and platform owner.');
     } finally {
       setBusy(null);
     }
@@ -191,7 +191,7 @@ function Inner() {
           </>
         )}
 
-        {currentStatus === 'loading' && <p>Loading...</p>}
+        {currentStatus === 'loading' && !actionError && <p>Loading...</p>}
         {currentStatus === 'unavailable' && (
           <p
             className="text-red-500 text-sm"
@@ -202,8 +202,15 @@ function Inner() {
             {LOAD_FAILURE}
           </p>
         )}
-        {currentStatus === 'resolved' && error && (
-          <p className="text-red-500 text-sm">{error}</p>
+        {actionError && (
+          <p
+            className="text-red-500 text-sm"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
+            {actionError}
+          </p>
         )}
 
         {currentStatus === 'resolved' && (
@@ -263,7 +270,7 @@ function Inner() {
                         <button
                           type="button"
                           onClick={() => promptFulfill(o.id)}
-                          disabled={isBusy}
+                          disabled={isBusy || Boolean(actionError)}
                           className="text-blue-600 hover:underline mr-2 text-xs"
                         >
                           Fulfill
@@ -273,7 +280,7 @@ function Inner() {
                         <button
                           type="button"
                           onClick={() => promptRefund(o.id, o.amountCents || 0)}
-                          disabled={isBusy}
+                          disabled={isBusy || Boolean(actionError)}
                           className="text-red-600 hover:underline mr-2 text-xs"
                         >
                           Refund
@@ -283,7 +290,7 @@ function Inner() {
                         <button
                           type="button"
                           onClick={() => promptCancel(o.id)}
-                          disabled={isBusy}
+                          disabled={isBusy || Boolean(actionError)}
                           className="text-amber-700 hover:underline text-xs"
                         >
                           Cancel


### PR DESCRIPTION
## Outcome

The Admin Orders page now treats a rejected Fulfill, Refund, or Cancel request as an unknown result. It discards the rejected value, shows one fixed accessible stop instruction, starts no automatic retry or reload, and disables every order-action button for the current open page.

A same-page Firestore identity change keeps the stop alert, performs no second lookup, and hides obsolete rows/actions. Refreshing or reopening can recreate controls, so the officer guide says that never makes a repeat safe.

## Scope

Exactly three paths:
- src/pages/admin/shop/AdminOrders.tsx
- src/App.test.jsx
- docs/officers/EVENTS_SHOP_MEMBERS.md

Exact reviewed head: 06dfdc0175956f1ff59268717ebd8dea9d6c2c8a
Exact diff SHA-256: d07b35e80f90330c544b822883ef9ebbe7281529bde69e7ae1e361c046534094

Concurrent #310 package-lock, dependency-test, and SECURITY.md hunks are untouched.

## Security and compatibility

- No rejected value property access, coercion, enumeration, stringify, logging, analytics, storage, or display.
- One fixed role=alert / aria-live=assertive / aria-atomic=true instruction.
- Exact existing Fulfill, full Refund, partial Refund, and Cancel request shapes remain covered.
- Successful action behavior keeps its existing one list reload.
- #303 list loading, rejection, stale-result, and unmount behavior remains covered.
- The browser lock is not authorization, idempotency, provider truth, or reconciliation. Admin Orders remains NOT AVAILABLE YET.

## Verification

- RED against old runtime: 8 failed / 1 successful compatibility control.
- #333 focused: 10/10.
- #303 + #333 focused: 21/21.
- Frontend: 12 suites / 497 tests.
- TypeScript: pass.
- Non-mutating lint: 106 files / 123 reviewed errors / 7 reviewed warnings.
- SPA: 11/11.
- Repository safety: 46/46.
- Functions lint: pass.
- Functions tests: 2,389 active passed / 64 skipped.
- Firestore Rules: 378/378.
- Commerce command-journal emulator: 63/63.
- Diagnostic production build: pass.
- Relative Markdown links and diff checks: pass.
- Three independent exact-diff reviews: approved.

## Release truth

- Source changed: yes.
- Tests passed locally: yes.
- Code merged: no, pending this PR.
- Website published: no.
- runmprc.com verified: no.
- Firebase Functions/Rules deployed: no.
- Stripe/provider configured or called: no.
- Orders or production data changed: no.
- Live behavior verified: no.

Officer impact: Future deployed source gives an officer one clear unknown-result instruction and prevents another order-action click on the current page. It does not approve Admin Orders for use.

Officer documentation: docs/officers/EVENTS_SHOP_MEMBERS.md

Deployment evidence: None. This PR contains source, mocked tests, and documentation only. Website, Firebase, Stripe/provider, production data, and live behavior remain unverified.

Closes #333