### PR TITLE
MEMBERS-DUES-001A: immutable membership term/evidence receipt ledger (#345)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -566,6 +566,28 @@ This contract does not verify a person, payment, plan, evidence item, refund, di
 
 The module is imported by no runtime or Functions index. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, changes no current profile/role/claim, and cannot make #81, annual renewal, discounts, roster export, or officer membership tools available. Source tests and a merge are not Firebase deployment or live behavior proof.
 
+### 8.0b Immutable membership term/evidence receipt ledger — SOURCE ONLY, UNUSED
+
+MEMBERS-DUES-001A [#345](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/345) defines one unused pure contract that preserves the immutable renewal/evidence history the §8.0a authority cannot hold by itself. The §8.0a reducer keeps only one replaceable current-term snapshot, so each recorded term decision overwrites the previous one. This contract records each term decision as an ordered, append-only receipt and projects any receipt back into the exact `record_term_decision` command the shipped authority already accepts, without duplicating that reducer.
+
+```mermaid
+flowchart LR
+    E["Empty ledger (receiptRevision 0)"] --> A["Append receipt: termRevision equals one-based position"]
+    A -- "Reused command/receipt id, skipped or repeated revision, reversed range" --> X["Fails closed"]
+    A -- "Exact re-append of the tail command" --> R["Read-only; returns the same ledger"]
+    A --> H["Ordered append-only history; earlier receipts never change"]
+    H --> P["Project one receipt with an expected revision"]
+    P --> C["Exact record_term_decision command accepted by the 8.0a authority"]
+```
+
+Text alternative: a ledger starts empty and grows only by appending one term/evidence receipt at a time, where each receipt's term revision equals its one-based position, command and receipt identifiers are unique across the whole history, and earlier receipts are never mutated. An exact re-append of the most recent command is read-only. A reused identifier, a skipped or repeated revision, a reversed time range, an unsupported version/state, an extra field, an accessor, a proxy, or a tampered snapshot fails through one fixed error. Any receipt projects into the exact versioned `record_term_decision` command that the §8.0a authority accepts, so the two contracts compose without a shared type.
+
+The CommonJS module creates an empty versioned ledger, creates one frozen receipt from an opaque evidence bundle (receipt id, command id, term revision/state/id, explicit half-open start/end, and opaque plan/evidence/policy references), appends receipts as an immutable ordered history with monotonic position-bound revisions and global identifier uniqueness, treats an exact tail re-append as read-only, and projects a receipt into the frozen `record_term_decision` command input. It accepts exact plain objects, bounded server-minted opaque identifiers, and safe-integer time values only.
+
+This contract does not verify a person, payment, plan, evidence item, refund, dispute, or policy decision, and it grants no entitlement by itself. It does not choose calendar-year versus anniversary terms, grace, prices, currency, plan eligibility, retention, tax, or legacy disposition; every reference is an opaque caller-supplied token and only technical bounds — a positive-duration range and a monotonic position-bound revision — are enforced. Durable persistence and replay, Firestore schema/Rules, custom claims and token refresh/revocation, cross-record uniqueness, runtime authorization and adoption, migration, and deployment are later children behind #114 and the protected release work.
+
+The module is imported by no runtime or Functions index and updates no officer procedure because it makes nothing officer-observable. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, and changes no current profile/role/claim. Source tests and a merge are not Firebase deployment or live behavior proof.
+
 ### 8.1 Paid race registration
 
 PAY-001B1 [#219](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/219) adds only the browser projection and first two server validation steps below. The website sends the active field set and omits volunteer tier. The callable preserves the opaque event ID, accepts an exact bounded envelope before Firestore, matches answers against the admitted selected server fields, and encodes callback values. It does not add the target request ID, snapshot, transaction, reservation, idempotent Session saga, safe confirmation capability, deployment, or live proof.

--- a/functions/membershipTermReceipt.js
+++ b/functions/membershipTermReceipt.js
@@ -1,0 +1,357 @@
+'use strict';
+
+const { types: { isProxy } } = require('node:util');
+
+const membershipTermReceiptSchemaVersion = 1;
+const MEMBERSHIP_AUTHORITY_SCHEMA_VERSION = 1;
+const MEMBERSHIP_TERM_RECEIPT_ERROR_MESSAGE = 'Membership term receipt input is invalid.';
+const MAX_TIME_MS = 8_640_000_000_000_000;
+const OPAQUE_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+const RECEIPT_FIELDS = Object.freeze([
+  'membershipTermReceiptSchemaVersion',
+  'receiptId',
+  'commandId',
+  'termRevision',
+  'termState',
+  'termId',
+  'startsAtMs',
+  'endsAtMs',
+  'planRef',
+  'evidenceRef',
+  'policyVersion',
+]);
+
+const CREATE_LEDGER_FIELDS = Object.freeze([
+  'membershipTermReceiptSchemaVersion',
+  'ledgerId',
+]);
+
+const LEDGER_FIELDS = Object.freeze([
+  'membershipTermReceiptSchemaVersion',
+  'ledgerId',
+  'receiptRevision',
+  'receipts',
+]);
+
+const PROJECTION_ENVELOPE_FIELDS = Object.freeze([
+  'membershipAuthoritySchemaVersion',
+  'expectedRevision',
+]);
+
+const MEMBERSHIP_TERM_RECEIPT_ENUMS = Object.freeze({
+  termState: Object.freeze([
+    'decision_pending',
+    'approved',
+    'suspended',
+    'ended',
+  ]),
+});
+
+const TERM_STATES = new Set(MEMBERSHIP_TERM_RECEIPT_ENUMS.termState);
+
+class MembershipTermReceiptError extends Error {
+  constructor() {
+    super(MEMBERSHIP_TERM_RECEIPT_ERROR_MESSAGE);
+    Object.defineProperty(this, 'name', {
+      value: 'MembershipTermReceiptError',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'message', {
+      value: MEMBERSHIP_TERM_RECEIPT_ERROR_MESSAGE,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'code', {
+      value: 'invalid_membership_term_receipt',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Error.captureStackTrace?.(this, MembershipTermReceiptError);
+    Object.freeze(this);
+  }
+}
+
+function fail() {
+  throw new MembershipTermReceiptError();
+}
+
+function readDataObject(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+  if (prototype !== Object.prototype) fail();
+
+  const data = Object.create(null);
+  for (const key of keys) {
+    if (typeof key !== 'string' || Object.prototype.hasOwnProperty.call(data, key)) fail();
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    data[key] = descriptor.value;
+  }
+  return { data, keys };
+}
+
+function readExactObject(value, expectedFields) {
+  const { data, keys } = readDataObject(value);
+  if (keys.length !== expectedFields.length) fail();
+  const keySet = new Set(keys);
+  if (expectedFields.some((field) => !keySet.has(field))) fail();
+  return data;
+}
+
+function readDataArray(value) {
+  if (!Array.isArray(value) || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+  if (prototype !== Array.prototype) fail();
+
+  const { length } = value;
+  if (!Number.isSafeInteger(length) || keys.length !== length + 1) fail();
+
+  const expected = new Set();
+  for (let index = 0; index < length; index += 1) expected.add(String(index));
+  expected.add('length');
+  for (const key of keys) {
+    if (typeof key !== 'string' || !expected.has(key)) fail();
+  }
+
+  const elements = [];
+  for (let index = 0; index < length; index += 1) {
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    elements.push(descriptor.value);
+  }
+  return elements;
+}
+
+function requireVersion(value) {
+  if (value !== membershipTermReceiptSchemaVersion) fail();
+}
+
+function requireOpaqueIdentifier(value) {
+  if (typeof value !== 'string' || !OPAQUE_IDENTIFIER_PATTERN.test(value)) fail();
+  return value;
+}
+
+function requireRevision(value, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) fail();
+  return value;
+}
+
+function requireTime(value) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_TIME_MS) fail();
+  return value;
+}
+
+function readReceipt(value) {
+  const receipt = readExactObject(value, RECEIPT_FIELDS);
+  requireVersion(receipt.membershipTermReceiptSchemaVersion);
+  requireOpaqueIdentifier(receipt.receiptId);
+  requireOpaqueIdentifier(receipt.commandId);
+  requireRevision(receipt.termRevision, 1);
+  if (!TERM_STATES.has(receipt.termState)) fail();
+  requireOpaqueIdentifier(receipt.termId);
+  requireTime(receipt.startsAtMs);
+  requireTime(receipt.endsAtMs);
+  if (receipt.startsAtMs >= receipt.endsAtMs) fail();
+  requireOpaqueIdentifier(receipt.planRef);
+  requireOpaqueIdentifier(receipt.evidenceRef);
+  requireOpaqueIdentifier(receipt.policyVersion);
+  return {
+    receiptId: receipt.receiptId,
+    commandId: receipt.commandId,
+    termRevision: receipt.termRevision,
+    termState: receipt.termState,
+    termId: receipt.termId,
+    startsAtMs: receipt.startsAtMs,
+    endsAtMs: receipt.endsAtMs,
+    planRef: receipt.planRef,
+    evidenceRef: receipt.evidenceRef,
+    policyVersion: receipt.policyVersion,
+  };
+}
+
+function freezeReceipt(receipt) {
+  return Object.freeze({
+    membershipTermReceiptSchemaVersion,
+    receiptId: receipt.receiptId,
+    commandId: receipt.commandId,
+    termRevision: receipt.termRevision,
+    termState: receipt.termState,
+    termId: receipt.termId,
+    startsAtMs: receipt.startsAtMs,
+    endsAtMs: receipt.endsAtMs,
+    planRef: receipt.planRef,
+    evidenceRef: receipt.evidenceRef,
+    policyVersion: receipt.policyVersion,
+  });
+}
+
+function freezeLedger(ledgerId, frozenReceipts) {
+  return Object.freeze({
+    membershipTermReceiptSchemaVersion,
+    ledgerId,
+    receiptRevision: frozenReceipts.length,
+    receipts: Object.freeze(frozenReceipts),
+  });
+}
+
+function readLedger(value) {
+  const ledger = readExactObject(value, LEDGER_FIELDS);
+  requireVersion(ledger.membershipTermReceiptSchemaVersion);
+  requireOpaqueIdentifier(ledger.ledgerId);
+  requireRevision(ledger.receiptRevision, 0);
+
+  const elements = readDataArray(ledger.receipts);
+  if (elements.length !== ledger.receiptRevision) fail();
+
+  const receipts = [];
+  const receiptIds = new Set();
+  const commandIds = new Set();
+  for (let index = 0; index < elements.length; index += 1) {
+    const receipt = readReceipt(elements[index]);
+    if (receipt.termRevision !== index + 1) fail();
+    if (receiptIds.has(receipt.receiptId) || commandIds.has(receipt.commandId)) fail();
+    receiptIds.add(receipt.receiptId);
+    commandIds.add(receipt.commandId);
+    receipts.push(receipt);
+  }
+
+  return {
+    ledgerId: ledger.ledgerId,
+    receiptRevision: ledger.receiptRevision,
+    receipts,
+    receiptIds,
+    commandIds,
+  };
+}
+
+function isExactReceiptMatch(existing, candidate) {
+  return existing.receiptId === candidate.receiptId
+    && existing.commandId === candidate.commandId
+    && existing.termRevision === candidate.termRevision
+    && existing.termState === candidate.termState
+    && existing.termId === candidate.termId
+    && existing.startsAtMs === candidate.startsAtMs
+    && existing.endsAtMs === candidate.endsAtMs
+    && existing.planRef === candidate.planRef
+    && existing.evidenceRef === candidate.evidenceRef
+    && existing.policyVersion === candidate.policyVersion;
+}
+
+function canonicalLedger(value, ledgerId, frozenReceipts) {
+  if (Object.isFrozen(value)
+    && Object.isFrozen(value.receipts)
+    && value.receipts.length === frozenReceipts.length
+    && value.receipts.every((receipt) => Object.isFrozen(receipt))) {
+    return value;
+  }
+  return freezeLedger(ledgerId, frozenReceipts);
+}
+
+function createTermEvidenceReceipt(input) {
+  return freezeReceipt(readReceipt(input));
+}
+
+function createMembershipTermLedger(input) {
+  const data = readExactObject(input, CREATE_LEDGER_FIELDS);
+  requireVersion(data.membershipTermReceiptSchemaVersion);
+  requireOpaqueIdentifier(data.ledgerId);
+  return freezeLedger(data.ledgerId, []);
+}
+
+function appendTermEvidenceReceipt(ledgerInput, receiptInput) {
+  const ledger = readLedger(ledgerInput);
+  const receipt = readReceipt(receiptInput);
+  const frozenReceipts = ledger.receipts.map(freezeReceipt);
+  const tail = ledger.receipts.length > 0
+    ? ledger.receipts[ledger.receipts.length - 1]
+    : null;
+
+  if (tail && receipt.commandId === tail.commandId) {
+    if (!isExactReceiptMatch(tail, receipt)) fail();
+    return canonicalLedger(ledgerInput, ledger.ledgerId, frozenReceipts);
+  }
+
+  if (ledger.commandIds.has(receipt.commandId)) fail();
+  if (ledger.receiptIds.has(receipt.receiptId)) fail();
+  if (receipt.termRevision !== ledger.receiptRevision + 1) fail();
+
+  return freezeLedger(ledger.ledgerId, frozenReceipts.concat(freezeReceipt(receipt)));
+}
+
+function projectTermDecisionCommand(receiptInput, envelopeInput) {
+  const receipt = readReceipt(receiptInput);
+  const envelope = readExactObject(envelopeInput, PROJECTION_ENVELOPE_FIELDS);
+  if (envelope.membershipAuthoritySchemaVersion !== MEMBERSHIP_AUTHORITY_SCHEMA_VERSION) fail();
+  requireRevision(envelope.expectedRevision, 1);
+
+  return Object.freeze({
+    membershipAuthoritySchemaVersion: MEMBERSHIP_AUTHORITY_SCHEMA_VERSION,
+    commandType: 'record_term_decision',
+    commandId: receipt.commandId,
+    expectedRevision: envelope.expectedRevision,
+    termRevision: receipt.termRevision,
+    termState: receipt.termState,
+    termId: receipt.termId,
+    startsAtMs: receipt.startsAtMs,
+    endsAtMs: receipt.endsAtMs,
+    planRef: receipt.planRef,
+    evidenceRef: receipt.evidenceRef,
+    policyVersion: receipt.policyVersion,
+  });
+}
+
+Object.freeze(MembershipTermReceiptError.prototype);
+Object.freeze(MembershipTermReceiptError);
+
+module.exports = Object.freeze({
+  membershipTermReceiptSchemaVersion,
+  MEMBERSHIP_TERM_RECEIPT_ENUMS,
+  MembershipTermReceiptError,
+  createTermEvidenceReceipt,
+  createMembershipTermLedger,
+  appendTermEvidenceReceipt,
+  projectTermDecisionCommand,
+});

--- a/functions/membershipTermReceipt.test.js
+++ b/functions/membershipTermReceipt.test.js
@@ -1,0 +1,513 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { inspect } = require('node:util');
+
+const {
+  membershipTermReceiptSchemaVersion,
+  MEMBERSHIP_TERM_RECEIPT_ENUMS,
+  MembershipTermReceiptError,
+  createTermEvidenceReceipt,
+  createMembershipTermLedger,
+  appendTermEvidenceReceipt,
+  projectTermDecisionCommand,
+} = require('./membershipTermReceipt');
+
+const {
+  createMembershipAuthority,
+  applyMembershipAuthorityCommand,
+  deriveMembershipEntitlement,
+} = require('./membershipAuthority');
+
+const HOSTILE_CANARY = 'private-member@example.test/+12025550208?token=do-not-copy';
+const TERM_START_MS = 1_000_000;
+const TERM_END_MS = 2_000_000;
+
+function receiptInput(overrides = {}) {
+  return {
+    membershipTermReceiptSchemaVersion: 1,
+    receiptId: 'rcpt_test_001',
+    commandId: 'cmd_term_001',
+    termRevision: 1,
+    termState: 'approved',
+    termId: 'term_test_2026',
+    startsAtMs: TERM_START_MS,
+    endsAtMs: TERM_END_MS,
+    planRef: 'plan_test_001',
+    evidenceRef: 'evidence_test_001',
+    policyVersion: 'policy_test_001',
+    ...overrides,
+  };
+}
+
+function renewalReceiptInput(overrides = {}) {
+  return receiptInput({
+    receiptId: 'rcpt_test_002',
+    commandId: 'cmd_term_002',
+    termRevision: 2,
+    termState: 'suspended',
+    evidenceRef: 'evidence_test_002',
+    policyVersion: 'policy_test_002',
+    ...overrides,
+  });
+}
+
+function ledgerInput(overrides = {}) {
+  return {
+    membershipTermReceiptSchemaVersion: 1,
+    ledgerId: 'ldgr_test_001',
+    ...overrides,
+  };
+}
+
+function envelopeInput(overrides = {}) {
+  return {
+    membershipAuthoritySchemaVersion: 1,
+    expectedRevision: 2,
+    ...overrides,
+  };
+}
+
+function emptyLedger() {
+  return createMembershipTermLedger(ledgerInput());
+}
+
+function oneReceiptLedger() {
+  return appendTermEvidenceReceipt(emptyLedger(), receiptInput());
+}
+
+function createLinkedAuthorityRecord() {
+  return applyMembershipAuthorityCommand(
+    createMembershipAuthority({
+      membershipAuthoritySchemaVersion: 1,
+      membershipId: 'mbr_test_001',
+      commandId: 'cmd_create_001',
+    }),
+    {
+      membershipAuthoritySchemaVersion: 1,
+      commandType: 'associate_account',
+      commandId: 'cmd_link_001',
+      expectedRevision: 1,
+      uid: 'uid_test_001',
+    },
+  );
+}
+
+function captureError(callback) {
+  try {
+    callback();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected callback to throw');
+}
+
+function expectSafeError(callback, rawValue = HOSTILE_CANARY) {
+  const error = captureError(callback);
+  expect(error).toBeInstanceOf(MembershipTermReceiptError);
+  expect(error).toMatchObject({
+    name: 'MembershipTermReceiptError',
+    code: 'invalid_membership_term_receipt',
+    message: 'Membership term receipt input is invalid.',
+  });
+  expect(Object.isFrozen(error)).toBe(true);
+  const rendered = [
+    error.message,
+    String(error),
+    JSON.stringify(error),
+    inspect(error),
+    error.stack,
+  ].join('\n');
+  if (rawValue) expect(rendered).not.toContain(rawValue);
+  expect(rendered).not.toContain(HOSTILE_CANARY);
+  return error;
+}
+
+function expectDeepFrozen(value) {
+  expect(Object.isFrozen(value)).toBe(true);
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value)) expectDeepFrozen(child);
+  }
+}
+
+describe('immutable membership term/evidence receipt ledger contract', () => {
+  test('exports one frozen versioned API and enum catalog', () => {
+    const api = require('./membershipTermReceipt');
+    expect(membershipTermReceiptSchemaVersion).toBe(1);
+    expect(Object.isFrozen(api)).toBe(true);
+    expect(Object.isFrozen(MEMBERSHIP_TERM_RECEIPT_ENUMS)).toBe(true);
+    for (const values of Object.values(MEMBERSHIP_TERM_RECEIPT_ENUMS)) {
+      expect(Object.isFrozen(values)).toBe(true);
+    }
+    expect(MEMBERSHIP_TERM_RECEIPT_ENUMS.termState).toEqual([
+      'decision_pending',
+      'approved',
+      'suspended',
+      'ended',
+    ]);
+    expect(Object.isFrozen(MembershipTermReceiptError)).toBe(true);
+    expect(Object.isFrozen(MembershipTermReceiptError.prototype)).toBe(true);
+  });
+
+  test('creates an empty ledger that holds no receipts', () => {
+    const input = ledgerInput();
+    const before = JSON.stringify(input);
+    const ledger = createMembershipTermLedger(input);
+
+    expect(ledger).toEqual({
+      membershipTermReceiptSchemaVersion: 1,
+      ledgerId: 'ldgr_test_001',
+      receiptRevision: 0,
+      receipts: [],
+    });
+    expectDeepFrozen(ledger);
+    expect(Object.isFrozen(ledger.receipts)).toBe(true);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  test('creates a frozen receipt from an opaque evidence bundle without choosing policy', () => {
+    const input = receiptInput();
+    const before = JSON.stringify(input);
+    const receipt = createTermEvidenceReceipt(input);
+
+    expect(receipt).toEqual({
+      membershipTermReceiptSchemaVersion: 1,
+      receiptId: 'rcpt_test_001',
+      commandId: 'cmd_term_001',
+      termRevision: 1,
+      termState: 'approved',
+      termId: 'term_test_2026',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      evidenceRef: 'evidence_test_001',
+      policyVersion: 'policy_test_001',
+    });
+    expectDeepFrozen(receipt);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  test('appends renewals as an immutable ordered history that preserves earlier terms', () => {
+    const ledger1 = oneReceiptLedger();
+    expect(ledger1.receiptRevision).toBe(1);
+    expect(ledger1.receipts.map((receipt) => receipt.termRevision)).toEqual([1]);
+
+    const before = JSON.stringify(ledger1);
+    const ledger2 = appendTermEvidenceReceipt(ledger1, renewalReceiptInput());
+
+    expect(ledger2.receiptRevision).toBe(2);
+    expect(ledger2.receipts.map((receipt) => receipt.termRevision)).toEqual([1, 2]);
+    expect(ledger2.receipts[0]).toEqual(createTermEvidenceReceipt(receiptInput()));
+    expect(ledger2.receipts[1].termState).toBe('suspended');
+    expect(ledger2.receipts[1].evidenceRef).toBe('evidence_test_002');
+    expectDeepFrozen(ledger2);
+    expect(JSON.stringify(ledger1)).toBe(before);
+  });
+
+  test('makes an exact re-append read-only and rejects a changed reuse of the same command', () => {
+    const ledger1 = oneReceiptLedger();
+    expect(appendTermEvidenceReceipt(ledger1, receiptInput())).toBe(ledger1);
+
+    expectSafeError(() => appendTermEvidenceReceipt(
+      ledger1,
+      receiptInput({ evidenceRef: 'evidence_changed_001' }),
+    ));
+    expectSafeError(() => appendTermEvidenceReceipt(
+      ledger1,
+      receiptInput({ termState: 'suspended' }),
+    ));
+    expectSafeError(() => appendTermEvidenceReceipt(
+      ledger1,
+      receiptInput({ receiptId: 'rcpt_test_009' }),
+    ));
+  });
+
+  test('rejects reused command and receipt identifiers across the whole history', () => {
+    const ledger2 = appendTermEvidenceReceipt(oneReceiptLedger(), renewalReceiptInput());
+
+    expectSafeError(() => appendTermEvidenceReceipt(ledger2, receiptInput({
+      receiptId: 'rcpt_test_003',
+      commandId: 'cmd_term_001',
+      termRevision: 3,
+    })));
+    expectSafeError(() => appendTermEvidenceReceipt(ledger2, receiptInput({
+      receiptId: 'rcpt_test_001',
+      commandId: 'cmd_term_003',
+      termRevision: 3,
+    })));
+  });
+
+  test('rejects skipped, stale, and out-of-order term revisions', () => {
+    expectSafeError(() => appendTermEvidenceReceipt(emptyLedger(), receiptInput({ termRevision: 2 })));
+
+    const ledger1 = oneReceiptLedger();
+    expectSafeError(() => appendTermEvidenceReceipt(ledger1, receiptInput({
+      receiptId: 'rcpt_test_003',
+      commandId: 'cmd_term_003',
+      termRevision: 1,
+    })));
+    expectSafeError(() => appendTermEvidenceReceipt(ledger1, receiptInput({
+      receiptId: 'rcpt_test_003',
+      commandId: 'cmd_term_003',
+      termRevision: 3,
+    })));
+  });
+
+  test('projects a receipt into the exact record_term_decision command the shipped authority accepts', () => {
+    const linked = createLinkedAuthorityRecord();
+    const receipt = createTermEvidenceReceipt(receiptInput());
+    const command = projectTermDecisionCommand(receipt, envelopeInput());
+
+    expect(command).toEqual({
+      membershipAuthoritySchemaVersion: 1,
+      commandType: 'record_term_decision',
+      commandId: 'cmd_term_001',
+      expectedRevision: 2,
+      termRevision: 1,
+      termState: 'approved',
+      termId: 'term_test_2026',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      evidenceRef: 'evidence_test_001',
+      policyVersion: 'policy_test_001',
+    });
+    expect(Object.isFrozen(command)).toBe(true);
+
+    const approved = applyMembershipAuthorityCommand(linked, command);
+    expect(approved.term).toEqual({
+      state: 'approved',
+      termId: 'term_test_2026',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      evidenceRef: 'evidence_test_001',
+      policyVersion: 'policy_test_001',
+      revision: 1,
+    });
+    expect(deriveMembershipEntitlement({
+      membershipAuthoritySchemaVersion: 1,
+      record: approved,
+      uid: 'uid_test_001',
+      asOfMs: TERM_START_MS,
+    })).toEqual({
+      membershipAuthoritySchemaVersion: 1,
+      entitlement: 'current_member',
+      state: 'active',
+    });
+  });
+
+  test('ledger term revisions align with the authority renewal grammar end to end', () => {
+    const linked = createLinkedAuthorityRecord();
+    const firstReceipt = createTermEvidenceReceipt(receiptInput());
+    const renewalReceipt = createTermEvidenceReceipt(renewalReceiptInput());
+
+    const ledger = appendTermEvidenceReceipt(
+      appendTermEvidenceReceipt(emptyLedger(), firstReceipt),
+      renewalReceipt,
+    );
+    expect(ledger.receipts.map((receipt) => receipt.termRevision)).toEqual([1, 2]);
+
+    const approved = applyMembershipAuthorityCommand(
+      linked,
+      projectTermDecisionCommand(ledger.receipts[0], envelopeInput()),
+    );
+    const renewed = applyMembershipAuthorityCommand(
+      approved,
+      projectTermDecisionCommand(ledger.receipts[1], envelopeInput({ expectedRevision: 3 })),
+    );
+
+    expect(approved.term.revision).toBe(1);
+    expect(renewed.term.revision).toBe(2);
+    expect(renewed.revision).toBe(4);
+    expect(renewed.term.state).toBe('suspended');
+  });
+});
+
+describe('strict and non-identifying input boundary', () => {
+  test.each([
+    undefined,
+    null,
+    true,
+    1,
+    'ledger',
+    [],
+    new Date(0),
+    new Number(1),
+  ])('rejects non-plain root input case %#', (input) => {
+    expectSafeError(() => createMembershipTermLedger(input));
+    expectSafeError(() => createTermEvidenceReceipt(input));
+    expectSafeError(() => appendTermEvidenceReceipt(input, receiptInput()));
+    expectSafeError(() => appendTermEvidenceReceipt(emptyLedger(), input));
+    expectSafeError(() => projectTermDecisionCommand(input, envelopeInput()));
+    expectSafeError(() => projectTermDecisionCommand(receiptInput(), input));
+  });
+
+  test('rejects missing, extra, symbol, inherited, accessor, and proxy fields', () => {
+    for (const field of Object.keys(receiptInput())) {
+      const input = receiptInput();
+      delete input[field];
+      expectSafeError(() => createTermEvidenceReceipt(input));
+    }
+    for (const field of Object.keys(ledgerInput())) {
+      const input = ledgerInput();
+      delete input[field];
+      expectSafeError(() => createMembershipTermLedger(input));
+    }
+    expectSafeError(() => createTermEvidenceReceipt({ ...receiptInput(), email: HOSTILE_CANARY }));
+    const symbolInput = receiptInput();
+    symbolInput[Symbol(HOSTILE_CANARY)] = true;
+    expectSafeError(() => createTermEvidenceReceipt(symbolInput));
+    expectSafeError(() => createTermEvidenceReceipt(Object.assign(
+      Object.create({ email: HOSTILE_CANARY }),
+      receiptInput(),
+    )));
+    const getterInput = receiptInput();
+    Object.defineProperty(getterInput, 'termId', {
+      get() {
+        throw new Error(HOSTILE_CANARY);
+      },
+      enumerable: true,
+    });
+    expectSafeError(() => createTermEvidenceReceipt(getterInput));
+    expectSafeError(() => createTermEvidenceReceipt(new Proxy(receiptInput(), {})));
+    expectSafeError(() => createMembershipTermLedger(new Proxy(ledgerInput(), {})));
+    expectSafeError(() => appendTermEvidenceReceipt(
+      new Proxy(emptyLedger(), {}),
+      receiptInput(),
+    ));
+    expectSafeError(() => appendTermEvidenceReceipt(
+      emptyLedger(),
+      new Proxy(receiptInput(), {}),
+    ));
+    expectSafeError(() => projectTermDecisionCommand(new Proxy(receiptInput(), {}), envelopeInput()));
+    expectSafeError(() => projectTermDecisionCommand(receiptInput(), new Proxy(envelopeInput(), {})));
+  });
+
+  test.each([
+    'private-member@example.test',
+    '+12025550208',
+    'https://example.test/member',
+    'member with spaces',
+    'member/with/path',
+    'éxternal',
+    '',
+    'a'.repeat(129),
+  ])('rejects non-opaque identifier %p', (value) => {
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ receiptId: value })), value);
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ commandId: value })), value);
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ termId: value })), value);
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ planRef: value })), value);
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ evidenceRef: value })), value);
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ policyVersion: value })), value);
+    expectSafeError(() => createMembershipTermLedger(ledgerInput({ ledgerId: value })), value);
+  });
+
+  test.each([
+    ['email', HOSTILE_CANARY],
+    ['phoneNumber', '+12025550208'],
+    ['provider', 'google.com'],
+    ['role', 'admin_canary_345'],
+    ['stripePaymentId', 'pi_private'],
+    ['priceCents', 2500],
+    ['memberName', 'Private Runner'],
+  ])('rejects forbidden caller field %s', (field, value) => {
+    expectSafeError(() => createTermEvidenceReceipt({ ...receiptInput(), [field]: value }), String(value));
+  });
+
+  test.each([
+    NaN,
+    Infinity,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER,
+  ])('rejects invalid term time %p', (startsAtMs) => {
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ startsAtMs })));
+  });
+
+  test('rejects equal and reversed term bounds', () => {
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ startsAtMs: TERM_END_MS })));
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ startsAtMs: TERM_END_MS + 1 })));
+  });
+
+  test('rejects unsupported schema versions, term states, and non-recorded revisions', () => {
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({
+      membershipTermReceiptSchemaVersion: 2,
+    })));
+    expectSafeError(() => createMembershipTermLedger(ledgerInput({
+      membershipTermReceiptSchemaVersion: 2,
+    })));
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ termState: 'paid' })));
+    expectSafeError(() => createTermEvidenceReceipt(receiptInput({ termRevision: 0 })));
+  });
+
+  test('validates ledger snapshots again instead of trusting caller-created arrays', () => {
+    const valid = oneReceiptLedger();
+    const clone = () => JSON.parse(JSON.stringify(valid));
+    const nextReceipt = renewalReceiptInput();
+
+    const badCount = clone();
+    badCount.receiptRevision = 2;
+    expectSafeError(() => appendTermEvidenceReceipt(badCount, nextReceipt));
+
+    const extraField = clone();
+    extraField.receipts[0].priceCents = 2500;
+    expectSafeError(() => appendTermEvidenceReceipt(extraField, nextReceipt));
+
+    const nonMonotonic = clone();
+    nonMonotonic.receipts[0].termRevision = 2;
+    expectSafeError(() => appendTermEvidenceReceipt(nonMonotonic, nextReceipt));
+
+    const notArray = clone();
+    notArray.receipts = { 0: createTermEvidenceReceipt(receiptInput()), length: 1 };
+    expectSafeError(() => appendTermEvidenceReceipt(notArray, nextReceipt));
+
+    const sparse = clone();
+    const holed = [];
+    holed[1] = createTermEvidenceReceipt(receiptInput());
+    sparse.receipts = holed;
+    sparse.receiptRevision = 2;
+    expectSafeError(() => appendTermEvidenceReceipt(sparse, renewalReceiptInput({ termRevision: 3 })));
+
+    const proxied = clone();
+    proxied.receipts = new Proxy(valid.receipts.map((receipt) => ({ ...receipt })), {});
+    expectSafeError(() => appendTermEvidenceReceipt(proxied, nextReceipt));
+
+    const duplicated = clone();
+    duplicated.receipts = [duplicated.receipts[0], { ...duplicated.receipts[0], termRevision: 2 }];
+    duplicated.receiptRevision = 2;
+    expectSafeError(() => appendTermEvidenceReceipt(duplicated, renewalReceiptInput({ termRevision: 3 })));
+  });
+
+  test('rejects malformed projection envelopes', () => {
+    expectSafeError(() => projectTermDecisionCommand(
+      receiptInput(),
+      envelopeInput({ membershipAuthoritySchemaVersion: 2 }),
+    ));
+    expectSafeError(() => projectTermDecisionCommand(receiptInput(), envelopeInput({ expectedRevision: 0 })));
+    expectSafeError(() => projectTermDecisionCommand(receiptInput(), envelopeInput({ expectedRevision: 1.5 })));
+    expectSafeError(() => projectTermDecisionCommand(
+      receiptInput(),
+      { ...envelopeInput(), commandId: 'cmd_extra_001' },
+    ));
+    for (const field of Object.keys(envelopeInput())) {
+      const input = envelopeInput();
+      delete input[field];
+      expectSafeError(() => projectTermDecisionCommand(receiptInput(), input));
+    }
+  });
+});
+
+describe('static non-adoption and dependency boundary', () => {
+  test('has no runtime edge, external SDK, clock, random, logger, environment, or provider field', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'membershipTermReceipt.js'), 'utf8');
+    const index = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+    expect(index).not.toContain('membershipTermReceipt');
+    expect(source).not.toMatch(/firebase|firestore|stripe|google|whatsapp|strava/i);
+    expect(source).not.toMatch(/process\.env|Date\.now|new Date|Math\.random|console\.|fetch\s*\(|https?:/);
+    expect(source).not.toMatch(/email|phone|address|dob|emergency|price|payment/i);
+    const requires = [...source.matchAll(/require\(([^)]+)\)/g)].map((match) => match[1]);
+    expect(requires).toEqual(["'node:util'"]);
+  });
+});


