### PR TITLE
WEB-PRIVACY-001S: contain unknown Admin role results

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -2110,7 +2110,7 @@ Officer review steps after the source merge:
 
 **Expected result:** only a current successful mocked lookup shows website-account roles. Loading and rejection show one private fail-closed state with no false zero, stale account information, or role button. Successful results describe website access and account creation only. They do not display or infer annual membership, dues, eligibility, member pricing, discounts, or roster status. This does not authorize an officer to open the screen or change a role live.
 
-The existing role-change request, raw action-error text, authorization, audit, replay protection, and account-recovery behavior remain separate unfinished work. This slice does not make the Admin website-account screen or its role actions safe. Issue #116 remains responsible for the future server-authoritative membership roster and export.
+Issue [#361](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/361) contains only the source-level browser guard for an unknown role-change result. Server authority, command identity and repeat safety, reconciliation, durable audit, token revocation and propagation, account recovery, approved deployment, and live proof remain unfinished. This slice does not make the Admin website-account screen or its role actions safe. Issue #116 remains responsible for the future server-authoritative membership roster and export.
 
 **Stop conditions:** any real account, member, name, email address, payment, dues record, membership record, provider record, credential, or production data; an attempted role change; a request to infer membership from a role, account date, or email verification; a Firebase, permission, provider, account, or membership-record change; or a claim that source, tests, merge, preview, or a green workflow proves the screen or roster is live.
 
@@ -2121,6 +2121,71 @@ The existing role-change request, raw action-error text, authorization, audit, r
 **Escalation:** membership lead plus identity/platform security owner. Add the privacy owner if account details appeared. Add the treasurer if anyone inferred paid membership, dues, pricing, or discount eligibility. Use the private incident path if an access change might have completed without a current readback. Do not copy personal details into an issue, screenshot, email, message, or AI tool.
 
 No system-topology diagram changes are required because data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the website-account list display and the boundary separating website roles from the future authoritative membership roster.
+
+### Admin website-role change unknown result — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** tell an officer to stop when a website-role change has an unknown result. The page must not show a private error, account details, or another role-change action after the request rejects.
+
+**Approver:** membership lead plus identity/platform owner. Add the privacy owner if any account detail appeared. This source slice does not provide approval for live use.
+
+**Prerequisites:** issues [#307](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/307) and [#361](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/361) must be merged for source review. Use only a made-up admin identity, mocked database references, made-up website accounts, and a mocked role-change request. Keep the Admin website-account screen marked **NOT AVAILABLE YET**. Do not open the production Admin screen, change a real role, use production data, or test Firebase.
+
+```mermaid
+flowchart LR
+    A["Current made-up website-account list"] --> B["One mocked role-change request"]
+    B --> C["Pending; every role button disabled"]
+    C -- "Resolved" --> D["One existing mocked list reload"]
+    C -- "Rejected" --> E["Fixed unknown-result alert"]
+    E --> F["Account details and role controls hidden"]
+    F --> G["Stop; contact membership lead and platform owner"]
+    H["Complete rejected value"] -. "Discarded" .-> I["No page, analytics, console, or stored detail"]
+    J["Account context changes or page closes"] -. "Old result ignored" .-> K["No display or request change"]
+```
+
+Text alternative: one mocked role request may start from a current made-up account list. Every role button is disabled while it is pending. A current success keeps the existing single list reload. A rejection discards the complete rejected value, shows one fixed stop message, hides account details and controls, and permits no repeat action on that page. Results from an older account context or a closed page do nothing.
+
+Officer review steps after the source merge:
+
+1. Keep the Admin website-account screen marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #361 issue.
+3. Ask the platform owner for the reviewed pull request.
+4. Ask the platform owner for the merged commit.
+5. Ask the platform owner for the synthetic frontend test result.
+6. Confirm the review used only a made-up admin identity.
+7. Confirm the review used only mocked database references.
+8. Confirm the review used only made-up website accounts.
+9. Confirm the review used only a mocked role-change request.
+10. Confirm one click starts exactly one mocked request with the existing made-up payload.
+11. Confirm every role button is disabled while that request is pending.
+12. Confirm a rapid click on the same row starts no second request.
+13. Confirm a click on another row starts no second request.
+14. Confirm a mocked success performs exactly one existing list reload.
+15. Confirm a mocked rejection shows exactly `We could not confirm that website access change. Do not repeat it. Stop and contact the membership lead and platform owner.`
+16. Confirm assistive technology receives the whole sentence immediately as one alert.
+17. Confirm the rejected value is not inspected, logged, measured, stored, sent to analytics, or displayed.
+18. Confirm the rejection starts no retry or list reload.
+19. Confirm the page keeps only its generic Admin heading, home link, and fixed alert after rejection.
+20. Confirm no role counts, filters, names, email addresses, dates, verification state, rows, or role buttons remain after rejection.
+21. Confirm another role request cannot start on that open page.
+22. Confirm an old success or failure cannot change the page after the Firebase app, database reference, admin account, or page changes.
+23. Confirm no test describes a website role as annual paid membership.
+24. Record source change, tests, merge, website publication, exact `runmprc.com` revision, Firebase deployment, permissions, account records, role changes, production data, Admin-screen approval, and live behavior as separate results.
+
+**Expected result:** a rejected mocked role request shows one fixed accessible instruction and no rejected detail. The page hides every account-derived value and role control. It sends no automatic retry or list reload. A successful mocked request keeps its existing payload and exactly one list reload. The fixed alert says the result is unknown; it does not claim that the role stayed the same.
+
+Reloading, closing, or reopening the page may make the controls appear again. It does not prove what happened and never makes a repeat safe. Stop and escalate instead.
+
+**Stop conditions:** any real officer, account, member, name, email address, role, payment, dues record, membership record, provider record, credential, or production data; an attempted production role change; a request to force a production failure; a private or technical detail on the page, in analytics, in the console, or in a review record; an automatic retry or list reload after rejection; a visible account detail or role button after the unknown-result alert; a repeated action; a Firebase, permission, account, or membership-record change; or a claim that source, tests, merge, preview, or a green workflow proves the role result or live safety.
+
+**Success proof:** for source completion, record the exact #361 issue, reviewed pull request, merged commit, old-source failure evidence, green synthetic tests, relevant full checks, and independent privacy/security, lifecycle/compatibility, and officer-continuity reviews. The safe officer review stops at those records. A future live process still needs server authority, repeat safety, reconciliation, durable audit, token revocation and propagation, recovery, backup, rollback, approved deployment, exact-revision verification, and live readback. Record website publication, `runmprc.com`, Firebase deployment, permission or role changes, provider configuration, account or membership changes, production-data actions, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend-and-guide revert or safe roll-forward. After any later approved publication, use the protected website release path and verify the replacement revision. Never undo by refreshing the page, repeating a role action, or changing an account, role, membership, permission, database record, or provider setting.
+
+**Escalation:** stop and contact the membership lead plus identity/platform security owner. Add the privacy owner if any account detail appeared. Use the private incident path if a role change might have completed, a private or technical detail appeared, or another request was attempted. Do not copy account details into an issue, screenshot, email, message, or AI tool.
+
+No system-topology diagram changes are required because this source slice changes no server authority, data movement, permissions, account ownership, or deployment topology. The diagram above records only the current page's role-request display and repeat-click guard.
 
 ### Admin Event editor load failure privacy — SOURCE ONLY, NOT LIVE
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7633,3 +7633,542 @@ describe('Admin website-account role-list load failure boundary', () => {
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });
+
+describe('Admin website-role change unknown-result boundary', () => {
+  const ROLE_CHANGE_UNKNOWN = 'We could not confirm that website access change. Do not repeat it. Stop and contact the membership lead and platform owner.';
+
+  function syntheticTimestamp(value) {
+    const date = new Date(value);
+    return { toDate: () => date };
+  }
+
+  function syntheticWebsiteAccount({
+    uid = 'synthetic-target-account',
+    email = `${uid}@example.test`,
+    fullName = 'Synthetic Target Account',
+    role = 'member',
+    emailVerified = true,
+    createdAt = '2030-05-16T20:00:00Z',
+  } = {}) {
+    return {
+      uid,
+      email,
+      fullName,
+      role,
+      emailVerified,
+      createdAt: syntheticTimestamp(createdAt),
+    };
+  }
+
+  function createDeferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function setAdminMembersContext({
+    app = firebaseApp,
+    database = firestore,
+    uid = 'synthetic-current-admin',
+  } = {}) {
+    useAuth.mockReturnValue({
+      user: { uid },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    useServiceLocator.mockReturnValue({
+      services: { firebaseResources: { app, firestore: database } },
+      isReady: true,
+    });
+  }
+
+  function getAccountRow(email) {
+    const emailCell = screen.getByText(email);
+    const row = emailCell.closest('tr');
+    expect(row).not.toBeNull();
+    return row;
+  }
+
+  function getRoleButton(email, role) {
+    return within(getAccountRow(email)).getByRole('button', { name: role });
+  }
+
+  function expectGenericAdminMembersShell() {
+    expect(screen.getByRole('heading', {
+      level: 1,
+      name: 'Website accounts',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Admin home/ }))
+      .toHaveAttribute('href', '/admin');
+    expect(window.location.pathname).toBe('/admin/members');
+  }
+
+  function expectAccountResultsToBeHidden(accounts) {
+    accounts.forEach((account) => {
+      expect(screen.queryByText(account.fullName)).not.toBeInTheDocument();
+      expect(screen.queryByText(account.email)).not.toBeInTheDocument();
+    });
+    [
+      'Admin website access',
+      'Member website access',
+      'Pending website verification',
+      'Total website accounts',
+    ].forEach((label) => {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByPlaceholderText('Search by name or email...'))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByText('No website accounts matched')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('button', {
+      name: /^(admin|member|unverified)$/i,
+    })).toHaveLength(0);
+  }
+
+  function spyOnBrowserConsole() {
+    return ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  }
+
+  const targetAccount = syntheticWebsiteAccount();
+  const otherAccount = syntheticWebsiteAccount({
+    uid: 'synthetic-other-account',
+    fullName: 'Synthetic Other Account',
+    role: 'unverified',
+    createdAt: '2030-06-17T20:00:00Z',
+  });
+  const initialAccounts = [targetAccount, otherAccount];
+
+  beforeEach(() => {
+    setAdminMembersContext();
+    listAllMembers.mockResolvedValue(initialAccounts);
+    setMemberRole.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('replaces an ordinary rejected role request with one fixed private terminal result', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    setMemberRole.mockRejectedValueOnce(Object.assign(
+      new Error('role-change-private-canary officer@example.test'),
+      {
+        code: 'functions/role-change-private-canary',
+        endpoint: 'https://provider.example.test/?token=role-change-secret-canary',
+      },
+    ));
+
+    renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ROLE_CHANGE_UNKNOWN);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expectGenericAdminMembersShell();
+    expectAccountResultsToBeHidden(initialAccounts);
+    expect(document.body).not.toHaveTextContent(
+      /role-change-private-canary|officer@example\.test|provider\.example|role-change-secret-canary/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /role-change-private-canary|officer@example\.test|provider\.example|role-change-secret-canary/i,
+    );
+    expect(track).not.toHaveBeenCalled();
+    expect(setMemberRole).toHaveBeenCalledWith(
+      firebaseApp,
+      targetAccount.email,
+      'admin',
+    );
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test.each([
+    [
+      'primitive',
+      () => ({
+        rejection: 'primitive-role-change-private-canary',
+        probes: [],
+      }),
+    ],
+    [
+      'accessor-backed',
+      () => {
+        const messageGetter = jest.fn(() => 'accessor-role-change-private-canary');
+        return {
+          rejection: Object.defineProperty({}, 'message', {
+            configurable: true,
+            get: messageGetter,
+          }),
+          probes: [messageGetter],
+        };
+      },
+    ],
+    [
+      'Proxy',
+      () => {
+        const getTrap = jest.fn((_target, property) => (
+          property === 'message' ? 'proxy-role-change-private-canary' : undefined
+        ));
+        return {
+          rejection: new Proxy({}, { get: getTrap }),
+          probes: [getTrap],
+        };
+      },
+    ],
+    [
+      'coercible',
+      () => {
+        const toString = jest.fn(() => 'coercible-role-change-private-canary');
+        const valueOf = jest.fn(() => 'coercible-role-change-value-canary');
+        return {
+          rejection: { toString, valueOf },
+          probes: [toString, valueOf],
+        };
+      },
+    ],
+  ])('does not inspect, log, measure, or render a %s rejected value', async (
+    _label,
+    createRejection,
+  ) => {
+    const consoleSpies = spyOnBrowserConsole();
+    const { rejection, probes } = createRejection();
+    setMemberRole.mockRejectedValueOnce(rejection);
+
+    renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(ROLE_CHANGE_UNKNOWN);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+    expectAccountResultsToBeHidden(initialAccounts);
+    expect(document.body).not.toHaveTextContent(
+      /primitive-role-change|accessor-role-change|proxy-role-change|coercible-role-change/i,
+    );
+    expect(JSON.stringify(track.mock.calls)).not.toMatch(
+      /primitive-role-change|accessor-role-change|proxy-role-change|coercible-role-change/i,
+    );
+    expect(track).not.toHaveBeenCalled();
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('disables every role-action button while one request is pending', async () => {
+    const pending = createDeferred();
+    setMemberRole.mockReturnValue(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+    const roleButtons = screen.getAllByRole('button', {
+      name: /^(\.\.\.|admin|member|unverified)$/i,
+    });
+    expect(roleButtons.length).toBeGreaterThan(2);
+    roleButtons.forEach((button) => expect(button).toBeDisabled());
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  test('blocks rapid repeats on the target row and every other row', async () => {
+    const pending = createDeferred();
+    setMemberRole.mockReturnValue(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+
+    const targetButton = getRoleButton(targetAccount.email, 'admin');
+    const otherMemberButton = getRoleButton(otherAccount.email, 'member');
+    const otherAdminButton = getRoleButton(otherAccount.email, 'admin');
+    fireEvent.click(targetButton);
+    fireEvent.click(targetButton);
+    fireEvent.click(otherMemberButton);
+    fireEvent.click(otherAdminButton);
+
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+    expect(setMemberRole).toHaveBeenCalledWith(
+      firebaseApp,
+      targetAccount.email,
+      'admin',
+    );
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  test('does not expose a same-page retry or reload after the role outcome becomes unknown', async () => {
+    const pending = createDeferred();
+    setMemberRole
+      .mockReturnValueOnce(pending.promise)
+      .mockResolvedValue({ ok: true });
+    renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      pending.reject(new Error('repeat-role-change-private-canary'));
+      await Promise.resolve();
+    });
+
+    const samePageRetries = screen.queryAllByRole('button', { name: 'admin' });
+    if (samePageRetries[0]) fireEvent.click(samePageRetries[0]);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toBe(ROLE_CHANGE_UNKNOWN);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveAttribute('aria-atomic', 'true');
+    expectAccountResultsToBeHidden(initialAccounts);
+    expect(document.body).not.toHaveTextContent('repeat-role-change-private-canary');
+  });
+
+  test.each([
+    [
+      'Firebase app',
+      {
+        app: { name: 'synthetic-current-app' },
+        database: firestore,
+        uid: 'synthetic-current-admin',
+        expectedListCalls: 1,
+      },
+    ],
+    [
+      'Firestore object',
+      {
+        app: firebaseApp,
+        database: { name: 'synthetic-current-firestore' },
+        uid: 'synthetic-current-admin',
+        expectedListCalls: 2,
+      },
+    ],
+    [
+      'admin UID',
+      {
+        app: firebaseApp,
+        database: firestore,
+        uid: 'synthetic-current-admin-two',
+        expectedListCalls: 1,
+      },
+    ],
+  ])('ignores an obsolete hostile rejection after the %s changes', async (
+    _label,
+    nextContext,
+  ) => {
+    const consoleSpies = spyOnBrowserConsole();
+    const pending = createDeferred();
+    setMemberRole.mockReturnValueOnce(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+
+    setAdminMembersContext(nextContext);
+    view.rerender(<App />);
+    await waitFor(() => {
+      expect(listAllMembers).toHaveBeenCalledTimes(nextContext.expectedListCalls);
+    });
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+
+    const messageGetter = jest.fn(() => 'obsolete-role-change-private-canary');
+    await act(async () => {
+      pending.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.getByText(targetAccount.fullName)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-role-change-private-canary');
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(nextContext.expectedListCalls);
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test.each([
+    [
+      'Firebase app',
+      {
+        app: { name: 'synthetic-current-success-app' },
+        database: firestore,
+        uid: 'synthetic-current-admin',
+        expectedListCalls: 1,
+      },
+    ],
+    [
+      'admin UID',
+      {
+        app: firebaseApp,
+        database: firestore,
+        uid: 'synthetic-current-success-admin',
+        expectedListCalls: 1,
+      },
+    ],
+  ])('does not reload for an obsolete resolution after the %s changes', async (
+    _label,
+    nextContext,
+  ) => {
+    const pending = createDeferred();
+    setMemberRole.mockReturnValueOnce(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+
+    setAdminMembersContext(nextContext);
+    view.rerender(<App />);
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+
+    await act(async () => {
+      pending.resolve({ ok: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(nextContext.expectedListCalls);
+    expect(screen.getByText(targetAccount.fullName)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('does not revive an old pending result after the app context changes away and back', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    const pending = createDeferred();
+    const otherApp = { name: 'synthetic-round-trip-app' };
+    setMemberRole.mockReturnValueOnce(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+
+    setAdminMembersContext({ app: otherApp });
+    view.rerender(<App />);
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(targetAccount.fullName)).toBeInTheDocument();
+
+    setAdminMembersContext({ app: firebaseApp });
+    view.rerender(<App />);
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(targetAccount.fullName)).toBeInTheDocument();
+    expect(getRoleButton(targetAccount.email, 'admin')).toBeEnabled();
+
+    const messageGetter = jest.fn(() => 'round-trip-role-change-private-canary');
+    await act(async () => {
+      pending.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.getByText(targetAccount.fullName)).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('round-trip-role-change-private-canary');
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('ignores a hostile role rejection after the page unmounts', async () => {
+    const consoleSpies = spyOnBrowserConsole();
+    const pending = createDeferred();
+    setMemberRole.mockReturnValueOnce(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const messageGetter = jest.fn(() => 'unmounted-role-change-private-canary');
+    await act(async () => {
+      pending.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  test('does not reload after a role request resolves on an unmounted page', async () => {
+    const pending = createDeferred();
+    setMemberRole.mockReturnValueOnce(pending.promise);
+    const view = renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    await act(async () => {
+      pending.resolve({ ok: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves one successful exact role request and exactly one list reload', async () => {
+    const refreshedAccount = syntheticWebsiteAccount({
+      role: 'admin',
+      fullName: 'Synthetic Refreshed Account',
+    });
+    listAllMembers
+      .mockResolvedValueOnce(initialAccounts)
+      .mockResolvedValueOnce([refreshedAccount, otherAccount]);
+    setMemberRole.mockResolvedValueOnce({ ok: true });
+    renderAdminMembers();
+    expect(await screen.findByText(targetAccount.fullName)).toBeInTheDocument();
+
+    fireEvent.click(getRoleButton(targetAccount.email, 'admin'));
+
+    expect(await screen.findByText(refreshedAccount.fullName)).toBeInTheDocument();
+    expect(screen.queryByText(targetAccount.fullName)).not.toBeInTheDocument();
+    expect(screen.getByText(refreshedAccount.email)).toBeInTheDocument();
+    expect(setMemberRole).toHaveBeenCalledWith(
+      firebaseApp,
+      targetAccount.email,
+      'admin',
+    );
+    expect(setMemberRole).toHaveBeenCalledTimes(1);
+    expect(listAllMembers).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllMembers).toHaveBeenNthCalledWith(2, firestore);
+    expect(listAllMembers).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/admin/members/AdminMembers.tsx
+++ b/src/pages/admin/members/AdminMembers.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useMemo, useRef, useState,
+  useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
 } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../../components/SEO';
@@ -20,7 +20,16 @@ interface MembersLoadOutcome {
   members: Member[];
 }
 
+interface RoleActionOutcome {
+  app: unknown;
+  firestore: unknown;
+  adminUid: string | null;
+  status: 'pending' | 'unknown';
+  targetEmail: string;
+}
+
 const LOAD_FAILURE = 'We could not load website accounts right now. Stop and contact the membership lead and platform owner before changing website access.';
+const ROLE_CHANGE_UNKNOWN = 'We could not confirm that website access change. Do not repeat it. Stop and contact the membership lead and platform owner.';
 
 function RolePill({ role }: { role: string }) {
   const style: Record<string, string> = {
@@ -44,21 +53,38 @@ function fmtDate(ts: any) {
 function Inner() {
   const { services, isReady } = useServiceLocator();
   const { user } = useAuth();
+  const app = isReady && services
+    ? services.firebaseResources.app
+    : null;
   const firestore = isReady && services
     ? services.firebaseResources.firestore
     : null;
+  const adminUid = user?.uid ?? null;
   const currentFirestoreRef = useRef(firestore);
   currentFirestoreRef.current = firestore;
+  const currentActionContextRef = useRef({ app, firestore, adminUid });
+  currentActionContextRef.current = { app, firestore, adminUid };
   const requestSequence = useRef(0);
+  const roleActionSequence = useRef(0);
+  const roleActionInFlight = useRef(false);
   const [loadOutcome, setLoadOutcome] = useState<MembersLoadOutcome | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [updating, setUpdating] = useState<string | null>(null);
+  const [roleActionOutcome, setRoleActionOutcome] = useState<RoleActionOutcome | null>(
+    null,
+  );
   const [filter, setFilter] = useState('');
   const [roleFilter, setRoleFilter] = useState<'all' | MemberRole>('all');
 
   const currentOutcome = loadOutcome?.firestore === firestore ? loadOutcome : null;
   const currentStatus = currentOutcome?.status ?? 'loading';
   const members = currentOutcome?.status === 'resolved' ? currentOutcome.members : [];
+  const currentRoleAction = roleActionOutcome?.app === app
+    && roleActionOutcome.firestore === firestore
+    && roleActionOutcome.adminUid === adminUid
+    ? roleActionOutcome
+    : null;
+  const roleActionPending = currentRoleAction?.status === 'pending';
+  const roleActionUnknown = currentRoleAction?.status === 'unknown';
+  const showAccountResults = currentStatus === 'resolved' && !roleActionUnknown;
 
   const reload = useCallback(async () => {
     if (!firestore || currentFirestoreRef.current !== firestore) return;
@@ -87,17 +113,56 @@ function Inner() {
     return () => { requestSequence.current += 1; };
   }, [firestore, reload]);
 
+  useLayoutEffect(() => {
+    roleActionSequence.current += 1;
+    roleActionInFlight.current = false;
+    setRoleActionOutcome(null);
+    return () => {
+      roleActionSequence.current += 1;
+      roleActionInFlight.current = false;
+    };
+  }, [app, firestore, adminUid]);
+
   async function changeRole(email: string, role: MemberRole) {
-    if (!services) return;
-    setUpdating(email);
-    setError(null);
+    if (
+      !app
+      || !firestore
+      || !adminUid
+      || currentStatus !== 'resolved'
+      || currentRoleAction
+      || roleActionInFlight.current
+    ) return;
+
+    roleActionSequence.current += 1;
+    const actionId = roleActionSequence.current;
+    const actionContext = { app, firestore, adminUid };
+    const isCurrentAction = () => actionId === roleActionSequence.current
+      && currentActionContextRef.current.app === actionContext.app
+      && currentActionContextRef.current.firestore === actionContext.firestore
+      && currentActionContextRef.current.adminUid === actionContext.adminUid;
+
+    roleActionInFlight.current = true;
+    setRoleActionOutcome({
+      ...actionContext,
+      status: 'pending',
+      targetEmail: email,
+    });
+
     try {
-      await setMemberRole(services.firebaseResources.app, email, role);
+      await setMemberRole(app, email, role);
+      if (!isCurrentAction()) return;
       await reload();
-    } catch (err: any) {
-      setError(err?.message || 'Role update failed');
+      if (!isCurrentAction()) return;
+      setRoleActionOutcome(null);
+    } catch {
+      if (!isCurrentAction()) return;
+      setRoleActionOutcome({
+        ...actionContext,
+        status: 'unknown',
+        targetEmail: email,
+      });
     } finally {
-      setUpdating(null);
+      if (isCurrentAction()) roleActionInFlight.current = false;
     }
   }
 
@@ -127,7 +192,7 @@ function Inner() {
         </Link>
         <h1 className="text-2xl font-bold mt-2">Website accounts</h1>
 
-        {currentStatus === 'resolved' && (
+        {showAccountResults && (
           <>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3 my-4">
               <div className="border rounded p-3 bg-purple-50">
@@ -169,7 +234,7 @@ function Inner() {
           </>
         )}
 
-        {currentStatus === 'loading' && <p>Loading...</p>}
+        {currentStatus === 'loading' && !roleActionPending && <p>Loading...</p>}
         {currentStatus === 'unavailable' && (
           <p
             className="text-red-500 text-sm"
@@ -180,11 +245,28 @@ function Inner() {
             {LOAD_FAILURE}
           </p>
         )}
-        {currentStatus === 'resolved' && error && (
-          <p className="text-red-500 text-sm">{error}</p>
+        {roleActionPending && (
+          <p
+            className="text-gray-600 text-sm"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            Updating website access...
+          </p>
+        )}
+        {roleActionUnknown && (
+          <p
+            className="text-red-500 text-sm"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+          >
+            {ROLE_CHANGE_UNKNOWN}
+          </p>
         )}
 
-        {currentStatus === 'resolved' && (
+        {showAccountResults && (
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr className="border-b bg-gray-50">
@@ -206,7 +288,8 @@ function Inner() {
               )}
               {filtered.map((m) => {
                 const isSelf = user?.uid === m.uid;
-                const busy = updating === m.email;
+                const busy = roleActionPending
+                  && currentRoleAction.targetEmail === m.email;
                 return (
                   <tr key={m.uid} className="border-b hover:bg-gray-50">
                     <td className="p-2">
@@ -226,7 +309,7 @@ function Inner() {
                           key={r}
                           type="button"
                           onClick={() => changeRole(m.email, r)}
-                          disabled={busy || (isSelf && r !== 'admin')}
+                          disabled={roleActionPending || (isSelf && r !== 'admin')}
                           className="text-blue-600 hover:underline mr-2 text-xs disabled:text-gray-400 disabled:no-underline"
                           title={isSelf && r !== 'admin' ? "Can't demote yourself" : ''}
                         >


### PR DESCRIPTION
## Outcome

Stops a second Admin website-role request when the first result is unknown.

- Discards the complete rejected value without binding or inspecting it.
- Shows one fixed accessible stop instruction.
- Hides account details and every role control after an unknown result.
- Disables every row's role buttons while one request is pending.
- Ignores stale app, Firestore, admin-account, round-trip, and unmount results.
- Preserves the exact successful request and one existing list reload.

Officer impact: A future approved publication will tell an officer to stop instead of inviting a repeated website-role change. The Admin website-account screen remains **NOT AVAILABLE YET**.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — added the complete source-only #361 procedure, diagram, text alternative, stop conditions, proof, undo, and escalation; narrowed the #307 residual note.

Deployment evidence: Source and tests only. No website publication, `runmprc.com` verification, Firebase deployment, provider configuration, account/role change, production-data action, migration, or live behavior occurred. A green workflow will not prove this browser guard is live.

## Verification

Exact reviewed head: `a2a8485c2b9bcf52c9aa536fefb47f4f7421b9aa`

Exact base: `9a79124cd62aa014ee3f9968bcae52bef3c81a9f`

Exact diff SHA-256: `27c4c9bd729fd6600fe59aad58258eef72f1bcafb598ab81a4bd3bb06027e231`

- Focused #361: 17/17.
- Focused #307 + #361 compatibility: 29/29.
- Frontend: 13 suites / 545 tests.
- TypeScript: pass.
- Non-mutating lint: 108 files / 121 reviewed errors / 6 reviewed warnings.
- SPA safety: 11/11.
- Repository safety: 50/50.
- Functions lint: pass.
- Functions under required Node 20: 33 suites passed, 2 skipped; 2,968 passed, 64 skipped.
- Firestore Rules: 378/378.
- Real demo-only commerce emulator: 63/63.
- Diagnostic build: pass.
- Relative links, sensitive-pattern scan, and diff check: pass.
- Three independent exact-head reviews: approved, no findings.

The system `npm` executable on this Mac uses Node 22 and exposes a pre-existing frozen-Error descriptor incompatibility in an unchanged Functions test. The exact Node 20 invocation from `functions/` and exact-base hosted CI both pass. This pull request changes no Functions file.

## Residual risk

This is a browser guard, not server idempotency or proof of the outcome. Reloading or another browser may recreate the controls. Server command identity, reconciliation, durable audit, Auth/Firestore consistency, token revocation, protected deployment, and live verification remain open.

Closes #361
