### PR TITLE
AUTH-MAIL-002: config-driven sender in account-email spam guidance (#120)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ REACT_APP_RECAPTCHA_SITE_KEY=
 REACT_APP_SENTRY_DSN=
 REACT_APP_SENTRY_ENV=development
 REACT_APP_STRAVA_CLIENT_ID=
+
+# Member-facing account-email sender named in anti-spam guidance (verification and
+# password-reset copy). AUTH-MAIL-001 (#119) sets this once an authenticated club
+# sender is owner-approved; leave blank for generic guidance. Public label only —
+# never a secret, address token, or private locator.
+REACT_APP_ACCOUNT_EMAIL_SENDER=

--- a/.github/lint-baseline.json
+++ b/.github/lint-baseline.json
@@ -10,11 +10,11 @@
   "targets": [
     "src"
   ],
-  "scannedFileCount": 106,
+  "scannedFileCount": 108,
   "scannedFilesByExtension": {
     ".js": 12,
     ".jsx": 35,
-    ".ts": 33,
+    ".ts": 35,
     ".tsx": 26
   },
   "errorCount": 123,
@@ -31,7 +31,7 @@
     ".ts": 0,
     ".tsx": 7
   },
-  "fingerprint": "sha256:f13e11e28a21ee078931352287e4074e8e5e7d5e9b39c76b3f1337df207e76ea",
+  "fingerprint": "sha256:3b3373bab8ca879d16ab45032b1a46c462175150fd8cca8eec75ebf3bc720773",
   "scannedFiles": [
     "src/App.jsx",
     "src/App.test.jsx",
@@ -106,6 +106,8 @@
     "src/services/account/accountService.test.ts",
     "src/services/account/accountService.ts",
     "src/services/account/adminMembersService.ts",
+    "src/services/accountEmail/accountEmailSender.test.ts",
+    "src/services/accountEmail/accountEmailSender.ts",
     "src/services/analytics/analytics.test.ts",
     "src/services/analytics/analytics.ts",
     "src/services/events/adminService.ts",

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -388,6 +388,39 @@ describe('Account profile recovery', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
+  test('accepted resend guidance names the configured sender without claiming delivery', async () => {
+    const ENV_KEY = 'REACT_APP_ACCOUNT_EMAIL_SENDER';
+    const originalSender = process.env[ENV_KEY];
+    process.env[ENV_KEY] = 'Synthetic Club Sender';
+    try {
+      let finishRequest: (() => void) | undefined;
+      resendVerificationEmail.mockImplementationOnce(() => new Promise<void>((resolve) => {
+        finishRequest = resolve;
+      }));
+      renderAccount();
+
+      const button = await screen.findByRole('button', {
+        name: 'Request another verification email',
+      });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      await act(async () => finishRequest?.());
+
+      const status = screen.getByRole('status');
+      expect(status).toHaveTextContent('The request was accepted.');
+      expect(status).toHaveTextContent('mark the message from Synthetic Club Sender as');
+      expect(status).toHaveTextContent('it does not fix delivery for everyone');
+      expect(status).not.toHaveTextContent(/\bsent\b|\bdelivered\b/i);
+    } finally {
+      if (originalSender === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = originalSender;
+      }
+    }
+  });
+
   test('shows one fixed failure result without provider details', async () => {
     const consoleSpies = [
       jest.spyOn(console, 'log').mockImplementation(() => undefined),
@@ -464,8 +497,7 @@ describe('Account profile recovery', () => {
       name: 'Request another verification email',
     }));
     await act(async () => Promise.resolve());
-    expect(await screen.findByText('The request was accepted. Delivery can take time. Check Inbox and Spam.'))
-      .toBeInTheDocument();
+    expect(await screen.findByRole('status')).toHaveTextContent('The request was accepted.');
     expect(screen.getByRole('button', { name: /Try again in/ })).toBeDisabled();
     expect(jest.getTimerCount()).toBe(1);
 

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -19,6 +19,7 @@ import {
 import { formatEventDate, formatPrice } from '../../services/events/eventsService';
 import StravaSection from './StravaSection';
 import { getLocationReturnPath } from '../login/loginReturnPath';
+import { getSpamGuidance } from '../../services/accountEmail/accountEmailSender';
 import './Account.css';
 
 function tsToDate(ts: Timestamp | null | undefined) {
@@ -121,6 +122,8 @@ function ResendVerificationButton() {
           className="verification-resend__result verification-resend__result--accepted"
         >
           The request was accepted. Delivery can take time. Check Inbox and Spam.
+          {' '}
+          {getSpamGuidance()}
         </p>
       )}
       {state === 'unavailable' && (

--- a/src/pages/login/LoginForm.jsx
+++ b/src/pages/login/LoginForm.jsx
@@ -7,6 +7,7 @@ import Header from '../../components/Header';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import SEO from '../../components/SEO';
 import { getSafeLoginReturnPath } from './loginReturnPath';
+import { getSpamGuidance } from '../../services/accountEmail/accountEmailSender';
 import './LoginForm.css';
 
 const RESET_COOLDOWN_SECONDS = 60;
@@ -189,7 +190,8 @@ function LoginForm() {
                 <p className="registration-outcome__message">
                   The email service accepted the verification email request.
                   Delivery is not guaranteed. Check your Inbox and Spam folder.
-                  If it is in Spam, mark it “Not spam.”
+                  {' '}
+                  {getSpamGuidance()}
                 </p>
               ) : (
                 <p className="registration-outcome__message">
@@ -243,8 +245,10 @@ function LoginForm() {
                 <p className="password-reset-outcome__message">
                   For privacy, this page always shows the same result. Email delivery
                   cannot be confirmed. Wait a few minutes, then check Inbox and Spam.
-                  If you find a reset message in Spam, mark it “Not spam.” Never share
-                  a reset link or code.
+                  {' '}
+                  {getSpamGuidance()}
+                  {' '}
+                  Never share a reset link or code.
                 </p>
               </div>
               <p

--- a/src/pages/login/LoginForm.test.jsx
+++ b/src/pages/login/LoginForm.test.jsx
@@ -607,3 +607,72 @@ describe('LoginForm return navigation', () => {
     );
   });
 });
+
+describe('LoginForm account-email spam guidance (AUTH-MAIL-002 C6)', () => {
+  const ENV_KEY = 'REACT_APP_ACCOUNT_EMAIL_SENDER';
+  const originalSender = process.env[ENV_KEY];
+  const register = jest.fn();
+  const sendPasswordReset = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    register.mockResolvedValue({
+      user: { email: 'member@example.test' },
+      verificationEmailRequest: 'accepted',
+    });
+    sendPasswordReset.mockResolvedValue(undefined);
+    useServiceLocator.mockReturnValue({
+      isReady: true,
+      services: {
+        identityService: { signIn: jest.fn(), register, sendPasswordReset },
+      },
+    });
+    useAuth.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: false,
+      isAdmin: false,
+    });
+  });
+
+  afterEach(() => {
+    if (originalSender === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalSender;
+    }
+    jest.restoreAllMocks();
+  });
+
+  test('registration guidance names the configured sender and warns delivery is not universal', async () => {
+    process.env[ENV_KEY] = 'Synthetic Club Sender';
+    renderLogin();
+    submitRegistration();
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('mark the message from Synthetic Club Sender as');
+    expect(status).toHaveTextContent('it does not fix delivery for everyone');
+  });
+
+  test('registration guidance stays generic when no sender is configured', async () => {
+    delete process.env[ENV_KEY];
+    renderLogin();
+    submitRegistration();
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent("mark the message from the club's account email as");
+    expect(status).toHaveTextContent('it does not fix delivery for everyone');
+  });
+
+  test('password-reset guidance names the sender behind the fixed generic result', async () => {
+    process.env[ENV_KEY] = 'Synthetic Club Sender';
+    renderLogin();
+    requestPasswordReset();
+
+    await screen.findByText('Password reset request finished.');
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('this page always shows the same result');
+    expect(status).toHaveTextContent('mark the message from Synthetic Club Sender as');
+    expect(status).toHaveTextContent('it does not fix delivery for everyone');
+    expect(status).toHaveTextContent('Never share a reset link or code.');
+  });
+});

--- a/src/services/accountEmail/accountEmailSender.test.ts
+++ b/src/services/accountEmail/accountEmailSender.test.ts
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+import {
+  getAccountEmailSenderLabel,
+  getSpamGuidance,
+} from './accountEmailSender';
+
+const ENV_KEY = 'REACT_APP_ACCOUNT_EMAIL_SENDER';
+const GENERIC_LABEL = "the club's account email";
+
+function setSender(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = value;
+  }
+}
+
+describe('account-email sender configuration (AUTH-MAIL-002 C6)', () => {
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    setSender(original);
+  });
+
+  test('falls back to a generic sender when none is configured', () => {
+    setSender(undefined);
+    expect(getAccountEmailSenderLabel()).toBe(GENERIC_LABEL);
+  });
+
+  test('treats a blank or whitespace-only configuration as unset', () => {
+    setSender('');
+    expect(getAccountEmailSenderLabel()).toBe(GENERIC_LABEL);
+    setSender('   ');
+    expect(getAccountEmailSenderLabel()).toBe(GENERIC_LABEL);
+  });
+
+  test('names the configured sender and can change without a code fork', () => {
+    setSender('Synthetic Club Sender');
+    expect(getAccountEmailSenderLabel()).toBe('Synthetic Club Sender');
+    // A later AUTH-MAIL-001 (#119) update is a configuration edit, not a code edit.
+    setSender('Synthetic Club Sender (updated)');
+    expect(getAccountEmailSenderLabel()).toBe('Synthetic Club Sender (updated)');
+  });
+
+  test('trims incidental whitespace around a configured sender', () => {
+    setSender('  Synthetic Club Sender  ');
+    expect(getAccountEmailSenderLabel()).toBe('Synthetic Club Sender');
+  });
+
+  test('spam guidance names the sender, offers one action, and refuses to over-promise', () => {
+    setSender('Synthetic Club Sender');
+    const guidance = getSpamGuidance();
+    expect(guidance).toContain('Synthetic Club Sender');
+    expect(guidance).toContain('Not spam');
+    expect(guidance).toContain('does not fix delivery for everyone');
+    expect(guidance).not.toMatch(/\bsent\b|\bdelivered\b|\baccepted\b/i);
+  });
+
+  test('generic guidance invents no address and never claims delivery', () => {
+    setSender(undefined);
+    const guidance = getSpamGuidance();
+    expect(guidance).toContain(GENERIC_LABEL);
+    expect(guidance).not.toContain('@');
+    expect(guidance).not.toMatch(/\bsent\b|\bdelivered\b/i);
+  });
+
+  test('resolving the sender never writes to the console', () => {
+    const spies = [
+      jest.spyOn(console, 'log').mockImplementation(() => undefined),
+      jest.spyOn(console, 'warn').mockImplementation(() => undefined),
+      jest.spyOn(console, 'error').mockImplementation(() => undefined),
+    ];
+    setSender('Synthetic Club Sender');
+    getAccountEmailSenderLabel();
+    getSpamGuidance();
+    spies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    spies.forEach((spy) => spy.mockRestore());
+  });
+});