### PR DESCRIPTION
Closes #345. Advances parent #114 (MEMBERS-DUES-001).

**Draft for owner review — P0 boundary, not auto-merged.**

## What this is
A pure, **source-only, unused** CommonJS contract — `functions/membershipTermReceipt.js` — that preserves the immutable renewal/evidence history the shipped single-snapshot membership-authority reducer (`functions/membershipAuthority.js`, #208) intentionally cannot hold.

The §8.0a reducer keeps only **one replaceable current-term snapshot** — each `record_term_decision` overwrites the previous term. That satisfies "current membership state" but not the parent invariant *"Each renewal creates a new immutable term/evidence relationship; it does not overwrite prior membership history."* This child adds exactly that missing piece, **without duplicating** the reducer.

## Behavior
- **Term/evidence receipt** — an immutable frozen record of one term decision's evidence bundle (`receiptId`, `commandId`, `termRevision`, `termState`, `termId`, half-open `startsAtMs`/`endsAtMs`, opaque `planRef`/`evidenceRef`/`policyVersion`).
- **Append-only ledger** — `{ ledgerId, receiptRevision, receipts[] }` with `receipts.length === receiptRevision`. Append enforces position-bound monotonic revision (`termRevision === receiptRevision + 1`), global `commandId`/`receiptId` uniqueness, and **tail exact-retry idempotency** (a replay of the last append returns the same ledger; a same-command-id-but-different-content append fails closed). Earlier receipts are never mutated.
- **Projection** — `projectTermDecisionCommand(receipt, { membershipAuthoritySchemaVersion, expectedRevision })` returns the exact `record_term_decision` command input that the shipped `applyMembershipAuthorityCommand` accepts. An integration test importing **both** modules proves the projection is accepted end-to-end, so the two contracts compose without a shared type and cannot drift.
- Frozen versioned API, opaque-identifier + safe-integer-ms validation, proxy/accessor/getter/extra-field rejection, and a frozen `MembershipTermReceiptError` that never leaks input — matching the `membershipAuthority.js` idiom exactly.

## Invents no owner policy
No calendar/anniversary/grace, plan eligibility, price/currency, refund/dispute, waiver/retention/tax, or legacy import. Every reference is an opaque caller-supplied token; only technical bounds (`startsAtMs < endsAtMs`, monotonic position-bound revision) are enforced — the same bounds the shipped reducer already enforces. It grants no entitlement by itself.

## Explicitly out of scope (deferred children / owner decisions)
Durable persistence & replay, Firestore schema & Rules, custom claims / token refresh, cross-record UID uniqueness, runtime authorization & adoption, migration, and deployment. Officer docs are **not** updated — this delivers no officer-observable capability (same precedent as #208).

## Validation
- `functions` jest: **89/89 pass** (43 new receipt tests + 46 existing authority tests), run under the repo test-safety gate with local secrets unset.
- Static non-adoption test asserts `index.js` does not reference the module and the source requires **only** `node:util` (no firebase/firestore/stripe/google/clock/env/network/PII tokens).
- No `src/` change (frontend lint baseline untouched); no runtime import; no production/provider/officer surface touched.
- `SYSTEM_DESIGN.md` §8.0b added marking the contract **SOURCE ONLY, UNUSED / NOT AVAILABLE YET**.

A green suite and a merge are **not** Firebase deployment or live-behavior proof.
