### PR TITLE
PAY-001B1E: fail closed on malformed event audience (#351)

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -397,6 +397,71 @@ Officer source-review steps:
 
 No main system map needs to change because this source change adds one format stop without changing ownership, permissions, storage locations, the Stripe boundary, or website publishing. The small diagram above records the invalid-capacity stop, the existing count path, and the separate volunteer path.
 
+## Race audience format guard — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** stop race and volunteer checkout when an event's stored public or members-only setting is draft, missing, mixed, or malformed.
+
+**Approver:** event lead plus membership lead and platform/security owner.
+
+**Prerequisites for source review:** issue [#351](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/351) must be merged. The exact pull request and merge commit must be named. Tests must use only a made-up event, runner, and website role with replacements that cannot contact Firebase or Stripe. New records use one `visibility` field. Older records without that field use one true-or-false `member_only` field. The private inventory in [#113](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/113) must identify any real older or mixed record before deployment or repair. This check does not choose an event audience. For this guard, a website role proves only that the stored audience gate passed. The unchanged later price-role check remains separate. Neither check proves current or paid club membership.
+
+```mermaid
+flowchart TD
+    A["Made-up request passes earlier counters and registration-window check"] --> B{"Exactly one allowed checkout audience?"}
+    B -- "No, or value is draft, mixed, missing, or malformed" --> C["Fixed unavailable result; no audience-role or later checkout work"]
+    B -- "Yes, public" --> D["Continue without the audience-role check"]
+    B -- "Yes, members-only" --> E{"Exact verified website member or admin role?"}
+    E -- "No" --> F["Existing members-only denial"]
+    E -- "Yes" --> G["Continue to the unchanged volunteer or participant path"]
+    E -. "Access check only" .-> H["Website role is not membership or payment proof"]
+```
+
+Text alternative: after earlier request counters and the registration-window check, exactly one audience that is allowed for checkout is required. A new public setting or an older false member-only flag continues without the audience-role check. A new members-only setting or an older true flag uses the existing verified website-role check. Draft is a known stored catalog value, but it is unavailable for checkout. Mixed, missing, or malformed formats also stop with one unavailable result. Passing the website-role check does not prove current or paid club membership.
+
+Officer source-review steps:
+
+1. Keep live race and volunteer checkout unavailable.
+2. Ask the platform owner for the exact #351 pull request.
+3. Ask the platform owner for the exact merge commit.
+4. Ask for the made-up test report from that same commit.
+5. Confirm the report uses only a made-up event, runner, and website role.
+6. Confirm a new-format event that may continue checkout uses only `public` or `members_only`.
+7. Confirm an older-format event has no new field and uses one exact true-or-false member-only flag.
+8. Confirm a draft audience stops checkout.
+9. Confirm both audience fields present stops checkout.
+10. Confirm both audience fields missing stops checkout.
+11. Confirm unknown, wrong-kind, hidden, inherited, or code-running audience values stop checkout.
+12. Confirm rejected values cannot run a stored method or automatic conversion.
+13. Confirm rejected values receive exactly `Registration is unavailable for this event`.
+14. Confirm the result and new guard logs expose no stored audience value or technical detail.
+15. Confirm the two request-count safety checks may already have written counters.
+16. Confirm the registration-window check may already have run.
+17. Confirm a malformed audience starts no website-role check.
+18. Confirm a malformed audience starts no volunteer, capacity, later participant role, price, token, registration write, Stripe Product, or Checkout Session work.
+19. Confirm a recognized members-only event keeps the existing website-role check and denial.
+20. Confirm a recognized public event starts no audience-role check.
+21. Confirm a later participant price-role check remains separate from the audience-role check.
+22. Confirm passing the audience-role check proves only the stored audience gate.
+23. Confirm the separate later role check keeps the existing member-price behavior without newly approving it.
+24. Confirm neither role check proves paid dues, current annual membership, or eligibility beyond its existing narrow result.
+25. Confirm valid made-up public and members-only participant paths keep their existing results.
+26. Confirm valid made-up public and members-only volunteer paths keep their existing results.
+27. Record source, tests, merge, website publication, `runmprc.com`, Firebase deployment, Stripe state, production data, migration, and live behavior as separate results.
+
+**Expected result:** exactly one audience that is allowed for checkout is required. New public and members-only settings and their older true-or-false equivalents keep their current access paths. Draft, mixed, missing, or malformed formats stop with one plain result before the audience-role check or later checkout work. The existing verified website-role check proves only the stored audience gate. The separate later role check keeps its existing member-price result. This source guard changes neither narrow result and proves no paid dues, current annual membership, or broader eligibility.
+
+**Stop conditions:** any real runner, volunteer, event, audience, account, role, membership, registration, payment, Firebase record, Stripe object, Stripe call, or production test; a request to choose or repair an audience in Firebase by hand; a missing exact commit; a stored audience value or technical detail in shared evidence; a malformed audience that starts role or later checkout work; deployment before the private #113 inventory and an owner-approved audience; or a claim that source, tests, merge, preview, or a green workflow proves membership or live checkout behavior.
+
+**Success proof:** exact #351 pull request and merge commit; recorded old-source failures using made-up values; green audience, caller, full server, database-permission, isolated test-database commerce, website, safety, and build checks; independent security, compatibility, identity, and backup-officer reviews; and a written statement that website publication, `runmprc.com`, Firebase, Stripe, production data, migration, and live behavior were not changed or verified. A future live release also needs the private #113 inventory, an owner-approved audience for each real event, the broader RACE/PAY staging proof, isolated Stripe test mode, exact Firebase Function deployment and readback, made-up staged account-role proof, and rollback evidence.
+
+**Undo:** before Firebase deployment, use one reviewed pull request that reverses the change or corrects it safely. After any approved backend deployment, use the protected backend release process and confirm the exact published Function revision. Never undo by changing an event, audience, role, membership, registration, Product, Session, or payment record by hand.
+
+**Escalation:** event lead plus membership lead and platform/security owner. Add the privacy owner if runner or account details appeared. Add the treasurer if membership or payment was inferred. Use the private incident path if a malformed audience may have reached role, registration, or Stripe work. Do not copy private details, stored audience values, provider identifiers, or role evidence into an issue, screenshot, email, message, or AI tool.
+
+No main system map needs to change because this source guard changes no audience owner, role policy, permission, storage location, data movement, Stripe boundary, or website publishing path. The small diagram above records the new failure stop and the current new-format and older-format access paths.
+
 ## Merchandise price format guard — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/functions/checkoutPromotionPolicy.test.js
+++ b/functions/checkoutPromotionPolicy.test.js
@@ -7,6 +7,8 @@ const mockFirestoreWrite = jest.fn();
 const mockGenerateToken = jest.fn();
 const mockResolveCallerRole = jest.fn();
 const mockCountActiveRegistrations = jest.fn();
+const mockProjectEventCheckoutAudience = jest.fn();
+const mockProjectParticipantCapacityLimit = jest.fn();
 const mockPickPriceCents = jest.fn();
 const mockIsEarlyBirdActive = jest.fn();
 const mockRegistrationAllocation = jest.fn();
@@ -119,6 +121,7 @@ jest.mock('./stripeHelpers', () => {
   const {
     isEarlyBirdActive,
     pickPriceCents,
+    projectEventCheckoutAudience,
     projectParticipantCapacityLimit,
   } = jest.requireActual('./stripeHelpers');
   return {
@@ -134,7 +137,14 @@ jest.mock('./stripeHelpers', () => {
       mockPickPriceCents(...args);
       return pickPriceCents(...args);
     },
-    projectParticipantCapacityLimit,
+    projectEventCheckoutAudience: (...args) => {
+      mockProjectEventCheckoutAudience(...args);
+      return projectEventCheckoutAudience(...args);
+    },
+    projectParticipantCapacityLimit: (...args) => {
+      mockProjectParticipantCapacityLimit(...args);
+      return projectParticipantCapacityLimit(...args);
+    },
     isEarlyBirdActive: (...args) => {
       mockIsEarlyBirdActive(...args);
       return isEarlyBirdActive(...args);
@@ -203,6 +213,8 @@ describe('Checkout promotion policy', () => {
     mockGenerateToken.mockReset();
     mockResolveCallerRole.mockReset();
     mockCountActiveRegistrations.mockReset();
+    mockProjectEventCheckoutAudience.mockReset();
+    mockProjectParticipantCapacityLimit.mockReset();
     mockPickPriceCents.mockReset();
     mockIsEarlyBirdActive.mockReset();
     mockRegistrationAllocation.mockReset();
@@ -839,6 +851,278 @@ describe('Checkout promotion policy', () => {
     });
   });
 
+  describe('event audience format guard', () => {
+    async function expectMalformedAudienceRejected({
+      audience = {},
+      configureStoredEvent,
+      canary = 'synthetic_audience_canary',
+      hooks = [],
+      request = validRaceRequest(),
+    }) {
+      const eventBefore = {
+        checkoutEnabled: true,
+        title: 'Synthetic Audience Race',
+        slug: 'synthetic-audience-race',
+        status: 'open',
+        capacity: null,
+        pricing: { nonMemberCents: 5_000 },
+        stripeProductId: 'prod_audience_policy',
+        waiverVersion: 'synthetic-v1',
+        ...audience,
+      };
+      admin.__seed('events/race-1', eventBefore);
+      const storedEvent = admin.__get('events/race-1');
+      configureStoredEvent?.(storedEvent);
+      const storedDescriptors = Object.getOwnPropertyDescriptors(storedEvent);
+      mockProductCreate.mockResolvedValueOnce({ id: 'prod_should_not_exist' });
+      const consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+        .map((method) => jest.spyOn(console, method).mockImplementation(() => {}));
+
+      try {
+        const outcome = await createCheckoutSession(request, {
+          auth: null,
+          rawRequest: {},
+        }).then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        );
+
+        expect(outcome.error).toMatchObject({
+          code: 'failed-precondition',
+          message: 'Registration is unavailable for this event',
+        });
+        const publicError = JSON.stringify({
+          code: outcome.error?.code,
+          message: outcome.error?.message,
+          stack: outcome.error?.stack,
+        });
+        expect(publicError).not.toContain(canary);
+        expect(publicError).not.toContain('visibility');
+        expect(publicError).not.toContain('member_only');
+        expect(mockFirestoreAccess).toHaveBeenCalledTimes(1);
+        expect(mockRateLimit).toHaveBeenCalledTimes(2);
+        expect(mockProjectEventCheckoutAudience).toHaveBeenCalledTimes(1);
+        expect(mockProjectEventCheckoutAudience).toHaveBeenCalledWith(storedEvent);
+        expect(mockRateLimit.mock.invocationCallOrder[1]).toBeLessThan(
+          mockProjectEventCheckoutAudience.mock.invocationCallOrder[0],
+        );
+        expect(mockResolveCallerRole).not.toHaveBeenCalled();
+        expect(mockProjectParticipantCapacityLimit).not.toHaveBeenCalled();
+        expect(mockCountActiveRegistrations).not.toHaveBeenCalled();
+        expect(mockIsEarlyBirdActive).not.toHaveBeenCalled();
+        expect(mockPickPriceCents).not.toHaveBeenCalled();
+        expect(mockGenerateToken).not.toHaveBeenCalled();
+        expect(mockRegistrationAllocation).not.toHaveBeenCalled();
+        expect(mockFirestoreWrite).not.toHaveBeenCalled();
+        expect(admin.__get('events/race-1/registrations/reg-new-1')).toBeUndefined();
+        expect(mockGetStripe).not.toHaveBeenCalled();
+        expect(mockProductCreate).not.toHaveBeenCalled();
+        expect(mockCheckoutCreate).not.toHaveBeenCalled();
+        consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+        hooks.forEach((hook) => expect(hook).not.toHaveBeenCalled());
+        expect(Object.getOwnPropertyDescriptors(storedEvent))
+          .toEqual(storedDescriptors);
+      } finally {
+        consoleSpies.forEach((spy) => spy.mockRestore());
+      }
+    }
+
+    test.each([
+      ['draft', { visibility: 'draft' }],
+      ['unknown', { visibility: 'synthetic_audience_canary' }],
+      ['both markers missing', {}],
+      ['malformed legacy marker', { member_only: 'true' }],
+      ['mixed modern and legacy markers', {
+        visibility: 'public',
+        member_only: false,
+      }],
+    ])('rejects a %s audience before later checkout work', async (
+      _name,
+      audience,
+    ) => {
+      await expectMalformedAudienceRejected({ audience });
+    });
+
+    test('does not invoke an accessor-backed audience marker', async () => {
+      const getter = jest.fn(() => 'public');
+
+      await expectMalformedAudienceRejected({
+        configureStoredEvent: (event) => {
+          Object.defineProperty(event, 'visibility', {
+            configurable: true,
+            enumerable: true,
+            get: getter,
+          });
+        },
+        hooks: [getter],
+      });
+    });
+
+    test('does not accept a hidden audience marker', async () => {
+      await expectMalformedAudienceRejected({
+        configureStoredEvent: (event) => {
+          Object.defineProperty(event, 'visibility', {
+            configurable: true,
+            value: 'public',
+          });
+        },
+      });
+    });
+
+    test('rejects malformed audience before the volunteer branch', async () => {
+      await expectMalformedAudienceRejected({
+        audience: {
+          visibility: 'draft',
+          volunteerEnabled: true,
+        },
+        request: {
+          eventId: 'race-1',
+          runner: {
+            firstName: 'Test',
+            lastName: 'Volunteer',
+            email: 'volunteer@example.test',
+          },
+          acceptedWaiver: true,
+          signupType: 'volunteer',
+        },
+      });
+    });
+
+    test.each([
+      ['modern public', { visibility: 'public' }, null, 1],
+      ['modern members-only', { visibility: 'members_only' }, {
+        uid: 'synthetic-member',
+        token: {
+          email_verified: true,
+          role: 'member',
+        },
+      }, 2],
+      ['legacy public', { member_only: false }, null, 1],
+      ['legacy members-only', { member_only: true }, {
+        uid: 'synthetic-member',
+        token: {
+          email_verified: true,
+          role: 'member',
+        },
+      }, 2],
+    ])('preserves the %s checkout path', async (
+      _name,
+      audience,
+      auth,
+      expectedRoleCalls,
+    ) => {
+      admin.__seed('events/race-1', {
+        checkoutEnabled: true,
+        title: 'Synthetic Recognized Audience Race',
+        slug: 'synthetic-recognized-audience-race',
+        status: 'open',
+        capacity: null,
+        pricing: { nonMemberCents: 5_000 },
+        stripeProductId: 'prod_recognized_audience_policy',
+        waiverVersion: 'synthetic-v1',
+        ...audience,
+      });
+
+      await expect(createCheckoutSession(validRaceRequest(), {
+        auth,
+        rawRequest: {},
+      })).resolves.toMatchObject({
+        sessionId: 'cs_registration_policy',
+        registrationId: 'reg-new-1',
+      });
+
+      expect(mockProjectEventCheckoutAudience).toHaveBeenCalledTimes(1);
+      expect(mockResolveCallerRole).toHaveBeenCalledTimes(expectedRoleCalls);
+      expect(mockProjectParticipantCapacityLimit).toHaveBeenCalledTimes(1);
+      expect(mockCountActiveRegistrations).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).toHaveBeenCalledTimes(1);
+      expect(mockProjectEventCheckoutAudience.mock.invocationCallOrder[0])
+        .toBeLessThan(mockResolveCallerRole.mock.invocationCallOrder[0]);
+    });
+
+    test('keeps the existing denial for legacy members-only access', async () => {
+      admin.__seed('events/race-1', {
+        checkoutEnabled: true,
+        title: 'Synthetic Legacy Members Race',
+        slug: 'synthetic-legacy-members-race',
+        status: 'open',
+        member_only: true,
+        pricing: { memberCents: 3_000, nonMemberCents: 5_000 },
+        stripeProductId: 'prod_legacy_members_policy',
+        waiverVersion: 'synthetic-v1',
+      });
+
+      await expect(createCheckoutSession(validRaceRequest({
+        priceTier: 'member',
+      }), {
+        auth: {
+          uid: 'synthetic-user',
+          token: { role: 'member' },
+        },
+        rawRequest: {},
+      })).rejects.toMatchObject({
+        code: 'permission-denied',
+        message: 'This event is open to club members only',
+      });
+
+      expect(mockProjectEventCheckoutAudience).toHaveBeenCalledTimes(1);
+      expect(mockResolveCallerRole).toHaveBeenCalledTimes(1);
+      expect(mockProjectParticipantCapacityLimit).not.toHaveBeenCalled();
+      expect(mockRegistrationAllocation).not.toHaveBeenCalled();
+      expect(mockFirestoreWrite).not.toHaveBeenCalled();
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      ['modern', { visibility: 'members_only' }],
+      ['legacy', { member_only: true }],
+    ])('preserves the %s members-only volunteer path', async (
+      _name,
+      audience,
+    ) => {
+      admin.__seed('events/race-1', {
+        checkoutEnabled: true,
+        title: 'Synthetic Members Volunteer Race',
+        slug: 'synthetic-members-volunteer-race',
+        status: 'open',
+        volunteerEnabled: true,
+        waiverVersion: 'synthetic-v1',
+        ...audience,
+      });
+
+      await expect(createCheckoutSession({
+        eventId: 'race-1',
+        runner: {
+          firstName: 'Test',
+          lastName: 'Volunteer',
+          email: 'volunteer@example.test',
+        },
+        acceptedWaiver: true,
+        signupType: 'volunteer',
+      }, {
+        auth: {
+          uid: 'synthetic-member',
+          token: {
+            email_verified: true,
+            role: 'member',
+          },
+        },
+        rawRequest: {},
+      })).resolves.toMatchObject({
+        free: true,
+        registrationId: 'reg-new-1',
+      });
+
+      expect(mockProjectEventCheckoutAudience).toHaveBeenCalledTimes(1);
+      expect(mockResolveCallerRole).toHaveBeenCalledTimes(1);
+      expect(mockProjectParticipantCapacityLimit).not.toHaveBeenCalled();
+      expect(mockRegistrationAllocation).toHaveBeenCalledTimes(1);
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(mockCheckoutCreate).not.toHaveBeenCalled();
+    });
+  });
+
   test('race checkout sends the exact disabled-adjustment payload', async () => {
     admin.__seed('events/race-1', {
       checkoutEnabled: true,
@@ -1065,6 +1349,7 @@ describe('Checkout promotion policy', () => {
       title: 'Synthetic Race',
       slug: 'synthetic-race',
       status: 'open',
+      visibility: 'public',
       volunteerEnabled: true,
       waiverVersion: 'synthetic-v1',
     });
@@ -1100,6 +1385,7 @@ describe('Checkout promotion policy', () => {
       title: 'Synthetic Free Race',
       slug: 'synthetic-free-race',
       status: 'open',
+      visibility: 'public',
       pricing: { nonMemberCents: 0 },
       waiverVersion: 'synthetic-v1',
     });

--- a/functions/createCheckoutSession.js
+++ b/functions/createCheckoutSession.js
@@ -7,6 +7,7 @@ const {
   resolveCallerRole,
   requireAppCheck,
   pickPriceCents,
+  projectEventCheckoutAudience,
   projectParticipantCapacityLimit,
   isEarlyBirdActive,
   isRegistrationOpen,
@@ -163,7 +164,14 @@ exports.createCheckoutSession = functions
       );
     }
 
-    if (event.visibility === 'members_only' || event.member_only === true) {
+    const audience = projectEventCheckoutAudience(event);
+    if (audience === undefined) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'Registration is unavailable for this event',
+      );
+    }
+    if (audience === 'members_only') {
       const role = await resolveCallerRole(context);
       if (role !== 'member' && role !== 'admin') {
         throw new functions.https.HttpsError(

--- a/functions/stripeHelpers.js
+++ b/functions/stripeHelpers.js
@@ -126,6 +126,43 @@ function pickPriceCents(event, priceTier) {
   return priceCents;
 }
 
+function projectEventCheckoutAudience(event) {
+  if (!isPlainEventRecord(event)) return undefined;
+
+  const visibility = selectedOwnDataValue(event, 'visibility', true);
+  const memberOnly = selectedOwnDataValue(event, 'member_only', true);
+  if (
+    visibility === INVALID_REGISTRATION_WINDOW_VALUE
+    || memberOnly === INVALID_REGISTRATION_WINDOW_VALUE
+  ) {
+    return undefined;
+  }
+  if (
+    visibility === MISSING_REGISTRATION_WINDOW_VALUE
+    && objectGetOwnPropertyDescriptor(objectPrototype, 'visibility')
+  ) {
+    return undefined;
+  }
+  if (
+    memberOnly === MISSING_REGISTRATION_WINDOW_VALUE
+    && objectGetOwnPropertyDescriptor(objectPrototype, 'member_only')
+  ) {
+    return undefined;
+  }
+
+  const hasVisibility = visibility !== MISSING_REGISTRATION_WINDOW_VALUE;
+  const hasMemberOnly = memberOnly !== MISSING_REGISTRATION_WINDOW_VALUE;
+  if (hasVisibility === hasMemberOnly) return undefined;
+
+  if (hasVisibility) {
+    return visibility === 'public' || visibility === 'members_only'
+      ? visibility
+      : undefined;
+  }
+  if (typeof memberOnly !== 'boolean') return undefined;
+  return memberOnly ? 'members_only' : 'public';
+}
+
 function projectParticipantCapacityLimit(event) {
   if (!isPlainEventRecord(event)) return undefined;
 
@@ -310,6 +347,7 @@ module.exports = {
   isValidEmail,
   validateRunner,
   pickPriceCents,
+  projectEventCheckoutAudience,
   projectParticipantCapacityLimit,
   isEarlyBirdActive,
   isRegistrationOpen,

--- a/functions/stripeHelpers.test.js
+++ b/functions/stripeHelpers.test.js
@@ -33,6 +33,7 @@ const {
   isEarlyBirdActive,
   isRegistrationOpen,
   pickPriceCents,
+  projectEventCheckoutAudience,
   projectParticipantCapacityLimit,
   requireAdmin,
   resolveCallerRole,
@@ -45,6 +46,274 @@ const NOW_MS = 1_735_689_600_000;
 function openEvent(overrides = {}) {
   return { status: 'open', ...overrides };
 }
+
+describe('event checkout audience validation', () => {
+  test.each([
+    ['modern public', { visibility: 'public' }, 'public'],
+    ['modern members-only', { visibility: 'members_only' }, 'members_only'],
+    ['legacy public', { member_only: false }, 'public'],
+    ['legacy members-only', { member_only: true }, 'members_only'],
+  ])('projects the %s format to %s', (_name, event, expected) => {
+    Object.freeze(event);
+    expect(projectEventCheckoutAudience(event)).toBe(expected);
+  });
+
+  test('rejects missing, mixed, and draft audience formats', () => {
+    expect(projectEventCheckoutAudience({})).toBeUndefined();
+    expect(projectEventCheckoutAudience({
+      visibility: 'public',
+      member_only: false,
+    })).toBeUndefined();
+    expect(projectEventCheckoutAudience({
+      visibility: 'members_only',
+      member_only: true,
+    })).toBeUndefined();
+    expect(projectEventCheckoutAudience({
+      visibility: 'draft',
+    })).toBeUndefined();
+  });
+
+  test.each([
+    ['present undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['true', true],
+    ['zero', 0],
+    ['number', 1],
+    ['empty string', ''],
+    ['draft', 'draft'],
+    ['unknown string', 'synthetic_audience_canary'],
+    ['case-changed string', 'Public'],
+    ['hyphenated string', 'members-only'],
+    ['bigint', BigInt(1)],
+    ['symbol', Symbol('visibility')],
+    ['boxed string', Object('public')],
+    ['plain record', { value: 'public' }],
+    ['array', ['public']],
+    ['Date', new Date(NOW_MS)],
+    ['Map', new Map([['visibility', 'public']])],
+    ['Set', new Set(['public'])],
+  ])('rejects a %s visibility value', (_name, visibility) => {
+    expect(projectEventCheckoutAudience({ visibility })).toBeUndefined();
+  });
+
+  test.each([
+    ['present undefined', undefined],
+    ['null', null],
+    ['zero', 0],
+    ['one', 1],
+    ['empty string', ''],
+    ['false text', 'false'],
+    ['true text', 'true'],
+    ['bigint', BigInt(1)],
+    ['symbol', Symbol('member-only')],
+    ['boxed boolean', Object(true)],
+    ['plain record', { value: true }],
+    ['array', [true]],
+    ['Date', new Date(NOW_MS)],
+    ['Map', new Map([['member_only', true]])],
+    ['Set', new Set([true])],
+  ])('rejects a %s legacy member-only value', (_name, memberOnly) => {
+    expect(projectEventCheckoutAudience({
+      member_only: memberOnly,
+    })).toBeUndefined();
+  });
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 1],
+    ['string', 'event'],
+    ['array', []],
+    ['Date', new Date(NOW_MS)],
+    ['null-prototype record', Object.create(null)],
+    ['custom-prototype record', Object.create({})],
+  ])('rejects a %s event root without throwing', (_name, event) => {
+    expect(() => projectEventCheckoutAudience(event)).not.toThrow();
+    expect(projectEventCheckoutAudience(event)).toBeUndefined();
+  });
+
+  test('rejects live and revoked Proxy event roots without invoking traps', () => {
+    const trap = jest.fn(() => {
+      throw new Error('synthetic event trap must not run');
+    });
+    const proxiedEvent = new Proxy({ visibility: 'public' }, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+
+    expect(projectEventCheckoutAudience(proxiedEvent)).toBeUndefined();
+    expect(trap).not.toHaveBeenCalled();
+
+    const revoked = Proxy.revocable({ visibility: 'public' }, {});
+    revoked.revoke();
+    expect(() => projectEventCheckoutAudience(revoked.proxy)).not.toThrow();
+    expect(projectEventCheckoutAudience(revoked.proxy)).toBeUndefined();
+  });
+
+  test.each([
+    ['visibility', 'public'],
+    ['member_only', false],
+  ])('rejects an accessor-backed or hidden %s field', (field, value) => {
+    const getter = jest.fn(() => value);
+    const accessorEvent = {};
+    Object.defineProperty(accessorEvent, field, {
+      enumerable: true,
+      get: getter,
+    });
+    const hiddenEvent = {};
+    Object.defineProperty(hiddenEvent, field, { value });
+
+    expect(projectEventCheckoutAudience(accessorEvent)).toBeUndefined();
+    expect(projectEventCheckoutAudience(hiddenEvent)).toBeUndefined();
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['visibility', { member_only: false }, 'public'],
+    ['member_only', { visibility: 'public' }, true],
+  ])('rejects shared-prototype %s pollution without reading it', (
+    field,
+    event,
+    value,
+  ) => {
+    const getter = jest.fn(() => value);
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      field,
+    );
+    let projected;
+
+    try {
+      Object.defineProperty(Object.prototype, field, {
+        configurable: true,
+        get: getter,
+      });
+      projected = projectEventCheckoutAudience(event);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Object.prototype, field, originalDescriptor);
+      } else {
+        delete Object.prototype[field];
+      }
+    }
+
+    expect(projected).toBeUndefined();
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'visibility',
+    'member_only',
+  ])('rejects live and revoked Proxy %s values without invoking traps', (
+    field,
+  ) => {
+    const trap = jest.fn(() => {
+      throw new Error('synthetic audience trap must not run');
+    });
+    const proxiedValue = new Proxy({}, {
+      get: trap,
+      getOwnPropertyDescriptor: trap,
+      getPrototypeOf: trap,
+      ownKeys: trap,
+    });
+
+    expect(projectEventCheckoutAudience({
+      [field]: proxiedValue,
+    })).toBeUndefined();
+    expect(trap).not.toHaveBeenCalled();
+
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    expect(() => projectEventCheckoutAudience({
+      [field]: revoked.proxy,
+    })).not.toThrow();
+    expect(projectEventCheckoutAudience({
+      [field]: revoked.proxy,
+    })).toBeUndefined();
+  });
+
+  test.each([
+    'visibility',
+    'member_only',
+  ])('does not invoke %s conversion or traversal hooks', (field) => {
+    const value = {
+      valueOf: jest.fn(() => field === 'visibility' ? 'public' : false),
+      toString: jest.fn(() => field === 'visibility' ? 'public' : 'false'),
+      toJSON: jest.fn(() => field === 'visibility' ? 'public' : false),
+      [Symbol.iterator]: jest.fn(),
+      [Symbol.toPrimitive]: jest.fn(
+        () => field === 'visibility' ? 'public' : false,
+      ),
+    };
+
+    expect(projectEventCheckoutAudience({
+      [field]: value,
+    })).toBeUndefined();
+    [
+      value.valueOf,
+      value.toString,
+      value.toJSON,
+      value[Symbol.iterator],
+      value[Symbol.toPrimitive],
+    ].forEach((hook) => {
+      expect(hook).not.toHaveBeenCalled();
+    });
+  });
+
+  test('uses captured validation intrinsics', () => {
+    const originalGetPrototypeOf = Object.getPrototypeOf;
+    const originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const originalHasOwn = Object.hasOwn;
+    const fail = () => {
+      throw new Error('synthetic replaced intrinsic must not run');
+    };
+    let modern;
+    let legacy;
+
+    try {
+      Object.getPrototypeOf = fail;
+      Object.getOwnPropertyDescriptor = fail;
+      Object.hasOwn = fail;
+      modern = projectEventCheckoutAudience({ visibility: 'public' });
+      legacy = projectEventCheckoutAudience({ member_only: true });
+    } finally {
+      Object.getPrototypeOf = originalGetPrototypeOf;
+      Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+      Object.hasOwn = originalHasOwn;
+    }
+
+    expect(modern).toBe('public');
+    expect(legacy).toBe('members_only');
+  });
+
+  test('does not mutate or traverse unrelated fields', () => {
+    const unrelatedGetter = jest.fn(() => 'private synthetic detail');
+    const symbolGetter = jest.fn(() => 'private synthetic symbol detail');
+    const event = { visibility: 'public' };
+    event.self = event;
+    Object.defineProperty(event, 'unrelated', {
+      enumerable: true,
+      get: unrelatedGetter,
+    });
+    Object.defineProperty(event, Symbol('unrelated'), {
+      enumerable: true,
+      get: symbolGetter,
+    });
+    const before = Object.getOwnPropertyDescriptors(event);
+
+    const projected = projectEventCheckoutAudience(event);
+
+    expect(projected).toBe('public');
+    expect(Object.getOwnPropertyDescriptors(event)).toEqual(before);
+    expect(unrelatedGetter).not.toHaveBeenCalled();
+    expect(symbolGetter).not.toHaveBeenCalled();
+    event.visibility = 'members_only';
+    expect(projected).toBe('public');
+  });
+});
 
 describe('participant capacity validation', () => {
   test('keeps missing and null capacity unlimited', () => {


### PR DESCRIPTION
Closes #351

## Outcome

Race and volunteer checkout now accepts exactly one known audience format at the trusted server boundary:

- modern: exact own `visibility:'public'` or `visibility:'members_only'`, with no legacy marker;
- legacy: no modern marker and exact own boolean `member_only`.

`draft`, both markers present, both missing, or any malformed marker returns one fixed unavailable result before audience-role or later checkout work. This is source containment only. It does not choose a real event audience, prove membership/payment, migrate records, deploy Firebase, or make checkout live.

## Invariant and ordering

The new pure projector reads each audience field once as an own enumerable data property on an ordinary current-realm non-Proxy record. It invokes no stored accessor, trap, conversion, method, iterator, or serializer; it does not traverse unrelated fields, mutate input, or log a raw value.

The guard remains at the existing audience location. Strict request parsing, commerce admission/event read, answer matching, both request-count writes, and registration-window validation may already run and are not rolled back. Invalid/draft audience stops before audience-role resolution, volunteer enablement/free registration, participant capacity projection/count, later role/tier/cutoff/price work, confirmation token, registration allocation/write, or Stripe access/Product/Checkout Session creation.

Recognized members-only records retain the existing exact verified website-role gate and denial. That gate proves only the stored audience result. A separate later participant role lookup retains existing member-price behavior. Neither proves paid dues, current annual membership, or broader eligibility.

## Scope

Exactly five paths:

- `functions/stripeHelpers.js`
- `functions/stripeHelpers.test.js`
- `functions/createCheckoutSession.js`
- `functions/checkoutPromotionPolicy.test.js`
- `docs/officers/EVENTS_SHOP_MEMBERS.md`

Exact reviewed source head: `746409cf70611b7b35d9c87773645da77afaa322`

Exact diff SHA-256: `c3dc941566c4d440b90839d68994e854859147e1e16a3d66adf932d7f169e9d4`

## Verification

Old-source RED proof used only the in-memory harness: 57 existing cases passed and six intended audience cases failed because checkout continued.

Node 20 green checks:

- focused audience/helper + caller: 2 suites, 340/340 passed;
- full Functions: 31 active suites, 2,659 passed; 64 skipped;
- Functions lint: passed;
- frontend: 13 suites, 521/521 passed;
- reviewed frontend lint ledger: 108 files / 123 errors / 7 warnings, unchanged and passing;
- SPA + workflow/release/readback/artifact/dependency safety: 59/59 passed;
- diagnostic build: passed (`main.f2e14729.js`);
- `git diff --check`: passed;
- sensitive-pattern scan: clean.

Local Java is unavailable, so local Rules and real commerce-emulator checks could not run. Both remain required hosted PR gates and are not claimed by local evidence.

Three independent exact-head reviews approved:

- security/runtime and hostile-value behavior;
- caller ordering and modern/legacy compatibility;
- backup-officer identity and continuity wording.

## Residuals

- #113 must inventory and resolve any real older, mixed, or missing audience record before deployment or repair.
- #121 retains the future canonical public event/source contract.
- The current website role remains distinct from authoritative current/paid membership.
- #349 capacity behavior and the non-atomic final-seat residual remain unchanged.
- RACE/PAY staging, release, readback, rollback, and live proof remain incomplete.

## Officer continuity

Officer impact: Future deployed server code will stop checkout when audience data is draft, mixed, missing, or malformed. Officers must keep checkout unavailable and must not choose or repair an audience in Firebase by hand.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — added `Race audience format guard — SOURCE ONLY, NOT LIVE`, with approver, prerequisites, diagram/text alternative, steps, expected result, stop conditions, proof, undo, escalation, role-versus-membership wording, and #113 gate.

Deployment evidence: None. No protected release, website publication or `runmprc.com` verification, Firebase deployment, Stripe/provider change, production-data access/repair, migration, or live behavior occurred. Hosted source CI and the isolated PR preview, if green, do not prove those states.