--- a/src/services/accountEmail/accountEmailSender.ts
+++ b/src/services/accountEmail/accountEmailSender.ts
@@ -1,0 +1,26 @@
+// Single source of truth for the account-email sender named in member-facing
+// anti-spam guidance. AUTH-MAIL-001 (#119) owns the authenticated club sender
+// identity and its DNS; once that work sets REACT_APP_ACCOUNT_EMAIL_SENDER,
+// every guidance surface names the approved sender with no code change. Until
+// then the copy stays generic and promises nothing about a specific address.
+
+const GENERIC_SENDER_LABEL = "the club's account email";
+
+// Read at call time (not module load) so a build-time environment change flows
+// through every guidance string without a code fork.
+export function getAccountEmailSenderLabel(): string {
+  const configured = process.env.REACT_APP_ACCOUNT_EMAIL_SENDER;
+  if (typeof configured === 'string' && configured.trim() !== '') {
+    return configured.trim();
+  }
+  return GENERIC_SENDER_LABEL;
+}
+
+// Shared Spam-folder guidance used by every account-email surface. It names the
+// configured sender, offers the one safe personal action, and is explicit that
+// this does not fix delivery for everyone. It never claims a message was sent.
+export function getSpamGuidance(): string {
+  return `If it lands in Spam, mark the message from ${getAccountEmailSenderLabel()} as `
+    + '“Not spam.” That can help your future messages, but it does not fix delivery '
+    + 'for everyone.';
+}

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -35,7 +35,7 @@ const CLEAN_COMMANDS = Object.freeze([
   'test -z "$frontend_git_status"',
 ]);
 const LINT_SCRIPT = 'node .github/scripts/check-frontend-lint.cjs';
