### PR TITLE
PAY-001C1A: validate stored merchandise price

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -277,6 +277,52 @@ Officer source-review steps:
 
 **Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if any submitted person or event detail appears in output.
 
+## Merchandise price format guard — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** stop an invalid stored product price before the server creates an order identifier, changes a product record, or asks Stripe to create a Product or Checkout Session.
+
+**Approver:** shop lead plus treasurer and platform/security owner.
+
+**Prerequisites:** issue [#339](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/339) must be merged for source review. Use only a made-up active product, a made-up buyer, and test replacements that do not contact Stripe. The private inventory in [#113](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/113) is required before any deployment or catalog repair. This price check does not approve a product, price, tax, shipping rule, return policy, or live sale.
+
+```mermaid
+flowchart LR
+    A["Made-up product passes earlier checkout checks"] --> B["Read one stored price without conversion"]
+    B --> C{"Whole-number USD cents from 50 through 99,999,999?"}
+    C -- "No or unknown" --> D["Fixed unavailable result; no token, order, product change, or Stripe method"]
+    C -- "Yes" --> E["Copy the same cents into the unfinished order and Checkout request"]
+```
+
+Text alternative: after earlier checkout and request-count checks, an invalid stored price stops before a confirmation token, order, stored Stripe Product link, or Stripe call; a whole-number price inside the stated limits is copied unchanged into both later amount fields.
+
+Officer source-review steps:
+
+1. Keep live Shop checkout unavailable.
+2. Ask the platform owner for the exact #339 pull request and merge commit.
+3. Ask for the made-up test report from that same commit.
+4. Confirm the report uses only a made-up product and buyer.
+5. Confirm prices that are missing, zero, below 50 cents, negative, decimal, text, special computer values that are not usable prices, or numbers longer than eight digits receive exactly `This item is unavailable`.
+6. Confirm a rejected price creates no confirmation token or order identifier.
+7. Confirm a rejected price writes no order or stored Stripe Product link.
+8. Confirm a rejected price calls no Stripe Product or Checkout Session method.
+9. Confirm 50 cents, one ordinary test price, and 99,999,999 cents are copied unchanged into the made-up order and a test Checkout request that does not contact Stripe.
+10. Confirm the report says that earlier request, access, status, and option checks may already have run, and earlier request-count safety counters may already have been written and are not rolled back.
+11. Record source change, tests, merge, website publication, `runmprc.com`, Firebase deployment, Stripe state, catalog or order data, migration, and live behavior as separate results.
+
+**Expected result:** malformed stored prices stop safely with one plain result and no later order, stored Stripe Product link, or Stripe call or change. Exact whole-number values from 50 through 99,999,999 pass this source check and are copied without conversion. These technical limits are not approval to charge any amount or proof that Stripe will accept a later request. Complete product and option records, stock control, safe repeat handling, checking Stripe's answer, and matching club orders to Stripe are still unfinished.
+
+**Stop conditions:** any real buyer, product, price, order, payment, Firebase record, Stripe object, Stripe call, production test, or request to repair Firestore or Stripe by hand; a missing exact commit; a raw price or technical detail in output; a rejection that allocates an order identifier or performs a later order or stored Stripe Product-link write; or a claim that source, tests, merge, preview, or a green workflow proves Shop checkout is safe or live.
+
+**Success proof:** exact #339 pull request and merge commit; recorded old-source failures; green price-check tests, full server tests, database-permission tests, isolated test-database commerce tests, website tests, safety checks, and build checks; independent security, compatibility, and backup-officer reviews; and a written statement that website publication, `runmprc.com`, Firebase, Stripe settings, production data, migration, and live behavior were not changed or verified. Any future live release needs a private catalog inventory, approved business policy, isolated Stripe test-mode proof, Firebase deployment and readback, proof that club orders match Stripe, and rollback evidence.
+
+**Undo:** before Firebase deployment, use one reviewed pull request that reverses the change or corrects it safely. After any later approved backend deployment, use the approved backend release process and confirm the exact published Function revision. Never undo by changing a product, price, order, Product, Session, payment, or Stripe setting by hand.
+
+**Escalation:** shop lead plus treasurer and platform/security owner. Add the privacy owner if buyer or order details appeared. Use the private incident path if a malformed price might have created an order or Stripe object. Do not copy private details or Stripe IDs into an issue, screenshot, email, message, or AI tool.
+
+No main system map needs to change because this source change adds one price stop without changing who owns an account, who has permission, where records are stored, which Stripe boundary is used, or how the website is published. The small diagram above records the new failure path and the unchanged valid-price continuation.
+
 ## Late-registration amount format guard — SOURCE ONLY, NOT LIVE
 
 **Purpose:** stop a missing, malformed, or out-of-range late-registration amount before the server allocates a registration identifier, writes a paid record, or asks Stripe to create a Product, Price, or Payment Link.

--- a/functions/checkoutPromotionPolicy.test.js
+++ b/functions/checkoutPromotionPolicy.test.js
@@ -8,6 +8,7 @@ const mockGenerateToken = jest.fn();
 const mockResolveCallerRole = jest.fn();
 const mockCountActiveRegistrations = jest.fn();
 const mockRegistrationAllocation = jest.fn();
+const mockOrderAllocation = jest.fn();
 
 jest.mock('firebase-functions', () => {
   class HttpsError extends Error {
@@ -81,6 +82,7 @@ jest.mock('firebase-admin', () => {
         registrationSequence += 1;
         resolvedId = `reg-new-${registrationSequence}`;
       } else if (!resolvedId && this.path === 'orders') {
+        mockOrderAllocation(this.path);
         orderSequence += 1;
         resolvedId = `order-new-${orderSequence}`;
       }
@@ -192,6 +194,7 @@ describe('Checkout promotion policy', () => {
     mockResolveCallerRole.mockReset();
     mockCountActiveRegistrations.mockReset();
     mockRegistrationAllocation.mockReset();
+    mockOrderAllocation.mockReset();
     mockGetStripe.mockReturnValue({
       checkout: { sessions: { create: mockCheckoutCreate } },
       products: { create: mockProductCreate },
@@ -884,6 +887,271 @@ describe('Checkout promotion policy', () => {
       stripeSessionId: 'cs_order_policy',
     });
     expect(mockProductCreate).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['a string price', '2000'],
+    ['a sub-minimum paid price', 49],
+    ['zero', 0],
+    ['a fractional price', 50.5],
+    ['a non-finite price', Number.NaN],
+    ['a price over the provider limit', 100_000_000],
+  ])('rejects %s before order and provider side effects', async (
+    _name,
+    priceCents,
+  ) => {
+    admin.__seed('products/hat', {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      description: 'Synthetic test product',
+      slug: 'hat',
+      status: 'active',
+      priceCents,
+    });
+    mockProductCreate.mockResolvedValue({ id: 'prod_should_not_exist' });
+
+    const outcome = await createMerchCheckout({
+      productSlug: 'hat',
+      buyer: {
+        firstName: 'Test',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+      },
+    }, { auth: null, rawRequest: {} }).then(
+      (value) => ({ value }),
+      (error) => ({ error }),
+    );
+
+    expect({
+      settled: outcome.error ? 'rejected' : 'resolved',
+      code: outcome.error?.code || null,
+      message: outcome.error?.message || null,
+      rateLimitCalls: mockRateLimit.mock.calls.length,
+      tokenCalls: mockGenerateToken.mock.calls.length,
+      orderAllocations: mockOrderAllocation.mock.calls.length,
+      writes: mockFirestoreWrite.mock.calls.length,
+      stripeAccesses: mockGetStripe.mock.calls.length,
+      productCreates: mockProductCreate.mock.calls.length,
+      checkoutCreates: mockCheckoutCreate.mock.calls.length,
+    }).toEqual({
+      settled: 'rejected',
+      code: 'failed-precondition',
+      message: 'This item is unavailable',
+      rateLimitCalls: 2,
+      tokenCalls: 0,
+      orderAllocations: 0,
+      writes: 0,
+      stripeAccesses: 0,
+      productCreates: 0,
+      checkoutCreates: 0,
+    });
+    expect(admin.__get('products/hat').stripeProductId).toBeUndefined();
+    expect(admin.__get('orders/order-new-1')).toBeUndefined();
+  });
+
+  test.each([50, 99_999_999])(
+    'preserves the valid merchandise boundary %s in the order and Session',
+    async (priceCents) => {
+      admin.__seed('products/hat', {
+        checkoutEnabled: true,
+        title: 'Synthetic Hat',
+        slug: 'hat',
+        status: 'active',
+        priceCents,
+        stripeProductId: 'prod_hat_policy',
+      });
+
+      await createMerchCheckout({
+        productSlug: 'hat',
+        buyer: {
+          firstName: 'Test',
+          lastName: 'Buyer',
+          email: 'buyer@example.test',
+        },
+      }, { auth: null, rawRequest: {} });
+
+      expect(admin.__get('orders/order-new-1')).toMatchObject({
+        amountCents: priceCents,
+        currency: 'usd',
+      });
+      expect(mockCheckoutCreate.mock.calls[0][0]
+        .line_items[0].price_data.unit_amount).toBe(priceCents);
+      expect(mockProductCreate).not.toHaveBeenCalled();
+    },
+  );
+
+  test('uses one copied price when the admitted product changes after projection', async () => {
+    admin.__seed('products/hat', {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      slug: 'hat',
+      status: 'active',
+      priceCents: 2_000,
+      stripeProductId: 'prod_hat_policy',
+    });
+    mockGenerateToken.mockImplementation(() => {
+      admin.__get('products/hat').priceCents = 49;
+      return 'synthetic-confirmation-token';
+    });
+
+    await createMerchCheckout({
+      productSlug: 'hat',
+      buyer: {
+        firstName: 'Test',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+      },
+    }, { auth: null, rawRequest: {} });
+
+    expect(admin.__get('products/hat').priceCents).toBe(49);
+    expect(admin.__get('orders/order-new-1').amountCents).toBe(2_000);
+    expect(mockCheckoutCreate.mock.calls[0][0]
+      .line_items[0].price_data.unit_amount).toBe(2_000);
+  });
+
+  test('does not log or copy a hostile invalid merchandise price', async () => {
+    const canary = 'merch_price_secret_canary';
+    const productBefore = {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      slug: 'hat',
+      status: 'active',
+      priceCents: canary,
+    };
+    admin.__seed('products/hat', productBefore);
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => {}));
+
+    try {
+      const outcome = await createMerchCheckout({
+        productSlug: 'hat',
+        buyer: {
+          firstName: 'Test',
+          lastName: 'Buyer',
+          email: 'buyer@example.test',
+        },
+      }, { auth: null, rawRequest: {} }).then(
+        (value) => ({ value }),
+        (error) => ({ error }),
+      );
+
+      expect(outcome.error).toMatchObject({
+        code: 'failed-precondition',
+        message: 'This item is unavailable',
+      });
+      const publicError = [
+        outcome.error.code,
+        outcome.error.message,
+        outcome.error.stack,
+      ].join('\n');
+      expect(publicError).not.toContain(canary);
+      expect(publicError).not.toContain('priceCents');
+
+      expect(mockRateLimit).toHaveBeenCalledTimes(2);
+      expect(mockGenerateToken).not.toHaveBeenCalled();
+      expect(mockOrderAllocation).not.toHaveBeenCalled();
+      expect(mockFirestoreWrite).not.toHaveBeenCalled();
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(mockProductCreate).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+      expect(admin.__get('products/hat')).toEqual(productBefore);
+      expect(admin.__get('orders/order-new-1')).toBeUndefined();
+    } finally {
+      consoleSpies.forEach((spy) => spy.mockRestore());
+    }
+  });
+
+  test.each([
+    ['size', { sizes: ['M'], colors: ['blue'] }, { size: 'XL' }, 'Invalid size'],
+    ['color', { sizes: ['M'], colors: ['blue'] }, { color: 'red' }, 'Invalid color'],
+  ])('keeps invalid %s ahead of the price guard', async (
+    _name,
+    options,
+    selection,
+    message,
+  ) => {
+    admin.__seed('products/hat', {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      slug: 'hat',
+      status: 'active',
+      priceCents: 'invalid-price',
+      ...options,
+    });
+
+    await expect(createMerchCheckout({
+      productSlug: 'hat',
+      buyer: {
+        firstName: 'Test',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+      },
+      ...selection,
+    }, { auth: null, rawRequest: {} })).rejects.toMatchObject({
+      code: 'invalid-argument',
+      message,
+    });
+
+    expect(mockRateLimit).toHaveBeenCalledTimes(2);
+    expect(mockGenerateToken).not.toHaveBeenCalled();
+    expect(mockOrderAllocation).not.toHaveBeenCalled();
+    expect(mockFirestoreWrite).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  test('keeps sold-out status ahead of the price guard', async () => {
+    admin.__seed('products/hat', {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      slug: 'hat',
+      status: 'sold_out',
+      priceCents: 'invalid-price',
+    });
+
+    await expect(createMerchCheckout({
+      productSlug: 'hat',
+      buyer: {
+        firstName: 'Test',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+      },
+    }, { auth: null, rawRequest: {} })).rejects.toMatchObject({
+      code: 'failed-precondition',
+      message: 'This item is sold out',
+    });
+
+    expect(mockRateLimit).toHaveBeenCalledTimes(2);
+    expect(mockGenerateToken).not.toHaveBeenCalled();
+    expect(mockOrderAllocation).not.toHaveBeenCalled();
+    expect(mockFirestoreWrite).not.toHaveBeenCalled();
+    expect(mockGetStripe).not.toHaveBeenCalled();
+  });
+
+  test('keeps valid missing-Product mapping and checkout behavior', async () => {
+    admin.__seed('products/hat', {
+      checkoutEnabled: true,
+      title: 'Synthetic Hat',
+      slug: 'hat',
+      status: 'active',
+      priceCents: 2_000,
+    });
+    mockProductCreate.mockResolvedValue({ id: 'prod_hat_created' });
+
+    await createMerchCheckout({
+      productSlug: 'hat',
+      buyer: {
+        firstName: 'Test',
+        lastName: 'Buyer',
+        email: 'buyer@example.test',
+      },
+    }, { auth: null, rawRequest: {} });
+
+    expect(mockProductCreate).toHaveBeenCalledTimes(1);
+    expect(admin.__get('products/hat').stripeProductId).toBe('prod_hat_created');
+    expect(admin.__get('orders/order-new-1').amountCents).toBe(2_000);
+    expect(mockCheckoutCreate.mock.calls[0][0]
+      .line_items[0].price_data.unit_amount).toBe(2_000);
   });
 
   test.each([

--- a/functions/createMerchCheckout.js
+++ b/functions/createMerchCheckout.js
@@ -15,6 +15,9 @@ const {
   COMMERCE_OPERATIONS,
   requireCommerceAdmission,
 } = require('./commerceControl');
+const {
+  projectMerchandisePriceCents,
+} = require('./merchCheckoutValidation');
 
 const HOUR_MS = 60 * 60 * 1000;
 const MERCH_PER_IP_PER_HOUR = 20;
@@ -100,6 +103,14 @@ exports.createMerchCheckout = functions
       throw new functions.https.HttpsError('invalid-argument', 'Invalid color');
     }
 
+    const priceCents = projectMerchandisePriceCents(product);
+    if (priceCents === null) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'This item is unavailable',
+      );
+    }
+
     const confirmationToken = generateToken();
     const orderRef = db.collection('orders').doc();
 
@@ -115,7 +126,7 @@ exports.createMerchCheckout = functions
       shipping: null,
       size: size || null,
       color: color || null,
-      amountCents: product.priceCents,
+      amountCents: priceCents,
       currency: 'usd',
       status: 'pending',
       stripeSessionId: null,
@@ -151,7 +162,7 @@ exports.createMerchCheckout = functions
       line_items: [{
         price_data: {
           currency: 'usd',
-          unit_amount: product.priceCents,
+          unit_amount: priceCents,
           product: stripeProductId,
         },
         quantity: 1,

--- a/functions/merchCheckoutValidation.js
+++ b/functions/merchCheckoutValidation.js
@@ -1,0 +1,69 @@
+const { types: { isProxy } } = require('node:util');
+
+const STRIPE_MINIMUM_USD_CENTS = 50;
+const STRIPE_UNIT_AMOUNT_MAX_CENTS = 99_999_999;
+const INVALID_PRICE_VALUE = Symbol('invalid-merchandise-price-value');
+
+const numberIsSafeInteger = Number.isSafeInteger;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwn = Object.hasOwn;
+const objectIs = Object.is;
+const objectPrototype = Object.prototype;
+
+function isProxyValue(value) {
+  try {
+    return isProxy(value);
+  } catch (_error) {
+    return true;
+  }
+}
+
+function isPlainRecord(value) {
+  if (value === null || typeof value !== 'object' || isProxyValue(value)) {
+    return false;
+  }
+  try {
+    return objectGetPrototypeOf(value) === objectPrototype;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function ownEnumerableDataValue(record, key) {
+  let descriptor;
+  try {
+    descriptor = objectGetOwnPropertyDescriptor(record, key);
+  } catch (_error) {
+    return INVALID_PRICE_VALUE;
+  }
+  if (!descriptor
+    || !objectHasOwn(descriptor, 'value')
+    || descriptor.enumerable !== true) {
+    return INVALID_PRICE_VALUE;
+  }
+  return descriptor.value;
+}
+
+function projectMerchandisePriceCents(product) {
+  if (!isPlainRecord(product)) return null;
+
+  const priceCents = ownEnumerableDataValue(product, 'priceCents');
+  if (
+    typeof priceCents !== 'number'
+    || !numberIsSafeInteger(priceCents)
+    || objectIs(priceCents, -0)
+    || priceCents < STRIPE_MINIMUM_USD_CENTS
+    || priceCents > STRIPE_UNIT_AMOUNT_MAX_CENTS
+  ) {
+    return null;
+  }
+
+  return priceCents;
+}
+
+module.exports = {
+  STRIPE_MINIMUM_USD_CENTS,
+  STRIPE_UNIT_AMOUNT_MAX_CENTS,
+  projectMerchandisePriceCents,
+};

--- a/functions/merchCheckoutValidation.test.js
+++ b/functions/merchCheckoutValidation.test.js
@@ -1,0 +1,245 @@
+const {
+  STRIPE_MINIMUM_USD_CENTS,
+  STRIPE_UNIT_AMOUNT_MAX_CENTS,
+  projectMerchandisePriceCents,
+} = require('./merchCheckoutValidation');
+
+describe('merchandise Checkout price projection', () => {
+  test.each([
+    STRIPE_MINIMUM_USD_CENTS,
+    2_000,
+    STRIPE_UNIT_AMOUNT_MAX_CENTS,
+  ])('copies exact valid integer cents %s', (priceCents) => {
+    const product = { priceCents };
+
+    const projected = projectMerchandisePriceCents(product);
+    product.priceCents = 49;
+    Object.defineProperty(product, 'priceCents', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        throw new Error('changed getter should not run');
+      },
+    });
+    delete product.priceCents;
+
+    expect(projected).toBe(priceCents);
+  });
+
+  test('accepts an enumerable frozen price data property', () => {
+    expect(projectMerchandisePriceCents(Object.freeze({ priceCents: 2_000 })))
+      .toBe(2_000);
+  });
+
+  test.each([
+    ['explicit undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['true', true],
+    ['zero', 0],
+    ['negative zero', -0],
+    ['one cent', 1],
+    ['one below the minimum', STRIPE_MINIMUM_USD_CENTS - 1],
+    ['negative', -1],
+    ['fractional', 50.5],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+    ['one over the provider limit', STRIPE_UNIT_AMOUNT_MAX_CENTS + 1],
+    ['numeric string', '2000'],
+    ['bigint', 2_000n],
+    ['boxed number', new Number(2_000)], // eslint-disable-line no-new-wrappers
+    ['date', new Date(2_000)],
+    ['array', [2_000]],
+    ['plain object', { value: 2_000 }],
+    ['map', new Map([['value', 2_000]])],
+    ['set', new Set([2_000])],
+    ['function', () => 2_000],
+    ['symbol', Symbol('synthetic-price')],
+  ])('rejects %s without conversion', (_name, priceCents) => {
+    const conversion = jest.fn(() => {
+      throw new Error('conversion should not run');
+    });
+    if (priceCents && (typeof priceCents === 'object' || typeof priceCents === 'function')) {
+      Object.defineProperty(priceCents, Symbol.toPrimitive, {
+        configurable: true,
+        value: conversion,
+      });
+      Object.defineProperty(priceCents, 'valueOf', {
+        configurable: true,
+        value: conversion,
+      });
+      Object.defineProperty(priceCents, 'toString', {
+        configurable: true,
+        value: conversion,
+      });
+      Object.defineProperty(priceCents, 'toJSON', {
+        configurable: true,
+        value: conversion,
+      });
+      Object.defineProperty(priceCents, Symbol.iterator, {
+        configurable: true,
+        value: conversion,
+      });
+    }
+
+    expect(projectMerchandisePriceCents({ priceCents })).toBeNull();
+    expect(conversion).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number primitive', 2_000],
+    ['string primitive', '2000'],
+    ['boolean primitive', true],
+    ['bigint primitive', 2_000n],
+    ['symbol primitive', Symbol('synthetic-product')],
+    ['function', () => ({ priceCents: 2_000 })],
+    ['boxed number', new Number(2_000)], // eslint-disable-line no-new-wrappers
+    ['boxed string', new String('2000')], // eslint-disable-line no-new-wrappers
+    ['boxed boolean', new Boolean(true)], // eslint-disable-line no-new-wrappers
+    ['array', []],
+    ['date', new Date(0)],
+    ['map', new Map()],
+    ['set', new Set()],
+    ['null prototype', Object.create(null)],
+    ['custom prototype', Object.create({})],
+    ['class instance', new (class Product {})()],
+  ])('rejects a %s product container', (_name, product) => {
+    if (product && typeof product === 'object') product.priceCents = 2_000;
+    expect(projectMerchandisePriceCents(product)).toBeNull();
+  });
+
+  test('rejects missing, inherited, non-enumerable, and accessor prices without reading them', () => {
+    const getter = jest.fn(() => {
+      throw new Error('getter should not run');
+    });
+    const accessorProduct = {};
+    Object.defineProperty(accessorProduct, 'priceCents', {
+      enumerable: true,
+      get: getter,
+    });
+    const nonEnumerableProduct = {};
+    Object.defineProperty(nonEnumerableProduct, 'priceCents', {
+      enumerable: false,
+      value: 2_000,
+    });
+
+    expect(projectMerchandisePriceCents({})).toBeNull();
+    expect(projectMerchandisePriceCents(Object.create({ priceCents: 2_000 }))).toBeNull();
+    expect(projectMerchandisePriceCents(nonEnumerableProduct)).toBeNull();
+    expect(projectMerchandisePriceCents(accessorProduct)).toBeNull();
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test('ignores a polluted Object.prototype price getter', () => {
+    const previousDescriptor = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'priceCents',
+    );
+    const getter = jest.fn(() => {
+      throw new Error('inherited getter should not run');
+    });
+
+    try {
+      Object.defineProperty(Object.prototype, 'priceCents', {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+      expect(projectMerchandisePriceCents({})).toBeNull();
+      expect(getter).not.toHaveBeenCalled();
+    } finally {
+      if (previousDescriptor) {
+        Object.defineProperty(Object.prototype, 'priceCents', previousDescriptor);
+      } else {
+        delete Object.prototype.priceCents;
+      }
+    }
+  });
+
+  test('rejects live and revoked proxies without invoking traps', () => {
+    const trap = jest.fn(() => {
+      throw new Error('proxy trap should not run');
+    });
+    const proxy = new Proxy({ priceCents: 2_000 }, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    const revoked = Proxy.revocable({ priceCents: 2_000 }, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    revoked.revoke();
+
+    expect(projectMerchandisePriceCents(proxy)).toBeNull();
+    expect(projectMerchandisePriceCents(revoked.proxy)).toBeNull();
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test('does not enumerate or inspect unrelated hostile fields', () => {
+    const getter = jest.fn(() => {
+      throw new Error('unrelated getter should not run');
+    });
+    const trap = jest.fn(() => {
+      throw new Error('nested proxy trap should not run');
+    });
+    const product = { priceCents: 2_000 };
+    product.self = product;
+    product.nested = new Proxy({}, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    Object.defineProperty(product, 'unknown', {
+      enumerable: true,
+      get: getter,
+    });
+    Object.defineProperty(product, Symbol('synthetic-field'), {
+      enumerable: true,
+      get: getter,
+    });
+
+    expect(projectMerchandisePriceCents(product)).toBe(2_000);
+    expect(getter).not.toHaveBeenCalled();
+    expect(trap).not.toHaveBeenCalled();
+  });
+
+  test('uses captured intrinsics after import', () => {
+    const utilTypes = require('node:util').types;
+    const replacements = [
+      [Object, 'getOwnPropertyDescriptor'],
+      [Object, 'getPrototypeOf'],
+      [Object, 'hasOwn'],
+      [Object, 'is'],
+      [Number, 'isSafeInteger'],
+      [utilTypes, 'isProxy'],
+    ];
+    const originals = replacements.map(([owner, key]) => [owner, key, owner[key]]);
+    const replacement = jest.fn(() => {
+      throw new Error('patched intrinsic should not run');
+    });
+    let projected;
+
+    try {
+      replacements.forEach(([owner, key]) => {
+        owner[key] = replacement;
+      });
+      projected = projectMerchandisePriceCents({ priceCents: 2_000 });
+    } finally {
+      originals.forEach(([owner, key, original]) => {
+        owner[key] = original;
+      });
+    }
+
+    expect(projected).toBe(2_000);
+    expect(replacement).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Officer impact: Future deployed backend code will refuse a merchandise checkout when the stored catalog price is not one valid whole-number USD-cent value. Officers must stop and request reviewed catalog repair; they must not change Firestore or Stripe by hand.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — new plain-language `Merchandise price format guard — SOURCE ONLY, NOT LIVE` procedure.

Deployment evidence: Source and tests only. Website not published; `runmprc.com` not verified; Firebase not deployed; Stripe/provider settings not changed or verified; production catalog/order data not accessed or changed; no migration or live-behavior proof.

## Outcome

This focused PAY-001C child validates one stored merchandise price before confirmation-token generation, order-ID allocation, later order/product-link writes, Stripe access, Product creation, or Checkout Session creation.

Exact source head: `05384163d60f0e524cd492c48b12603cc72db199`

Exact five-file diff SHA-256: `9b00afccd3579bf6d85925732fcc4649f6299ff0f0d1bded2b3ad9522065769c`

## Security invariant

- Read `priceCents` only from an own enumerable data property on an ordinary non-Proxy product record.
- Do not coerce, enumerate, stringify, or invoke accessors, Proxy traps, or supplied conversion hooks.
- Admit only a primitive safe integer, not negative zero, from 50 through 99,999,999 cents.
- Return the fixed `failed-precondition / This item is unavailable` result for every malformed value.
- Preserve existing earlier admission, buyer, rate-limit, status, and option checks. Earlier rate-limit counters may already be written and are not rolled back.
- Copy one projected primitive unchanged into both the pending order snapshot and Stripe Session request.

## Changes

- Added a dependency-free CommonJS price projector and exhaustive pure tests.
- Adopted the projector in `createMerchCheckout` after status/option checks and before token/order/Stripe work.
- Added real-handler side-effect, fixed-error, canary-redaction, boundary, mutation-stability, validation-order, and valid Product-mapping regression tests.
- Added a complete nontechnical officer procedure with a Mermaid diagram and written alternative.

## Reproducible RED proof

On exact old runtime `4e962c8909503a225bb128607dc34da49a54f729`, Node 20, a test-only diff produced 31 existing passes and two intended failures. Both string `"2000"` and numeric `49` resolved and reached token generation, order allocation, Stripe Product creation, Checkout Session creation, and two later Firestore writes instead of failing first. Only synthetic values and mocks were used.

## Local verification

- Focused helper + real handler: 97/97
- Functions lint: pass
- Full Functions: 2,465 active pass; 64 emulator-only skipped
- Frontend Jest: 510/510
- Legacy frontend lint ledger: unchanged at 106 files / 123 reviewed errors / 7 warnings
- TypeScript and diagnostic production build: pass
- SPA navigation: 11/11
- Repository safety/workflow/release/readback/artifact: 46/46
- Firestore Rules: 378/378
- Real demo-only Firestore commerce-journal emulator: 63/63
- Diff check and secret-pattern scan: clean

The final wording-only amendment left all four runtime/test blobs byte-identical. The exact final head reran the 97 focused tests.

## Independent review

Three independent exact-hash reviews approve with no findings:

1. validation/security and Firestore compatibility;
2. handler side effects, test quality, and Node 20/CommonJS compatibility;
3. officer continuity, diagram accuracy, and deployment-state truth.

## Residual risk and explicit exclusions

This does not complete product/variant schemas, inventory holds, request idempotency, persistence-first checkout, Stripe result validation, Product/Price synchronization, webhook behavior, retry/reconciliation, or approved business policy. It does not inventory or repair malformed production catalog data; that remains a private #113 decision. It changes no package, lockfile, workflow, Rules, endpoint export, provider setting, secret, deployment, production data, or live system.

This PR intentionally does not auto-close #339. The issue remains claimed until exact-head hosted CI, controlled merge, exact-main CI/deployment audit, checklist/evidence update, and explicit release.