### PR TITLE
OAUTH-001C1G: scrub Strava callback history before use

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -130,6 +130,26 @@ flowchart LR
 
 Text alternative: the 404 page temporarily carries the complete return route to the root page; an early referrer policy keeps the path/query/fragment out of subresource request headers, and the root page deletes the temporary value before accepting only a same-origin route. App Check, Analytics, and Sentry stay off on that initial capability-bearing callback. The bridge does not prove payment, OAuth state, or identity. Server/provider verification still decides the result.
 
+### Strava callback current-address cleanup — source only, not live
+
+OAUTH-001C1G [#335](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/335) adds a second boundary after the existing Pages handoff. The Strava callback keeps only its initial `code`, `state`, and provider-error fields in temporary component memory. It replaces the current native browser and React Router entry with the same path, no address details after `?` or `#`, and no saved callback detail before the callback mounts its Auth/service work, verifies state, or starts the existing exchange attempt.
+
+```mermaid
+flowchart LR
+    Route["Strava callback with made-up address details after ? or #"] --> Capture["Capture three selected fields in temporary page memory"]
+    Capture --> Replace["Replace current browser and Router entry with path only"]
+    Replace --> Clean{"Both current locations clean?"}
+    Clean -- "Not yet" --> Wait["Wait; no state check or exchange"]
+    Wait -. "Detected replacement failure" .-> Stop["Fixed accessible failure"]
+    Clean -- "Yes" --> Checks["Existing sign-in, provider-error, code, and state checks"]
+    Checks --> Exchange["At most one exchange attempt for the same signed-in account and app"]
+    Outside["Earlier browser, provider, hosting, or network copies"] -. "Remain outside this boundary" .-> Residual["Back or history is not cleanup proof"]
+```
+
+Text alternative: the callback captures three selected made-up fields in temporary page memory, replaces the current browser and Router entry with the clean path, and proceeds to the existing checks only after both current locations are clean. Unconfirmed cleanup waits without state verification or exchange. A detected replacement failure shows the fixed stop. Cleaning the current entry does not erase earlier browser or outside copies.
+
+The source also discards a later same-route callback. After unmount or a signed-in UID, service, Firebase resources, or app change, an obsolete browser result cannot navigate or show success. That does not cancel an exchange that already reached the server or provider; its outcome may still occur and require separate reconciliation. This child does not change the Pages bridge, provider request, server state model, App Check enforcement, scopes, membership, or deployment. Source, tests, merge, website publication, `runmprc.com` revision verification, Firebase deployment, Strava configuration, production data, and live OAuth behavior remain separate states. Canonical [#88](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/88) remains open for server-issued one-use state, expiry/replay, account and scope policy, concurrency, reconciliation, revoke/audit, IAM/encryption, provider configuration, deployment, and live proof.
+
 ### Firebase Auth action link — source only, not live
 
 ```mermaid

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -494,7 +494,7 @@ Officer review steps after the source merge:
 10. Confirm the failure sentence is announced as an urgent screen-reader alert.
 11. Record website publication, `runmprc.com`, Firebase, Strava, production-data, and live-behavior evidence as separate results.
 
-**Expected result:** the reviewed source uses one fixed, actionable sentence for both a callback query failure and an exchange failure. It does not inspect, display, or log the rejected exchange value. Existing sign-in, missing-code, failed-security-check, success, and Back-to-account behavior stays in place. This does not remove the callback details from the browser address.
+**Expected result:** the reviewed source uses one fixed, actionable sentence for both a callback query failure and an exchange failure. It does not inspect, display, or log the rejected exchange value. Existing sign-in, missing-code, failed-security-check, success, and Back-to-account behavior stays in place. The separate OAUTH-001C1G child adds source-only cleanup of the current browser entry before callback-specific checks or exchange. It does not erase earlier browser, provider, hosting, or network copies or complete issue #88.
 
 **Stop conditions:** any real member or Strava account; a request for a callback URL, authorization code, state value, provider error, private browser history, or screenshot containing private values; a real provider call; a production Firebase or Strava change; a raw detail in the page or console; or a claim that source, tests, merge, or a green workflow proves the wording is live.
 
@@ -504,7 +504,58 @@ Officer review steps after the source merge:
 
 **Escalation:** membership lead plus platform/security owner. Add the privacy owner and use the private incident path if any callback or provider detail appeared. Do not copy the detail into an issue, message, screenshot, or AI tool.
 
-No system diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged.
+For #242 alone, page structure, data movement, permissions, account ownership, and deployment topology were unchanged. The separate #335 procedure and diagram below record the later current-address data-order change.
+
+## Strava callback current-address cleanup — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** remove made-up Strava callback address details after `?` or `#` before the page checks the callback or starts a mocked exchange.
+
+**Approver:** membership lead plus platform/security and privacy owners.
+
+**Prerequisites:** issue [#335](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/335) must be merged at an exact reviewed commit. Use no real Strava account, callback, code, state, provider error, or member data. Calling this published also requires a protected website release and an exact revision check on `runmprc.com`. That still does not prove live OAuth behavior. This child does not deploy Firebase, configure Strava, call the provider, or inspect production data.
+
+```mermaid
+flowchart LR
+    A["Made-up callback address details after ? or #"] --> B["Keep three selected fields in temporary page memory"]
+    B --> C{"Both current entries proven clean?"}
+    C -- "Not yet" --> W["Wait; no state check or exchange"]
+    W -. "Detected replacement failure" .-> D["Fixed accessible stop"]
+    C -- "Yes" --> E["Continue the existing sign-in, error, code, and state checks"]
+    E --> F["One mocked exchange may continue"]
+    G["Earlier browser, provider, hosting, or network copies"] -. "Not erased" .-> H["Back is not proof of cleanup"]
+```
+
+Text alternative: the page first cleans the current browser and page entry. While cleanup is unconfirmed, it waits without checking state or starting an exchange. A detected replacement failure shows the fixed stop. Cleaning the current entry does not erase earlier history or outside copies.
+
+Officer review steps after the source merge:
+
+1. Keep this procedure marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for issue #335, the reviewed pull request, the exact merge commit, and synthetic test results.
+3. Confirm every test uses only made-up callback values and mocked services.
+4. Confirm the current address has no details after `?` or `#` before any callback decision, state check, or exchange.
+5. Confirm the page's current route also has no address details after `?` or `#`, or saved callback detail.
+6. Confirm unconfirmed cleanup keeps waiting and performs no state check or exchange.
+7. Confirm a detected failed or ineffective replacement shows one fixed accessible result.
+8. Confirm that failure performs no state check and no exchange.
+9. Confirm a second callback loaded into the same page is discarded and does not start another exchange.
+10. Confirm a changed signed-in account or service prevents an older browser result from navigating or showing success.
+11. Confirm successful cleanup preserves the existing #242 sign-in, provider-error, missing-code, invalid-state, pending, success, and fixed-failure behavior.
+12. Confirm made-up values do not appear in the page, console, analytics, screenshots, or saved test artifacts.
+13. Record source changed, tests passed, merged, website published, `runmprc.com` revision verified, Firebase deployed, Strava configured, production data changed, and live behavior verified as separate results.
+
+**Expected result:** the current visible callback entry is clean before processing. A cleanup failure stops safely. Callback values exist only temporarily in page memory. A changed account or service prevents an obsolete browser result from navigating or showing success, but it does not cancel an exchange that already reached the server or provider. That outcome may still occur and need separate reconciliation. Earlier browser history, address suggestions or sync, provider records, hosting records, and network records are not erased. Back may return to an earlier page and must never be treated as proof of cleanup.
+
+**Stop conditions:** a request for a real callback, code, state, provider error, screenshot, browser-history view, developer-tools capture, or copied address; callback details remaining after cleanup; processing after cleanup failure; a real provider or Firebase service call; or a claim that source, tests, merge, or green CI proves live behavior.
+
+**Success proof:** for source completion, record issue #335, the reviewed pull request, exact commit, intended old-source failures, green synthetic ordering/failure/lifecycle tests, relevant full checks, and independent privacy/officer review. For publication evidence, separately record the protected website publication and exact `runmprc.com` revision. Those checks do not make this procedure available or prove production OAuth behavior. A separately approved non-production plan may prove staged behavior only.
+
+**Undo:** before publication, use a reviewed revert or corrective pull request. After publication, use the protected website rollback process and verify the restored revision. Never paste, save, inspect, or replay an old callback address during rollback.
+
+**Escalation:** contact the platform/security and privacy owners if callback details may have appeared outside the current clean page. Use the private incident path. Do not copy a value into an issue, message, screenshot, or AI tool.
+
+This child keeps canonical issue #88 open and incomplete. Server-issued one-use state, UID/session binding, expiry and replay protection, App Check handoff, account and scope policy, concurrency, revoke/audit behavior, IAM/encryption, provider configuration, deployment, and live verification remain separate work.
 
 ## Strava connection record pairing — SOURCE ONLY, NOT LIVE
 

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -7,7 +7,8 @@ import {
   act, fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import {
-  MemoryRouter, Route, Routes, useNavigationType,
+  BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate,
+  useNavigationType,
 } from 'react-router-dom';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { useAuth } from '../../services/hooks/useAuth';
@@ -1325,9 +1326,114 @@ function CallbackAccountDestination() {
   );
 }
 
+function CallbackLocationWitness() {
+  const location = useLocation();
+
+  return (
+    <span
+      hidden
+      data-testid="strava-callback-location"
+      data-search-clean={String(location.search === '')}
+      data-hash-clean={String(location.hash === '')}
+      data-state-clean={String(location.state === null)}
+    />
+  );
+}
+
+type CallbackRouterSnapshot = Readonly<{
+  search: string;
+  hash: string;
+  state: unknown;
+}>;
+
+type CallbackRouterObservation = {
+  current: CallbackRouterSnapshot | null;
+  onLocation?: (snapshot: CallbackRouterSnapshot) => void;
+};
+
+function CallbackSameRouteProbe() {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(
+        '/account/strava/callback?code=second-code-canary&state=second-state-canary'
+        + '#second-fragment-canary',
+      )}
+    >
+      Load another callback
+    </button>
+  );
+}
+
+function CallbackRouteHarness({
+  observation,
+}: {
+  observation?: CallbackRouterObservation;
+}) {
+  const location = useLocation();
+  const observationTarget = observation;
+  if (observationTarget) {
+    const snapshot = {
+      search: location.search,
+      hash: location.hash,
+      state: location.state,
+    };
+    observationTarget.current = snapshot;
+    observationTarget.onLocation?.(snapshot);
+  }
+
+  return (
+    <>
+      <StravaCallback />
+      <CallbackLocationWitness />
+      <CallbackSameRouteProbe />
+    </>
+  );
+}
+
+function renderBrowserStravaCallback(
+  entry = '/account/strava/callback?code=synthetic-code&state=synthetic-state',
+  seedHistory = true,
+  strictMode = false,
+  observation?: CallbackRouterObservation,
+) {
+  if (seedHistory) {
+    window.history.replaceState(
+      {
+        idx: 0,
+        key: 'synthetic-callback-entry',
+        usr: { privateCallbackState: 'history-state-canary' },
+      },
+      '',
+      entry,
+    );
+  }
+
+  const router = (
+    <BrowserRouter
+      future={{
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      }}
+    >
+      <Routes>
+        <Route
+          path="/account/strava/callback"
+          element={<CallbackRouteHarness observation={observation} />}
+        />
+        <Route path="/account" element={<CallbackAccountDestination />} />
+      </Routes>
+    </BrowserRouter>
+  );
+  return render(strictMode ? <React.StrictMode>{router}</React.StrictMode> : router);
+}
+
 function renderStravaCallback(
   entry = '/account/strava/callback?code=synthetic-code&state=synthetic-state',
 ) {
+  window.history.replaceState(null, '', '/account/strava/callback');
   return render(
     <MemoryRouter
       initialEntries={[entry]}
@@ -1352,6 +1458,7 @@ describe('Strava callback error boundary', () => {
       isReady: true,
     });
     (useAuth as jest.Mock).mockReturnValue({
+      user: USER,
       isAuthenticated: true,
       isLoading: false,
     });
@@ -1364,6 +1471,441 @@ describe('Strava callback error boundary', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    window.history.replaceState(null, '', '/');
+  });
+
+  describe('current browser history cleanup', () => {
+    test('cleans native and Router state before hooks, state verification, or exchange', async () => {
+      const routerObservation: CallbackRouterObservation = { current: null };
+      const observedLocations: Array<{
+        native: string;
+        router: CallbackRouterSnapshot | null;
+      }> = [];
+      const observedServices = { firebaseResources: { app } };
+      const observeLocation = () => {
+        observedLocations.push({
+          native: `${window.location.search}${window.location.hash}`,
+          router: routerObservation.current,
+        });
+      };
+      (useServiceLocator as jest.Mock).mockImplementation(() => {
+        observeLocation();
+        return {
+          services: observedServices,
+          isReady: true,
+        };
+      });
+      (useAuth as jest.Mock).mockImplementation(() => {
+        observeLocation();
+        return {
+          user: USER,
+          isAuthenticated: true,
+          isLoading: false,
+        };
+      });
+      (verifyStravaState as jest.Mock).mockImplementation(() => {
+        observeLocation();
+        return true;
+      });
+      (stravaExchangeCode as jest.Mock).mockImplementationOnce(() => {
+        observeLocation();
+        return new Promise(() => {
+          // Keep the made-up exchange pending so the clean callback route remains mounted.
+        });
+      });
+      const initialHistoryLength = window.history.length;
+
+      renderBrowserStravaCallback(
+        '/account/strava/callback?code=private-code-canary&state=private-state-canary'
+        + '#private-fragment-canary',
+        true,
+        false,
+        routerObservation,
+      );
+
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+      expect(observedLocations).not.toHaveLength(0);
+      expect(observedLocations).toEqual(observedLocations.map(() => ({
+        native: '',
+        router: { search: '', hash: '', state: null },
+      })));
+      expect(window.location.pathname).toBe('/account/strava/callback');
+      expect(window.location.search).toBe('');
+      expect(window.location.hash).toBe('');
+      expect(JSON.stringify(window.history.state)).not.toMatch(
+        /history-state-canary|private-code-canary|private-state-canary|private-fragment-canary/,
+      );
+      expect(window.history.length).toBe(initialHistoryLength);
+      expect(screen.getByTestId('strava-callback-location')).toHaveAttribute(
+        'data-search-clean',
+        'true',
+      );
+      expect(screen.getByTestId('strava-callback-location')).toHaveAttribute(
+        'data-hash-clean',
+        'true',
+      );
+      expect(screen.getByTestId('strava-callback-location')).toHaveAttribute(
+        'data-state-clean',
+        'true',
+      );
+      expect(verifyStravaState).toHaveBeenCalledWith('private-state-canary');
+      expect(stravaExchangeCode).toHaveBeenCalledWith(app, 'private-code-canary');
+      expect(document.body).not.toHaveTextContent(
+        /private-code-canary|private-state-canary|private-fragment-canary|history-state-canary/,
+      );
+    });
+
+    test.each([
+      ['Firebase services are not ready', false, false],
+      ['authentication is loading', true, true],
+    ])('cleans the current entry before waiting when %s', async (_case, isReady, isLoading) => {
+      const observedLocations: string[] = [];
+      const observedServices = { firebaseResources: { app } };
+      const observeLocation = () => {
+        observedLocations.push(`${window.location.search}${window.location.hash}`);
+      };
+      (useServiceLocator as jest.Mock).mockImplementation(() => {
+        observeLocation();
+        return {
+          services: isReady ? observedServices : null,
+          isReady,
+        };
+      });
+      (useAuth as jest.Mock).mockImplementation(() => {
+        observeLocation();
+        return {
+          user: USER,
+          isAuthenticated: true,
+          isLoading,
+        };
+      });
+
+      renderBrowserStravaCallback(
+        '/account/strava/callback?code=waiting-code-canary&state=waiting-state-canary'
+        + '#waiting-fragment-canary',
+      );
+
+      await waitFor(() => expect(window.location.search).toBe(''));
+      expect(window.location.hash).toBe('');
+      expect(observedLocations).not.toHaveLength(0);
+      expect(observedLocations).toEqual(observedLocations.map(() => ''));
+      expect(screen.getByText('Connecting your Strava...')).toBeInTheDocument();
+      expect(verifyStravaState).not.toHaveBeenCalled();
+      expect(stravaExchangeCode).not.toHaveBeenCalled();
+      expect(document.body).not.toHaveTextContent(/waiting-.*-canary/);
+    });
+
+    test('fails closed before hooks or exchange when the current entry cannot be replaced', async () => {
+      window.history.replaceState(
+        {
+          idx: 0,
+          key: 'synthetic-failure-entry',
+          usr: { privateCallbackState: 'history-failure-state-canary' },
+        },
+        '',
+        '/account/strava/callback?code=history-failure-code-canary'
+        + '&state=history-failure-state-canary#history-failure-fragment-canary',
+      );
+      jest.spyOn(window.history, 'replaceState').mockImplementation(() => {
+        throw new Error('history-replace-private-canary');
+      });
+      (stravaExchangeCode as jest.Mock).mockReturnValueOnce(new Promise(() => {
+        // The old source reaches this promise; the fixed source must not.
+      }));
+
+      renderBrowserStravaCallback(undefined, false);
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(alert).toHaveAttribute('aria-live', 'assertive');
+      expect(alert).toHaveAttribute('aria-atomic', 'true');
+      expect(useServiceLocator).not.toHaveBeenCalled();
+      expect(useAuth).not.toHaveBeenCalled();
+      expect(verifyStravaState).not.toHaveBeenCalled();
+      expect(stravaExchangeCode).not.toHaveBeenCalled();
+      expect(document.body).not.toHaveTextContent(/history-.*-canary/);
+    });
+
+    test('fails closed when native replacement returns without cleaning the address', async () => {
+      window.history.replaceState(
+        {
+          idx: 0,
+          key: 'synthetic-noop-entry',
+          usr: { privateCallbackState: 'history-noop-state-canary' },
+        },
+        '',
+        '/account/strava/callback?code=history-noop-code-canary'
+        + '&state=history-noop-state-canary#history-noop-fragment-canary',
+      );
+      jest.spyOn(window.history, 'replaceState').mockImplementation(() => undefined);
+
+      renderBrowserStravaCallback(undefined, false);
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(useServiceLocator).not.toHaveBeenCalled();
+      expect(useAuth).not.toHaveBeenCalled();
+      expect(verifyStravaState).not.toHaveBeenCalled();
+      expect(stravaExchangeCode).not.toHaveBeenCalled();
+      expect(document.body).not.toHaveTextContent(/history-noop-.*-canary/);
+    });
+
+    test('fails closed when native replacement silently changes to another path', async () => {
+      const routerObservation: CallbackRouterObservation = {
+        current: null,
+        onLocation: (location) => {
+          if (
+            location.search === ''
+            && location.hash === ''
+            && location.state === null
+            && window.location.pathname === '/account/strava/callback'
+          ) {
+            window.history.replaceState(
+              window.history.state,
+              '',
+              '/silent-path-divergence',
+            );
+          }
+        },
+      };
+
+      renderBrowserStravaCallback(
+        '/account/strava/callback?code=history-divergent-code-canary'
+        + '&state=history-divergent-state-canary#history-divergent-fragment-canary',
+        true,
+        false,
+        routerObservation,
+      );
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(window.location.pathname).toBe('/silent-path-divergence');
+      expect(useServiceLocator).not.toHaveBeenCalled();
+      expect(useAuth).not.toHaveBeenCalled();
+      expect(verifyStravaState).not.toHaveBeenCalled();
+      expect(stravaExchangeCode).not.toHaveBeenCalled();
+      expect(document.body).not.toHaveTextContent(/history-divergent-.*-canary/);
+    });
+
+    test('rejects a later same-route callback without reusing either capability', async () => {
+      (stravaExchangeCode as jest.Mock).mockReturnValue(new Promise(() => {
+        // Keep the first made-up exchange pending while the route changes.
+      }));
+      renderBrowserStravaCallback();
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Load another callback' }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(window.location.search).toBe('');
+      expect(window.location.hash).toBe('');
+      expect(verifyStravaState).toHaveBeenCalledTimes(1);
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+      expect(document.body).not.toHaveTextContent(
+        /second-code-canary|second-state-canary|second-fragment-canary/,
+      );
+    });
+
+    test('makes one exchange across StrictMode replay and ordinary rerenders', async () => {
+      let finishExchange: (() => void) | undefined;
+      (stravaExchangeCode as jest.Mock).mockReturnValueOnce(new Promise((resolve) => {
+        finishExchange = () => resolve({ ok: true, athleteId: null });
+      }));
+      const page = renderBrowserStravaCallback(undefined, true, true);
+
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+      page.rerender(
+        <React.StrictMode>
+          <BrowserRouter
+            future={{
+              v7_relativeSplatPath: true,
+              v7_startTransition: true,
+            }}
+          >
+            <Routes>
+              <Route path="/account/strava/callback" element={<CallbackRouteHarness />} />
+              <Route path="/account" element={<CallbackAccountDestination />} />
+            </Routes>
+          </BrowserRouter>
+        </React.StrictMode>,
+      );
+
+      expect(verifyStravaState).toHaveBeenCalledTimes(1);
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        finishExchange?.();
+        await Promise.resolve();
+      });
+      expect(await screen.findByText('Account destination')).toBeInTheDocument();
+      expect(screen.getByTestId('callback-navigation-type')).toHaveTextContent('REPLACE');
+    });
+
+    test.each([
+      ['signed-in UID', 'resolve'],
+      ['service identity', 'reject'],
+      ['Firebase app', 'resolve'],
+    ])('discards a pending result after a %s change when it would %s', async (
+      changedContext,
+      outcome,
+    ) => {
+      let settleExchange: (() => void) | undefined;
+      const firstFirebaseResources = { app };
+      const firstServices = { firebaseResources: firstFirebaseResources };
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: firstServices,
+        isReady: true,
+      });
+      (useAuth as jest.Mock).mockReturnValue({
+        user: USER,
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      (stravaExchangeCode as jest.Mock).mockReturnValueOnce(new Promise((resolve, reject) => {
+        settleExchange = outcome === 'resolve'
+          ? () => resolve({ ok: true, athleteId: null })
+          : () => reject(Object.defineProperty({}, 'message', {
+            get() {
+              throw new Error('obsolete-context-private-canary');
+            },
+          }));
+      }));
+      const page = renderBrowserStravaCallback();
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+
+      let nextUser = USER;
+      let nextServices = firstServices;
+      if (changedContext === 'signed-in UID') {
+        nextUser = { ...USER, uid: 'second-synthetic-user' };
+      } else if (changedContext === 'service identity') {
+        nextServices = { firebaseResources: firstFirebaseResources };
+      } else {
+        nextServices = {
+          firebaseResources: { app: { name: 'second-synthetic-app' } },
+        };
+      }
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: nextServices,
+        isReady: true,
+      });
+      (useAuth as jest.Mock).mockReturnValue({
+        user: nextUser,
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      page.rerender(
+        <BrowserRouter
+          future={{
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+          }}
+        >
+          <Routes>
+            <Route path="/account/strava/callback" element={<CallbackRouteHarness />} />
+            <Route path="/account" element={<CallbackAccountDestination />} />
+          </Routes>
+        </BrowserRouter>,
+      );
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(verifyStravaState).toHaveBeenCalledTimes(1);
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        settleExchange?.();
+        await Promise.resolve();
+      });
+      expect(screen.queryByText('Account destination')).not.toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(document.body).not.toHaveTextContent('obsolete-context-private-canary');
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps a pending attempt invalid after the account changes away and back', async () => {
+      let finishExchange: (() => void) | undefined;
+      const firstServices = { firebaseResources: { app } };
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: firstServices,
+        isReady: true,
+      });
+      (useAuth as jest.Mock).mockReturnValue({
+        user: USER,
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      (stravaExchangeCode as jest.Mock).mockReturnValueOnce(new Promise((resolve) => {
+        finishExchange = () => resolve({ ok: true, athleteId: null });
+      }));
+      const page = renderBrowserStravaCallback();
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { ...USER, uid: 'second-synthetic-user' },
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      page.rerender(
+        <BrowserRouter
+          future={{
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+          }}
+        >
+          <Routes>
+            <Route path="/account/strava/callback" element={<CallbackRouteHarness />} />
+            <Route path="/account" element={<CallbackAccountDestination />} />
+          </Routes>
+        </BrowserRouter>,
+      );
+      expect(await screen.findByRole('alert')).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+
+      (useAuth as jest.Mock).mockReturnValue({
+        user: USER,
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      page.rerender(
+        <BrowserRouter
+          future={{
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+          }}
+        >
+          <Routes>
+            <Route path="/account/strava/callback" element={<CallbackRouteHarness />} />
+            <Route path="/account" element={<CallbackAccountDestination />} />
+          </Routes>
+        </BrowserRouter>,
+      );
+
+      await act(async () => {
+        finishExchange?.();
+        await Promise.resolve();
+      });
+      expect(screen.queryByText('Account destination')).not.toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(STRAVA_CALLBACK_FAILURE);
+      expect(verifyStravaState).toHaveBeenCalledTimes(1);
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+    });
+
+    test('makes a pending result inert after unmount without logging', async () => {
+      let finishExchange: (() => void) | undefined;
+      const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+        .map((method) => jest.spyOn(console, method as any).mockImplementation(() => undefined));
+      (stravaExchangeCode as jest.Mock).mockReturnValueOnce(new Promise((resolve) => {
+        finishExchange = () => resolve({ ok: true, athleteId: null });
+      }));
+      const page = renderBrowserStravaCallback();
+      await waitFor(() => expect(stravaExchangeCode).toHaveBeenCalledTimes(1));
+      page.unmount();
+
+      await act(async () => {
+        finishExchange?.();
+        await Promise.resolve();
+      });
+
+      expect(document.body).not.toHaveTextContent('Account destination');
+      expect(stravaExchangeCode).toHaveBeenCalledTimes(1);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
   });
 
   test.each([

--- a/src/pages/account/StravaCallback.tsx
+++ b/src/pages/account/StravaCallback.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Navigate, useLocation, useNavigate,
+} from 'react-router-dom';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { useAuth } from '../../services/hooks/useAuth';
 import SEO from '../../components/SEO';
@@ -7,49 +9,47 @@ import { stravaExchangeCode, verifyStravaState } from '../../services/strava/str
 
 const STRAVA_CALLBACK_FAILURE = 'We could not connect Strava. Please return to My Account and try again.';
 
-function StravaCallback() {
-  const [params] = useSearchParams();
-  const { services, isReady } = useServiceLocator();
-  const { isAuthenticated, isLoading } = useAuth();
-  const code = params.get('code');
-  const state = params.get('state');
-  const err = params.get('error');
+type CallbackStatus = 'exchanging' | 'done' | 'error';
 
-  const [status, setStatus] = useState<'exchanging' | 'done' | 'error'>('exchanging');
-  const [message, setMessage] = useState<string>('');
+type CallbackSnapshot = Readonly<{
+  code: string | null;
+  state: string | null;
+  error: string | null;
+}>;
 
-  useEffect(() => {
-    if (isLoading || !isReady) return;
-    if (!isAuthenticated) {
-      setStatus('error');
-      setMessage('You need to be signed in to connect Strava.');
-      return;
-    }
-    if (err) {
-      setStatus('error');
-      setMessage(STRAVA_CALLBACK_FAILURE);
-      return;
-    }
-    if (!code) {
-      setStatus('error');
-      setMessage('Missing authorization code from Strava.');
-      return;
-    }
-    if (!verifyStravaState(state)) {
-      setStatus('error');
-      setMessage('Security check failed (state mismatch). Please try connecting again.');
-      return;
-    }
-    if (!services) return;
+type AttemptContext = Readonly<{
+  uid: string;
+  services: object;
+  firebaseResources: object;
+  app: object;
+}>;
 
-    stravaExchangeCode(services.firebaseResources.app, code)
-      .then(() => setStatus('done'))
-      .catch(() => {
-        setStatus('error');
-        setMessage(STRAVA_CALLBACK_FAILURE);
-      });
-  }, [services, isReady, isAuthenticated, isLoading, code, state, err]);
+function readCallbackSnapshot(search: string): CallbackSnapshot {
+  try {
+    const params = new URLSearchParams(search);
+    return Object.freeze({
+      code: params.get('code'),
+      state: params.get('state'),
+      error: params.get('error'),
+    });
+  } catch {
+    return Object.freeze({ code: null, state: null, error: null });
+  }
+}
 
+function nativeAddressIsClean(expectedPathname: string): boolean {
+  return window.location.pathname === expectedPathname
+    && window.location.search === ''
+    && window.location.hash === '';
+}
+
+function CallbackScreen({
+  status,
+  message,
+}: {
+  status: CallbackStatus;
+  message: string;
+}) {
   if (status === 'done') {
     return <Navigate to="/account" replace />;
   }
@@ -83,6 +83,241 @@ function StravaCallback() {
       </div>
     </>
   );
+}
+
+function CallbackAttempt({ snapshot }: { snapshot: CallbackSnapshot }) {
+  const { services, isReady } = useServiceLocator();
+  const {
+    user, isAuthenticated, isLoading,
+  } = useAuth();
+  const [status, setStatus] = useState<CallbackStatus>('exchanging');
+  const [message, setMessage] = useState('');
+  const mountedRef = useRef(false);
+  const decisionStartedRef = useRef(false);
+  const runRef = useRef<symbol | null>(null);
+  const attemptContextRef = useRef<AttemptContext | null>(null);
+  const attemptInvalidatedRef = useRef(false);
+
+  const firebaseResources = services?.firebaseResources ?? null;
+  const app = firebaseResources?.app ?? null;
+  const uid = user?.uid ?? null;
+  const attemptContext = attemptContextRef.current;
+  const contextChanged = attemptContext !== null && (
+    !isReady
+    || isLoading
+    || !isAuthenticated
+    || uid !== attemptContext.uid
+    || services !== attemptContext.services
+    || firebaseResources !== attemptContext.firebaseResources
+    || app !== attemptContext.app
+  );
+  if (contextChanged) {
+    attemptInvalidatedRef.current = true;
+    runRef.current = null;
+  }
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (
+      attemptInvalidatedRef.current
+      || decisionStartedRef.current
+      || isLoading
+      || !isReady
+    ) return;
+    if (!isAuthenticated || uid === null) {
+      decisionStartedRef.current = true;
+      setStatus('error');
+      setMessage('You need to be signed in to connect Strava.');
+      return;
+    }
+    if (snapshot.error) {
+      decisionStartedRef.current = true;
+      setStatus('error');
+      setMessage(STRAVA_CALLBACK_FAILURE);
+      return;
+    }
+    if (!snapshot.code) {
+      decisionStartedRef.current = true;
+      setStatus('error');
+      setMessage('Missing authorization code from Strava.');
+      return;
+    }
+    if (services === null || firebaseResources === null || app === null) return;
+
+    decisionStartedRef.current = true;
+    try {
+      if (!verifyStravaState(snapshot.state)) {
+        setStatus('error');
+        setMessage('Security check failed (state mismatch). Please try connecting again.');
+        return;
+      }
+    } catch {
+      setStatus('error');
+      setMessage('Security check failed (state mismatch). Please try connecting again.');
+      return;
+    }
+
+    const run = Symbol('strava-callback-exchange');
+    runRef.current = run;
+    attemptContextRef.current = {
+      uid,
+      services,
+      firebaseResources,
+      app,
+    };
+
+    let exchange: ReturnType<typeof stravaExchangeCode>;
+    try {
+      exchange = stravaExchangeCode(app, snapshot.code);
+    } catch {
+      runRef.current = null;
+      setStatus('error');
+      setMessage(STRAVA_CALLBACK_FAILURE);
+      return;
+    }
+
+    Promise.resolve(exchange).then(
+      () => {
+        if (
+          !mountedRef.current
+          || attemptInvalidatedRef.current
+          || runRef.current !== run
+        ) return;
+        runRef.current = null;
+        setStatus('done');
+      },
+      () => {
+        if (
+          !mountedRef.current
+          || attemptInvalidatedRef.current
+          || runRef.current !== run
+        ) return;
+        runRef.current = null;
+        setStatus('error');
+        setMessage(STRAVA_CALLBACK_FAILURE);
+      },
+    );
+  }, [
+    app,
+    firebaseResources,
+    isAuthenticated,
+    isLoading,
+    isReady,
+    services,
+    snapshot,
+    uid,
+  ]);
+
+  if (attemptInvalidatedRef.current) {
+    return <CallbackScreen status="error" message={STRAVA_CALLBACK_FAILURE} />;
+  }
+  return <CallbackScreen status={status} message={message} />;
+}
+
+function StravaCallback() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const snapshotRef = useRef<CallbackSnapshot | null>(null);
+  const snapshotCapturedRef = useRef(false);
+  if (!snapshotCapturedRef.current) {
+    snapshotRef.current = readCallbackSnapshot(location.search);
+    snapshotCapturedRef.current = true;
+  }
+
+  const routerLocationIsClean = location.search === ''
+    && location.hash === ''
+    && location.state === null;
+  const currentLocationIsClean = routerLocationIsClean
+    && nativeAddressIsClean(location.pathname);
+  const initiallyCleanRef = useRef(currentLocationIsClean);
+  const cleanupCompleteRef = useRef(initiallyCleanRef.current);
+  const cleanupFailedRef = useRef(false);
+  const cleanupRequestedRef = useRef(false);
+  const [cleanupState, setCleanupState] = useState<'pending' | 'clean' | 'failed'>(
+    initiallyCleanRef.current ? 'clean' : 'pending',
+  );
+
+  useEffect(() => {
+    if (cleanupFailedRef.current) return undefined;
+
+    if (currentLocationIsClean) {
+      cleanupCompleteRef.current = true;
+      setCleanupState('clean');
+      return undefined;
+    }
+
+    if (
+      cleanupRequestedRef.current
+      && routerLocationIsClean
+      && !nativeAddressIsClean(location.pathname)
+    ) {
+      cleanupFailedRef.current = true;
+      snapshotRef.current = null;
+      setCleanupState('failed');
+      return undefined;
+    }
+
+    const cleanLocation = {
+      pathname: location.pathname,
+      search: '',
+      hash: '',
+    };
+
+    if (cleanupCompleteRef.current) {
+      cleanupFailedRef.current = true;
+      snapshotRef.current = null;
+      setCleanupState('failed');
+      try {
+        navigate(cleanLocation, { replace: true, state: null });
+      } catch {
+        // The fixed failure below is the only public result.
+      }
+      return undefined;
+    }
+
+    if (!cleanupRequestedRef.current) {
+      cleanupRequestedRef.current = true;
+      try {
+        navigate(cleanLocation, { replace: true, state: null });
+      } catch {
+        cleanupFailedRef.current = true;
+        snapshotRef.current = null;
+        setCleanupState('failed');
+        return undefined;
+      }
+
+      if (!nativeAddressIsClean(cleanLocation.pathname)) {
+        cleanupFailedRef.current = true;
+        snapshotRef.current = null;
+        setCleanupState('failed');
+        return undefined;
+      }
+    }
+
+    return undefined;
+  }, [
+    currentLocationIsClean,
+    location.hash,
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+    routerLocationIsClean,
+  ]);
+
+  if (cleanupState === 'failed') {
+    return <CallbackScreen status="error" message={STRAVA_CALLBACK_FAILURE} />;
+  }
+  if (cleanupState !== 'clean' || !currentLocationIsClean || snapshotRef.current === null) {
+    return <CallbackScreen status="exchanging" message="" />;
+  }
+  return <CallbackAttempt snapshot={snapshotRef.current} />;
 }
 
 export default StravaCallback;


### PR DESCRIPTION
Closes #335

## Outcome

The Strava callback now captures only the initial synthetic-tested `code`, `state`, and provider-error fields in temporary component memory. It replaces the current native browser and React Router entry with the same clean path before mounting callback-specific Auth/service hooks, checking state, or starting the existing exchange attempt.

A thrown, ineffective, or path-divergent replacement shows one fixed accessible stop. An unconfirmed Router transition waits with callback-specific work unmounted. A later callback reinjection is discarded. UID/service/Firebase/app changes permanently invalidate the browser result; they do not cancel server/provider work that already began.

## Security and compatibility proof

- Native pathname, query, and fragment plus Router pathname, query, fragment, and saved state must agree and be clean before callback work.
- Synthetic canaries are observed at hook/verify/exchange time and never appear in the page, console, Router state, or saved artifacts.
- StrictMode, ordinary rerenders, A→B→A identity changes, service/app changes, unmount, synchronous failure, rejected promises, and same-route reinjection are covered.
- Existing signed-out, provider-error, missing-code, invalid-state, pending, success, fixed-error, Back-link, `(app, code)` call, and success `REPLACE` behavior remain covered.
- #99 Pages/telemetry/App Check behavior and #242 failure wording remain unchanged.

Exact reviewed source head: `a52564cbf94c843e574c55c8e24d25485ded93d7`

Exact four-path diff SHA-256: `f9fefe29014c5432bfa37a120c4206406fa2de5cc2d65997bd3a6f1486ed82ed`

## Verification

Node 20:

- Intended RED on old source: 3 failures; test-only diff `a2f2b25886f10effbbb46190454c100dcf609d35db93fc45d4408a64ce5dcb2f`
- Callback boundary: 23/23
- Complete Account file: 68/68
- Complete frontend: 12 suites / 510 tests
- TypeScript: passed
- Non-mutating lint ledger: 106 files / 123 reviewed errors / 7 reviewed warnings
- SPA and repository-safety suite: 57/57
- Diagnostic production build: passed
- Functions lint and tests: 2,389 passed / 64 intentionally skipped
- Firestore Rules emulator: 378/378
- Real commerce-journal emulator: 63/63
- `git diff --check`: clean

Three independent exact-hash reviews approved security/privacy, React/Router test and lifecycle behavior, and officer/system documentation.

## Residual scope

Canonical #88 remains open for server-issued one-use state, UID/session binding, TTL/replay, App Check handoff, account/scope policy, concurrency and reconciliation, revoke/audit, IAM/encryption, provider configuration, deployment, and live proof. Cleaning the current entry does not erase earlier browser, provider, hosting, or network copies.

Officer impact: Future published source removes made-up Strava callback details from the current entry before callback-specific work. Officers must never request, copy, screenshot, inspect, or replay a real callback.

Officer documentation: `SYSTEM_DESIGN.md`; `docs/officers/EVENTS_SHOP_MEMBERS.md`.

Deployment evidence: Source and local tests only at PR creation. Website publication, exact `runmprc.com` revision verification, Firebase deployment, Strava/provider configuration, production-data action, and live OAuth behavior were not performed or claimed.