-const EXPECTED_LINT_FILES = 106;
+const EXPECTED_LINT_FILES = 108;
 const EXPECTED_LINT_ERRORS = 123;
 const EXPECTED_LINT_WARNINGS = 7;
 const YAML_TO_JSON = [


### PR DESCRIPTION
## Summary

Advances **#120** (AUTH-MAIL-002, honest email-delivery states) by closing its one remaining code gap: **acceptance criterion C6** — *"Spam guidance names the currently configured sender generically and can be updated after AUTH-MAIL-001 without a code fork."*

Verification and password-reset anti-spam copy now flows through a single `getSpamGuidance()` seam that names the configured sender, so #119 can publish the owner-approved sender by configuration alone.

## What changed

- **New `src/services/accountEmail/accountEmailSender.ts`** — `getAccountEmailSenderLabel()` reads `REACT_APP_ACCOUNT_EMAIL_SENDER` at call time (blank/whitespace → generic `"the club's account email"`); `getSpamGuidance()` builds the one-action spam copy from it.
- **`LoginForm.jsx`** — registration-accepted and password-reset-finished guidance route through `getSpamGuidance()`.
- **`Account.tsx`** — verification-resend accepted guidance routes through `getSpamGuidance()`.
- **`.env.example`** — documents `REACT_APP_ACCOUNT_EMAIL_SENDER` as a public label only (never a secret/address token), left blank by default.
- Component + unit tests; lint baseline regenerated for the two new lint-clean files (counts unchanged: 123 errors / 7 warnings).

## Honesty invariants preserved

- Guidance never claims a message was **sent** or **delivered** (unit test asserts it matches neither `/\bsent\b/` nor `/\bdelivered\b/`).
- It states plainly that marking the sender "Not spam" **does not fix delivery for everyone**.
- Generic fallback invents no address (`@`-free). No raw Firebase error codes, addresses, links, or tokens are shown or logged.

## Scope / issue status

This is the client-side seam only; it does **not** decide or store the sender identity, which remains owned by **#119 (AUTH-MAIL-001, `blocked-owner`)**. The other #120 criteria (C5, C7, C8, C9, C10) are already honest in source and stay gated on owner sender publication and live verification — so **#120 remains open**; this PR advances it rather than closing it.

**Officer / deployment impact:** None. Frontend-only copy seam behind a blank-by-default public env var.

## Validation

- `check-frontend-lint.cjs` baseline gate: pass (108 files, 123 errors / 7 warnings — unchanged; +2 new files are finding-free).
- Full Jest suite: **521 passed / 13 suites**.
- Build (CI-accurate `CI=true DISABLE_ESLINT_PLUGIN=true npm run build`): **Compiled successfully**.
