### PR TITLE
PAY-001B1C: fail closed on malformed early-bird cutoff (#341)

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -277,6 +277,63 @@ Officer source-review steps:
 
 **Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if any submitted person or event detail appears in output.
 
+## Early-bird cutoff format guard — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** treat a missing or malformed stored early-bird cutoff as inactive before later registration or Stripe work.
+
+**Approver:** event lead plus treasurer and platform/security owner.
+
+**Prerequisites for source review:** issue [#341](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/341) must be merged. The exact pull request and merge commit must be named. Tests must use only a made-up event, a made-up runner, and replacements that cannot contact Firebase or Stripe. A Firebase date-and-time value means the database's own `Timestamp` format. Text and an ordinary JavaScript date value do not count. The private inventory in [#113](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/113) is required before deployment or data repair. This check does not approve a cutoff date, timezone, price, membership rule, or eligibility policy.
+
+```mermaid
+flowchart TD
+    A["Made-up race checkout passes earlier checks"] --> B{"Cutoff uses the exact Firebase date-and-time format?"}
+    B -- "No" --> C["Treat early bird as inactive"]
+    B -- "Yes" --> D{"Is the test clock before the cutoff?"}
+    D -- "No" --> C
+    D -- "Yes" --> E["Continue to the separate price check"]
+    C --> F{"Did the request explicitly choose early bird?"}
+    F -- "Yes" --> G["Fixed unavailable result; no later registration or Stripe work"]
+    F -- "No" --> H["Use the existing member or nonmember fallback"]
+```
+
+Text alternative: after earlier checkout checks, a missing, malformed, or reached cutoff makes early bird inactive. An explicit early-bird choice receives one fixed unavailable result and stops before later registration or Stripe work. Automatic price selection uses the existing member or nonmember fallback. Only the exact Firebase date-and-time format later than the test clock may continue to the separate price check.
+
+Officer source-review steps:
+
+1. Keep live race checkout unavailable.
+2. Ask the platform owner for the exact #341 pull request.
+3. Ask the platform owner for the exact merge commit.
+4. Ask for the made-up test report from that same commit.
+5. Confirm the report uses only a made-up event and runner.
+6. Confirm missing, null, text, ordinary JavaScript date, altered, or distinguishably fake cutoff values are inactive.
+7. Confirm one valid cutoff is active before its exact time.
+8. Confirm that cutoff is inactive at its exact time or later.
+9. Confirm malformed values cannot run a method stored inside them.
+10. Confirm malformed values cannot expose their stored value in the new fixed result or guard logs.
+11. Confirm an explicit early-bird request receives exactly `Early-bird pricing is no longer available`.
+12. Confirm that rejection creates no confirmation token.
+13. Confirm that rejection creates no registration identifier or registration write.
+14. Confirm that rejection creates no Stripe Product or Checkout Session.
+15. Confirm earlier checkout, access, capacity, and role checks may already have run.
+16. Confirm earlier request-count safety counters may already have been written and are not rolled back.
+17. Confirm automatic price selection uses the existing member or nonmember fallback when early bird is inactive.
+18. Record source, tests, merge, website publication, `runmprc.com`, Firebase deployment, Stripe state, production data, migration, and live behavior as separate results.
+
+**Expected result:** only the exact current Firebase date-and-time format can make early bird active, and only while the clock is strictly before it. Missing or malformed cutoffs are inactive without running stored code or exposing the value. An explicit early-bird choice stops with the fixed unavailable result before later registration or Stripe work. Automatic selection keeps its existing fallback. The separate race price guard still checks the selected amount. This cutoff check does not approve that amount or prove that the complete checkout is safe.
+
+**Stop conditions:** any real runner, event, registration, payment, Firebase record, Stripe object, Stripe call, or production test; a request to repair Firebase or Stripe by hand; a missing exact commit; private or raw cutoff details in shared evidence; a rejection that allocates a registration identifier, writes a registration, or reaches Stripe; deployment before the #113 inventory; or a claim that source, tests, merge, preview, or a green workflow approves the business cutoff or proves live checkout behavior.
+
+**Success proof:** exact #341 pull request and merge commit; recorded old-source failures using made-up values; green cutoff, caller, full server, database-permission, isolated test-database commerce, website, safety, and build checks; independent security, compatibility, and backup-officer reviews; and a written statement that website publication, `runmprc.com`, Firebase, Stripe, production data, migration, and live behavior were not changed or verified. A future live release also needs an owner-approved date, timezone, price, and fallback policy; the private #113 inventory; isolated Stripe test-mode proof; exact Firebase Function deployment and readback; and rollback evidence.
+
+**Undo:** before Firebase deployment, use one reviewed pull request that reverses the change or corrects it safely. After any approved backend deployment, use the protected backend release process and confirm the exact published Function revision. Never undo by changing an event, cutoff, registration, Product, Session, or payment record by hand.
+
+**Escalation:** event lead plus treasurer and platform/security owner. Add the privacy owner if runner or event details appeared. Use the private incident path if a malformed cutoff may have reached registration or Stripe work. Do not copy private details, cutoff values, or provider identifiers into an issue, screenshot, email, message, or AI tool.
+
+No main system map needs to change because this source change adds one failure stop without changing ownership, permissions, storage locations, the Stripe boundary, or website publishing. The small diagram above records the new failure path and the unchanged fallback paths.
+
 ## Merchandise price format guard — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/functions/checkoutPromotionPolicy.test.js
+++ b/functions/checkoutPromotionPolicy.test.js
@@ -535,6 +535,73 @@ describe('Checkout promotion policy', () => {
     }
   });
 
+  test('rejects an explicit early-bird request with a malformed cutoff before later work', async () => {
+    const malformedCutoff = '2999-01-01T00:00:00.000Z';
+    const eventBefore = {
+      checkoutEnabled: true,
+      title: 'Synthetic Race',
+      slug: 'synthetic-race',
+      status: 'open',
+      visibility: 'public',
+      capacity: 10,
+      pricing: {
+        earlyBirdCents: 2_000,
+        earlyBirdUntil: malformedCutoff,
+      },
+      waiverVersion: 'synthetic-v1',
+    };
+    admin.__seed('events/race-1', eventBefore);
+    mockProductCreate.mockResolvedValueOnce({ id: 'prod_should_not_exist' });
+    const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => {}));
+
+    try {
+      const outcome = await createCheckoutSession(validRaceRequest({
+        priceTier: 'earlyBird',
+      }), { auth: null, rawRequest: {} }).then(
+        (value) => ({ value }),
+        (error) => ({ error }),
+      );
+
+      expect(outcome.error).toMatchObject({
+        code: 'failed-precondition',
+        message: 'Early-bird pricing is no longer available',
+      });
+      const publicError = [
+        outcome.error.code,
+        outcome.error.message,
+        outcome.error.stack,
+      ].join('\n');
+      expect(publicError).not.toContain(malformedCutoff);
+      expect(publicError).not.toContain('earlyBirdUntil');
+
+      expect(mockFirestoreAccess).toHaveBeenCalledTimes(1);
+      expect(mockRateLimit).toHaveBeenCalledTimes(2);
+      expect(mockCountActiveRegistrations).toHaveBeenCalledTimes(1);
+      expect(mockCountActiveRegistrations).toHaveBeenCalledWith('race-1');
+      expect(mockResolveCallerRole).toHaveBeenCalledTimes(1);
+      const lastRateLimitCall = Math.max(...mockRateLimit.mock.invocationCallOrder);
+      expect(lastRateLimitCall).toBeLessThan(
+        mockCountActiveRegistrations.mock.invocationCallOrder[0],
+      );
+      expect(mockCountActiveRegistrations.mock.invocationCallOrder[0]).toBeLessThan(
+        mockResolveCallerRole.mock.invocationCallOrder[0],
+      );
+
+      expect(mockGenerateToken).not.toHaveBeenCalled();
+      expect(mockRegistrationAllocation).not.toHaveBeenCalled();
+      expect(mockFirestoreWrite).not.toHaveBeenCalled();
+      expect(admin.__get('events/race-1/registrations/reg-new-1')).toBeUndefined();
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(mockProductCreate).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+      expect(admin.__get('events/race-1')).toEqual(eventBefore);
+    } finally {
+      consoleSpies.forEach((spy) => spy.mockRestore());
+    }
+  });
+
   test('race checkout sends the exact disabled-adjustment payload', async () => {
     admin.__seed('events/race-1', {
       checkoutEnabled: true,

--- a/functions/stripeHelpers.js
+++ b/functions/stripeHelpers.js
@@ -126,13 +126,28 @@ function pickPriceCents(event, priceTier) {
   return priceCents;
 }
 
-function isEarlyBirdActive(event, now = Date.now()) {
-  const pricing = event.pricing || {};
-  if (!pricing.earlyBirdCents || !pricing.earlyBirdUntil) return false;
-  const untilMs = pricing.earlyBirdUntil.toMillis
-    ? pricing.earlyBirdUntil.toMillis()
-    : new Date(pricing.earlyBirdUntil).getTime();
-  return now < untilMs;
+function isEarlyBirdActive(event, now = dateNow()) {
+  if (!numberIsFinite(now) || !isPlainEventRecord(event)) return false;
+
+  const pricing = selectedOwnDataValue(event, 'pricing', true);
+  if (!isPlainEventRecord(pricing)) return false;
+
+  const earlyBirdCents = selectedOwnDataValue(
+    pricing,
+    'earlyBirdCents',
+    true,
+  );
+  if (
+    earlyBirdCents === MISSING_REGISTRATION_WINDOW_VALUE
+    || earlyBirdCents === INVALID_REGISTRATION_WINDOW_VALUE
+    || !earlyBirdCents
+  ) {
+    return false;
+  }
+
+  const cutoff = selectedOwnDataValue(pricing, 'earlyBirdUntil', true);
+  const cutoffMs = timestampToMillis(cutoff);
+  return cutoffMs !== INVALID_REGISTRATION_WINDOW_VALUE && now < cutoffMs;
 }
 
 function isProxyValue(value) {

--- a/functions/stripeHelpers.test.js
+++ b/functions/stripeHelpers.test.js
@@ -30,6 +30,7 @@ jest.mock('./serverConfig', () => ({
 }));
 
 const {
+  isEarlyBirdActive,
   isRegistrationOpen,
   pickPriceCents,
   requireAdmin,
@@ -43,6 +44,445 @@ const NOW_MS = 1_735_689_600_000;
 function openEvent(overrides = {}) {
   return { status: 'open', ...overrides };
 }
+
+describe('early-bird cutoff validation', () => {
+  function eventWithCutoff(earlyBirdUntil, earlyBirdCents = 2_000) {
+    return {
+      pricing: {
+        earlyBirdCents,
+        earlyBirdUntil,
+      },
+    };
+  }
+
+  test.each([
+    ['one millisecond before', NOW_MS - 1, true],
+    ['at the cutoff', NOW_MS, false],
+    ['one millisecond after', NOW_MS + 1, false],
+  ])('uses a strict valid Timestamp cutoff %s', (_name, now, expected) => {
+    expect(isEarlyBirdActive(
+      eventWithCutoff(Timestamp.fromMillis(NOW_MS)),
+      now,
+    )).toBe(expected);
+  });
+
+  test('accepts frozen current-realm records and a frozen Timestamp', () => {
+    const cutoff = Object.freeze(Timestamp.fromMillis(NOW_MS + 1));
+    const pricing = Object.freeze({
+      earlyBirdCents: 2_000,
+      earlyBirdUntil: cutoff,
+    });
+    const event = Object.freeze({ pricing });
+
+    expect(isEarlyBirdActive(event, NOW_MS)).toBe(true);
+  });
+
+  test('floors valid Timestamp nanoseconds to the stored millisecond', () => {
+    const second = Math.floor(NOW_MS / 1_000);
+
+    expect(isEarlyBirdActive(
+      eventWithCutoff(new Timestamp(second, 999_999)),
+      NOW_MS,
+    )).toBe(false);
+    expect(isEarlyBirdActive(
+      eventWithCutoff(new Timestamp(second, 1_000_000)),
+      NOW_MS,
+    )).toBe(true);
+  });
+
+  test.each([
+    ['ISO string', new Date(NOW_MS + 1_000).toISOString()],
+    ['JavaScript Date', new Date(NOW_MS + 1_000)],
+  ])('rejects a future %s instead of granting the discount', (_name, cutoff) => {
+    expect(isEarlyBirdActive(eventWithCutoff(cutoff), NOW_MS)).toBe(false);
+  });
+
+  test('does not invoke a pseudo toMillis method', () => {
+    const toMillis = jest.fn(() => NOW_MS + 1_000);
+    const active = isEarlyBirdActive(eventWithCutoff({ toMillis }), NOW_MS);
+
+    expect({ active, calls: toMillis.mock.calls.length }).toEqual({
+      active: false,
+      calls: 0,
+    });
+  });
+
+  test('returns inactive instead of allowing a pseudo method to throw', () => {
+    const toMillis = jest.fn(() => {
+      throw new Error('synthetic cutoff method must not run');
+    });
+    let outcome;
+
+    try {
+      outcome = { active: isEarlyBirdActive(eventWithCutoff({ toMillis }), NOW_MS) };
+    } catch (error) {
+      outcome = { threw: error.message };
+    }
+
+    expect(outcome).toEqual({ active: false });
+    expect(toMillis).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['numeric string', String(NOW_MS)],
+    ['JavaScript Date', new Date(NOW_MS)],
+    ['null', null],
+    ['undefined', undefined],
+    ['boolean', true],
+    ['bigint', BigInt(NOW_MS)],
+  ])('rejects invalid clock input: %s', (_name, now) => {
+    expect(isEarlyBirdActive(
+      eventWithCutoff(Timestamp.fromMillis(NOW_MS + 1)),
+      now,
+    )).toBe(false);
+  });
+
+  test('rejects coercible clocks and short-circuits before a hostile event', () => {
+    const clockHooks = {
+      valueOf: jest.fn(() => NOW_MS),
+      toString: jest.fn(() => String(NOW_MS)),
+      [Symbol.toPrimitive]: jest.fn(() => NOW_MS),
+    };
+    const eventTrap = jest.fn(() => {
+      throw new Error('synthetic event trap must not run');
+    });
+    const hostileEvent = new Proxy({}, {
+      get: eventTrap,
+      getOwnPropertyDescriptor: eventTrap,
+      getPrototypeOf: eventTrap,
+      ownKeys: eventTrap,
+    });
+
+    expect(isEarlyBirdActive(eventWithCutoff(
+      Timestamp.fromMillis(NOW_MS + 1),
+    ), clockHooks)).toBe(false);
+    expect(isEarlyBirdActive(hostileEvent, Number.NaN)).toBe(false);
+    expect(clockHooks.valueOf).not.toHaveBeenCalled();
+    expect(clockHooks.toString).not.toHaveBeenCalled();
+    expect(clockHooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+    expect(eventTrap).not.toHaveBeenCalled();
+  });
+
+  test('uses captured validation intrinsics and the captured default clock', () => {
+    const originalDateNow = Date.now;
+    const originalNumberIsFinite = Number.isFinite;
+    const originalNumberIsSafeInteger = Number.isSafeInteger;
+    const originalMathFloor = Math.floor;
+    const originalGetPrototypeOf = Object.getPrototypeOf;
+    const originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const originalHasOwn = Object.hasOwn;
+    const originalOwnKeys = Reflect.ownKeys;
+    const fail = () => {
+      throw new Error('synthetic replaced intrinsic must not run');
+    };
+    const event = eventWithCutoff(Timestamp.fromMillis(originalDateNow() + 60_000));
+    let active;
+
+    try {
+      Date.now = fail;
+      Number.isFinite = fail;
+      Number.isSafeInteger = fail;
+      Math.floor = fail;
+      Object.getPrototypeOf = fail;
+      Object.getOwnPropertyDescriptor = fail;
+      Object.hasOwn = fail;
+      Reflect.ownKeys = fail;
+      active = isEarlyBirdActive(event);
+    } finally {
+      Date.now = originalDateNow;
+      Number.isFinite = originalNumberIsFinite;
+      Number.isSafeInteger = originalNumberIsSafeInteger;
+      Math.floor = originalMathFloor;
+      Object.getPrototypeOf = originalGetPrototypeOf;
+      Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+      Object.hasOwn = originalHasOwn;
+      Reflect.ownKeys = originalOwnKeys;
+    }
+
+    expect(active).toBe(true);
+  });
+
+  test.each([
+    ['missing', Symbol('missing')],
+    ['undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['zero', 0],
+    ['negative zero', -0],
+    ['empty string', ''],
+    ['NaN', Number.NaN],
+    ['zero bigint', BigInt(0)],
+  ])('keeps a %s early-bird amount inactive', (_name, amount) => {
+    const pricing = { earlyBirdUntil: Timestamp.fromMillis(NOW_MS + 1) };
+    if (_name !== 'missing') pricing.earlyBirdCents = amount;
+
+    expect(isEarlyBirdActive({ pricing }, NOW_MS)).toBe(false);
+  });
+
+  test('does not broaden the existing truthy amount gate or invoke amount hooks', () => {
+    const hooks = {
+      valueOf: jest.fn(() => 0),
+      toString: jest.fn(() => ''),
+      toJSON: jest.fn(() => 0),
+      [Symbol.toPrimitive]: jest.fn(() => 0),
+    };
+    const truthyValues = [-1, true, '2000', BigInt(1), Symbol('amount'), hooks];
+
+    truthyValues.forEach((amount) => {
+      expect(isEarlyBirdActive(eventWithCutoff(
+        Timestamp.fromMillis(NOW_MS + 1),
+        amount,
+      ), NOW_MS)).toBe(true);
+    });
+    expect(hooks.valueOf).not.toHaveBeenCalled();
+    expect(hooks.toString).not.toHaveBeenCalled();
+    expect(hooks.toJSON).not.toHaveBeenCalled();
+    expect(hooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+  });
+
+  test('rejects inherited, accessor-backed, and hidden amount fields', () => {
+    const cutoff = Timestamp.fromMillis(NOW_MS + 1);
+    const inherited = Object.create({ earlyBirdCents: 2_000 });
+    inherited.earlyBirdUntil = cutoff;
+
+    const getter = jest.fn(() => 2_000);
+    const accessorBacked = { earlyBirdUntil: cutoff };
+    Object.defineProperty(accessorBacked, 'earlyBirdCents', { get: getter });
+
+    const hidden = { earlyBirdUntil: cutoff };
+    Object.defineProperty(hidden, 'earlyBirdCents', { value: 2_000 });
+
+    expect(isEarlyBirdActive({ pricing: inherited }, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive({ pricing: accessorBacked }, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive({ pricing: hidden }, NOW_MS)).toBe(false);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['null event', null],
+    ['undefined event', undefined],
+    ['numeric event', 1],
+    ['array event', []],
+    ['Date event', new Date(NOW_MS)],
+    ['null-prototype event', Object.create(null)],
+    ['custom-prototype event', Object.create({})],
+    ['null pricing', { pricing: null }],
+    ['array pricing', { pricing: [] }],
+    ['null-prototype pricing', { pricing: Object.create(null) }],
+    ['custom-prototype pricing', { pricing: Object.create({}) }],
+  ])('rejects an invalid container: %s', (_name, event) => {
+    expect(() => isEarlyBirdActive(event, NOW_MS)).not.toThrow();
+    expect(isEarlyBirdActive(event, NOW_MS)).toBe(false);
+  });
+
+  test('rejects Proxy event and pricing records without invoking traps', () => {
+    const trap = jest.fn(() => {
+      throw new Error('synthetic container trap must not run');
+    });
+    const proxyHandler = {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    };
+    const proxiedEvent = new Proxy(eventWithCutoff(
+      Timestamp.fromMillis(NOW_MS + 1),
+    ), proxyHandler);
+    const proxiedPricing = new Proxy({
+      earlyBirdCents: 2_000,
+      earlyBirdUntil: Timestamp.fromMillis(NOW_MS + 1),
+    }, proxyHandler);
+
+    expect(isEarlyBirdActive(proxiedEvent, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive({ pricing: proxiedPricing }, NOW_MS)).toBe(false);
+    expect(trap).not.toHaveBeenCalled();
+
+    const revokedEvent = Proxy.revocable({}, {});
+    const revokedPricing = Proxy.revocable({}, {});
+    revokedEvent.revoke();
+    revokedPricing.revoke();
+    expect(isEarlyBirdActive(revokedEvent.proxy, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive({ pricing: revokedPricing.proxy }, NOW_MS)).toBe(false);
+  });
+
+  test('rejects inherited, accessor-backed, and hidden pricing fields', () => {
+    const pricing = {
+      earlyBirdCents: 2_000,
+      earlyBirdUntil: Timestamp.fromMillis(NOW_MS + 1),
+    };
+    const inherited = Object.create({ pricing });
+
+    const getter = jest.fn(() => pricing);
+    const accessorBacked = {};
+    Object.defineProperty(accessorBacked, 'pricing', { get: getter });
+
+    const hidden = {};
+    Object.defineProperty(hidden, 'pricing', { value: pricing });
+
+    expect(isEarlyBirdActive(inherited, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive(accessorBacked, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive(hidden, NOW_MS)).toBe(false);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['missing', Symbol('missing')],
+    ['undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['zero', 0],
+    ['true', true],
+    ['number', NOW_MS + 1],
+    ['ISO string', new Date(NOW_MS + 1).toISOString()],
+    ['JavaScript Date', new Date(NOW_MS + 1)],
+    ['array', []],
+    ['plain record', {}],
+    ['Map', new Map()],
+    ['Set', new Set()],
+  ])('rejects a %s cutoff representation', (_name, cutoff) => {
+    const pricing = { earlyBirdCents: 2_000 };
+    if (_name !== 'missing') pricing.earlyBirdUntil = cutoff;
+
+    expect(isEarlyBirdActive({ pricing }, NOW_MS)).toBe(false);
+  });
+
+  test('does not invoke cutoff accessors or conversion hooks', () => {
+    const cutoffGetter = jest.fn(() => Timestamp.fromMillis(NOW_MS + 1));
+    const pricing = { earlyBirdCents: 2_000 };
+    Object.defineProperty(pricing, 'earlyBirdUntil', { get: cutoffGetter });
+
+    const hooks = {
+      toMillis: jest.fn(() => NOW_MS + 1),
+      toJSON: jest.fn(() => new Date(NOW_MS + 1).toISOString()),
+      valueOf: jest.fn(() => NOW_MS + 1),
+      toString: jest.fn(() => String(NOW_MS + 1)),
+      [Symbol.iterator]: jest.fn(),
+      [Symbol.toPrimitive]: jest.fn(() => NOW_MS + 1),
+    };
+
+    expect(isEarlyBirdActive({ pricing }, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive(eventWithCutoff(hooks), NOW_MS)).toBe(false);
+    expect(cutoffGetter).not.toHaveBeenCalled();
+    Object.values(hooks).forEach((hook) => expect(hook).not.toHaveBeenCalled());
+  });
+
+  test('rejects inherited and hidden cutoff fields', () => {
+    const inherited = Object.create({
+      earlyBirdUntil: Timestamp.fromMillis(NOW_MS + 1),
+    });
+    inherited.earlyBirdCents = 2_000;
+    const hidden = { earlyBirdCents: 2_000 };
+    Object.defineProperty(hidden, 'earlyBirdUntil', {
+      value: Timestamp.fromMillis(NOW_MS + 1),
+    });
+
+    expect(isEarlyBirdActive({ pricing: inherited }, NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive({ pricing: hidden }, NOW_MS)).toBe(false);
+  });
+
+  test('rejects Proxy and modified Timestamp representations without side effects', () => {
+    const trap = jest.fn(() => {
+      throw new Error('synthetic Timestamp trap must not run');
+    });
+    const proxied = new Proxy(Timestamp.fromMillis(NOW_MS + 1), {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+    expect(isEarlyBirdActive(eventWithCutoff(proxied), NOW_MS)).toBe(false);
+    expect(trap).not.toHaveBeenCalled();
+
+    const revoked = Proxy.revocable(Timestamp.fromMillis(NOW_MS + 1), {});
+    revoked.revoke();
+    expect(isEarlyBirdActive(eventWithCutoff(revoked.proxy), NOW_MS)).toBe(false);
+
+    const modified = Timestamp.fromMillis(NOW_MS + 1);
+    const ownMethod = jest.fn(() => NOW_MS + 1);
+    Object.defineProperty(modified, 'toMillis', { value: ownMethod });
+    expect(isEarlyBirdActive(eventWithCutoff(modified), NOW_MS)).toBe(false);
+    expect(ownMethod).not.toHaveBeenCalled();
+
+    class TimestampSubclass extends Timestamp {}
+    expect(isEarlyBirdActive(eventWithCutoff(new TimestampSubclass(
+      Math.floor(NOW_MS / 1_000),
+      1_000_000,
+    )), NOW_MS)).toBe(false);
+
+    const extraKey = Timestamp.fromMillis(NOW_MS + 1);
+    Object.defineProperty(extraKey, Symbol('synthetic-extra'), { value: true });
+    expect(isEarlyBirdActive(eventWithCutoff(extraKey), NOW_MS)).toBe(false);
+  });
+
+  test('rejects accessor-backed and hidden Timestamp internals without reading them', () => {
+    const internalGetter = jest.fn(() => Math.floor(NOW_MS / 1_000));
+    const accessorBacked = Object.create(Timestamp.prototype);
+    Object.defineProperties(accessorBacked, {
+      _seconds: { get: internalGetter, enumerable: true },
+      _nanoseconds: { value: 0, enumerable: true },
+    });
+    const hidden = Object.create(Timestamp.prototype);
+    Object.defineProperties(hidden, {
+      _seconds: { value: Math.floor(NOW_MS / 1_000) },
+      _nanoseconds: { value: 1_000_000 },
+    });
+
+    expect(isEarlyBirdActive(eventWithCutoff(accessorBacked), NOW_MS)).toBe(false);
+    expect(isEarlyBirdActive(eventWithCutoff(hidden), NOW_MS)).toBe(false);
+    expect(internalGetter).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['seconds below range', -62_135_596_801, 0],
+    ['seconds above range', 253_402_300_800, 0],
+    ['fractional seconds', Math.floor(NOW_MS / 1_000) + 0.5, 0],
+    ['non-finite seconds', Number.POSITIVE_INFINITY, 0],
+    ['negative nanoseconds', Math.floor(NOW_MS / 1_000), -1],
+    ['nanoseconds above range', Math.floor(NOW_MS / 1_000), 1_000_000_000],
+    ['fractional nanoseconds', Math.floor(NOW_MS / 1_000), 0.5],
+    ['non-finite nanoseconds', Math.floor(NOW_MS / 1_000), Number.NaN],
+  ])('rejects Timestamp-shaped %s', (_name, seconds, nanoseconds) => {
+    const malformed = Object.create(Timestamp.prototype);
+    Object.defineProperties(malformed, {
+      _seconds: { value: seconds, enumerable: true },
+      _nanoseconds: { value: nanoseconds, enumerable: true },
+    });
+
+    expect(isEarlyBirdActive(eventWithCutoff(malformed), NOW_MS)).toBe(false);
+  });
+
+  test('does not mutate or traverse unrelated event and pricing fields', () => {
+    const unrelatedGetter = jest.fn(() => 'private synthetic detail');
+    const symbolGetter = jest.fn(() => 'private synthetic symbol detail');
+    const pricing = {
+      earlyBirdCents: 2_000,
+      earlyBirdUntil: Timestamp.fromMillis(NOW_MS + 1),
+    };
+    const event = { pricing };
+    pricing.self = pricing;
+    event.self = event;
+    Object.defineProperty(event, 'unrelated', { get: unrelatedGetter, enumerable: true });
+    Object.defineProperty(pricing, Symbol('unrelated'), {
+      get: symbolGetter,
+      enumerable: true,
+    });
+    const beforeEvent = Object.getOwnPropertyDescriptors(event);
+    const beforePricing = Object.getOwnPropertyDescriptors(pricing);
+
+    const active = isEarlyBirdActive(event, NOW_MS);
+
+    expect(active).toBe(true);
+    expect(Object.getOwnPropertyDescriptors(event)).toEqual(beforeEvent);
+    expect(Object.getOwnPropertyDescriptors(pricing)).toEqual(beforePricing);
+    expect(unrelatedGetter).not.toHaveBeenCalled();
+    expect(symbolGetter).not.toHaveBeenCalled();
+    pricing.earlyBirdCents = 0;
+    expect(active).toBe(true);
+  });
+});
 
 describe('registration-window validation', () => {
   test('keeps missing and null bounds unbounded', () => {


### PR DESCRIPTION
Closes #341.

Hardens the pure `isEarlyBirdActive` helper so a missing or malformed stored early-bird cutoff fails closed (early-bird inactive) before any later registration or Stripe work — without invoking supplied methods, accessors, Proxy traps, coercion, or logs.

## Change

`functions/stripeHelpers.js` — the single `isEarlyBirdActive` hunk (22 insertions / 7 deletions):

- Requires a finite primitive `now` and an ordinary current-realm plain event/pricing record (rejects Proxies, inherited/accessor-backed fields).
- Selects `earlyBirdCents` and `earlyBirdUntil` only as **own enumerable data** values via the existing `selectedOwnDataValue` projection.
- Adopts the cutoff through the existing strict `timestampToMillis` projection (checks the same-process SDK prototype, the exact `_seconds`/`_nanoseconds` data descriptors, and safe-integer ranges — never calls `toMillis`, constructors, or getters). Any non-Timestamp (ISO string, JS `Date`, pseudo-`toMillis` object, throwing accessor, modified/Proxy shape) → `INVALID` sentinel → inactive.
- Preserves strict `now < cutoff`: one ms before is active; equality and later are inactive.

Caller behavior is intentionally unchanged: an **explicit** early-bird request with a malformed cutoff still receives the existing fixed `Early-bird pricing is no longer available` (`failed-precondition`) response — without leaking the malformed value or `earlyBirdUntil` — and preserves `rateLimit → countActiveRegistrations → resolveCallerRole` ordering. An **automatic** choice falls back through the existing member/non-member rules. This child does not validate the early-bird amount (merged #327 `pickPriceCents` remains the cents validator); it does not touch immutable price/waiver snapshots, checkout idempotency, provider sync, or live race checkout.

## Officer impact

Future deployed server code will treat early-bird pricing as inactive when the stored cutoff is missing, null, the wrong type, or malformed. An officer must stop and request a reviewed private inventory (#113) or repair; **no officer should edit production Firestore or Stripe by hand.**

## Officer documentation

`docs/officers/EVENTS_SHOP_MEMBERS.md` — one separately named `Early-bird cutoff format guard — SOURCE ONLY, NOT LIVE` procedure (purpose, approver, prerequisites, 18 source-review steps, expected result, Mermaid diagram + written alternative). Status: **NOT AVAILABLE YET / NOT LIVE.**

## Deployment evidence

**None.** This PR is **source + tests + docs only.** Source, tests, review, merge, website publication, `runmprc.com`, Firebase deployment, Stripe/provider state, production data, migration, and live behavior are recorded separately. A green workflow alone does not prove any website, Firebase, or provider change is live — nothing here is deployed.

## Validation (local, Node 20, sanitized env — no live systems contacted)

- `functions/stripeHelpers.test.js` + `functions/checkoutPromotionPolicy.test.js`: **217/217 passing**, covering: real Admin SDK Timestamp fixtures (active before; inactive at equality and later; frozen fixture); missing/null cutoff and missing current-price gate inactive; every malformed cutoff class inactive without throw; pseudo methods / own accessors / inherited values / live+revoked Proxies / conversion hooks / iterators / serializers never invoked; invalid `now` inactive without conversion; input records unchanged; explicit-request malformed cutoff → fixed unavailable response with no confirmation-token, registration allocation/write, Stripe Product/Session, or log.
- `eslint` on all three changed JS files: clean.
- Additive, focused diff — the four owned files only; no unrelated hunks.

Full Functions lint + tests, Firestore Rules tests, and build run in CI on this PR.
