### PR TITLE
AUTH-UX-001A: make My Account sign-out private and one-retry-safe

### DIFF
--- a/docs/officers/EMERGENCY_AND_RECOVERY.md
+++ b/docs/officers/EMERGENCY_AND_RECOVERY.md
@@ -31,7 +31,7 @@
 | Account exists but a verification email request is unavailable | Ask the member to stop resending. Record only the time, route path `/login` or `/account`, and plain status. Omit all query/fragment text. Do not ask for the email address, password, code, action link, mailbox access, or screenshot. |
 | Verification link is unusable or temporarily unavailable | Ask the member to stop after one deliberate check and one retry. Record only the time, clean route `/auth/action`, and plain result. Never copy anything after `?` or `#`, and never ask for the link, code, email address, or screenshot. |
 | Password reset does not lead to a private message | Ask the member to stop after one displayed wait and one retry. Record only the time, route path `/login`, and plain status. Do not ask which address they entered or whether an account exists. |
-| Profile Save says permission is missing | Ask the member to stop, sign out, and wait. Open a new redacted incident through [Request a change](./REQUEST_A_CHANGE.md). Do not edit the database, delete the login, recreate the account, or grant a role. |
+| Profile Save says permission is missing | Ask the member to stop and choose **Sign out** once. If the result is not confirmed, assume they are still signed in. Ask them to close the browser and not let anyone else use that device. Open a new redacted incident through [Request a change](./REQUEST_A_CHANGE.md). Do not edit the database, delete the login, recreate the account, or grant a role. |
 | Private member information is visible | Contact platform and privacy owners immediately; they choose containment through an approved service procedure. Do not change permissions yourself. |
 | Unexpected payment, refund, order, or signup | Contact treasurer and platform owners. The new source guard is not deployed and its officer control is NOT AVAILABLE YET. Do not test with real money. |
 | Password, secret, or recovery code exposed | Contact the owning service's two approved owners. They revoke/rotate through the service-specific procedure and record evidence. Do not rotate it from this generic guide. |
@@ -267,11 +267,15 @@ Officer steps after every prerequisite has live proof:
 **Prerequisites:** the time, the public `/account` address, and a redacted description with no member details.
 
 1. Ask the member to stop using Save.
-2. Ask the member to sign out.
-3. Open a new redacted incident by following [Request a change](./REQUEST_A_CHANGE.md).
-4. Use [#118](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/118) only as engineering context. Do not add member incidents or private details to it.
-5. Share only the time and the plain symptom.
-6. Wait for a made-up account test and separate website, server Function, and database-permission proof.
+2. Ask the member to choose **Sign out** once.
+3. If the result is not confirmed, assume the member is still signed in.
+4. Ask the member to close the browser.
+5. Ask the member not to let anyone else use that device until the membership lead or platform owner helps.
+6. Keep the linked [safer sign-out result](./EVENTS_SHOP_MEMBERS.md#my-account-sign-out-result--source-only-not-live) marked **NOT LIVE** until exact website proof exists.
+7. Open a new redacted incident by following [Request a change](./REQUEST_A_CHANGE.md).
+8. Use [#118](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/118) only as engineering context. Do not add member incidents or private details to it.
+9. Share only the time and the plain symptom.
+10. Wait for a made-up account test and separate website, server Function, and database-permission proof.
 
 **Expected result:** no manual account or database change occurs. The member retries only after the automated repair is proven live.
 

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -790,55 +790,55 @@ Safe officer steps:
 
 **Approver:** membership lead plus identity/platform owner. Add the privacy owner if account details appeared when they should have been hidden.
 
-**Prerequisites:** issue [#368](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/368), its exact reviewed pull request and merge commit, and synthetic test evidence. Calling this behavior live also requires a later protected website publication and an exact `runmprc.com` revision check. The source review must not use a real account or session. It does not change Firebase settings, provider settings, production data, or sessions on another device.
+**Prerequisites:** issue [#368](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/368), its exact reviewed pull request and merge commit, and tests that use only made-up accounts and results. Before calling this source published, the club must also complete a protected website publication and an exact `runmprc.com` revision check. Those two checks prove only that the source was published. They do not prove a real sign-out, removal of an active sign-in, or sign-out on another device. The source review must not use a real account or active sign-in. It does not change Firebase settings, provider settings, production data, or sign-ins on another device.
 
 ```mermaid
 flowchart TD
     A["Member chooses Sign out once"] --> B["Hide private My Account details immediately"]
     B --> C["Show Signing out; disable the control"]
-    C --> D{"Current command result"}
-    D -- "Fulfilled" --> E["Stay private and pending"]
-    E --> F{"Existing Auth state removes My Account"}
+    C --> D{"Current sign-out request"}
+    D -- "Finishes without an error" --> E["Stay private and pending"]
+    E --> F{"Existing website sign-in state removes My Account"}
     F -- "Not yet" --> E
     F -- "Yes" --> G["Existing route leaves My Account"]
-    D -- "First rejection" --> H["Say result is unconfirmed; allow one retry"]
+    D -- "First request cannot confirm sign-out" --> H["Say result is unconfirmed; allow one retry"]
     H --> I["Member chooses retry once"]
     I --> J["Hide details; disable the control"]
-    J --> K{"Current command result"}
-    K -- "Fulfilled" --> E
-    K -- "Second rejection" --> L["Assume still signed in"]
+    J --> K{"Current sign-out request"}
+    K -- "Finishes without an error" --> E
+    K -- "Second request cannot confirm sign-out" --> L["Assume still signed in"]
     L --> M["Close browser; stop device use; get help"]
 ```
 
-Text alternative: the first choice immediately hides private details and blocks repeats. A fulfilled command alone does not prove sign-out. Only the existing account-state change removes My Account. One rejected attempt allows one retry. A second rejection requires closing the browser, stopping use of that device, and getting help.
+Text alternative: the first choice immediately hides private details and blocks repeats. A request that finishes without an error does not prove sign-out. Only the existing website sign-in state can remove My Account. If the first request cannot confirm sign-out, the page allows one retry. If the second request cannot confirm sign-out, the member must close the browser, stop use of that device, and get help.
 
 Backup-officer source-review steps:
 
 1. Keep this procedure marked **NOT AVAILABLE YET**.
-2. Obtain the exact #368 issue, reviewed pull request, merge commit, and synthetic test evidence.
-3. Confirm the tests use only made-up accounts and a mocked sign-out command.
+2. Obtain the exact #368 issue, reviewed pull request, merge commit, and made-up test evidence.
+3. Confirm the tests use only made-up accounts and a made-up sign-out result that does not contact Firebase.
 4. Confirm the first choice immediately hides every private My Account surface.
 5. Confirm the pending result says `Signing out. Keep this page open.`
 6. Confirm the pending result disables the control.
-7. Confirm command fulfillment alone stays private and pending.
-8. Confirm the first rejection says `We could not confirm sign-out. You may still be signed in. Try sign out once more.`
+7. Confirm a request that finishes without an error stays private and pending.
+8. Confirm the first request that cannot confirm sign-out says `We could not confirm sign-out. You may still be signed in. Try sign out once more.`
 9. Confirm the retry locks immediately.
-10. Confirm the second rejection says `We still could not confirm sign-out. You may still be signed in. Close the browser and do not let anyone else use this device until the membership lead or platform owner helps.`
+10. Confirm the second request that cannot confirm sign-out says `We still could not confirm sign-out. You may still be signed in. Close the browser and do not let anyone else use this device until the membership lead or platform owner helps.`
 11. Confirm a third request is not possible.
-12. Confirm rejected details do not reach the page, console, analytics, or storage.
+12. Confirm failed-request details do not reach the page, browser developer logs, tracking tools, or browser storage.
 13. Record source, tests, merge, website publication, `runmprc.com`, Firebase, provider, production data, and live behavior as separate results.
 
-**Expected result:** the first sign-out choice creates an immediate private boundary. Only one retry is possible. A fulfilled command is not shown as local success; the existing Firebase Auth state remains the authority for leaving My Account.
+**Expected result:** the first sign-out choice hides all private details immediately. Only one retry is possible. A request that finishes without an error is not shown as success. Only the existing website sign-in state decides when My Account closes.
 
-**Stop conditions:** a real account or session; a production sign-out test; a raw error detail; private details that remain visible; more than one retry; a claim that closing the browser proves sign-out or revokes another session; or a claim that source, tests, merge, preview, or green CI proves live behavior.
+**Stop conditions:** a real account or active sign-in; a production sign-out test; a raw error detail; private details that remain visible; more than one retry; a claim that closing the browser proves sign-out or removes another active sign-in; or a claim that source, tests, merge, preview, or green CI proves live behavior.
 
-**Success proof:** exact #368 issue, pull request, merge commit, RED evidence, green synthetic tests, relevant full checks, and independent security and backup-officer reviews. Record website publication and exact `runmprc.com` proof separately. Record Firebase, provider, production-data, and live actions as not performed unless each has separate evidence.
+**Success proof:** exact #368 issue, pull request, merge commit, recorded tests that failed against the old source, green tests with made-up data, relevant full checks, and independent security and backup-officer reviews. Record website publication and exact `runmprc.com` proof separately. Record Firebase, provider, production-data, and live actions as not performed unless each has separate evidence.
 
-**Undo:** before publication, use one reviewed revert or safe roll-forward. After a future publication, use the protected website rollback path and verify the exact revision. Never edit Auth accounts, sessions, profiles, or provider settings as an undo.
+**Undo:** before publication, use one reviewed revert or safe roll-forward. After a future publication, use the protected website rollback path and verify the exact revision. Never edit sign-in accounts, active sign-ins, profiles, or provider settings as an undo.
 
 **Escalation:** membership lead plus identity/platform security owner. Add the privacy owner and use the private incident path if any account detail appeared.
 
-This local state diagram records a changed My Account display boundary. Account ownership, permissions, data movement, data stores, and deployment topology do not change, so the system maps do not change.
+This local state diagram records the changed My Account display. The change does not alter who owns accounts, what permissions exist, where data moves or is kept, or how the website is published. The system maps therefore stay unchanged.
 
 ## My Account phone collection pause — SOURCE ONLY, NOT LIVE
 

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -762,11 +762,15 @@ Safe officer steps:
 1. Ask the member to stop retrying Save.
 2. Record the time and the public `/account` page address.
 3. Do not record their name, email, phone, login code, or screenshot of profile details.
-4. Ask them to sign out.
-5. Open a new redacted incident through [Request a change](./REQUEST_A_CHANGE.md).
-6. Use #118 only as engineering context. Do not add member incidents or private details to it.
-7. Wait for the platform owner to test with a made-up account.
-8. Tell the member to retry only after the website, server Function, database permissions, and live behavior are each proven.
+4. Ask them to choose **Sign out** once.
+5. If the page does not clearly leave My Account, assume they are still signed in.
+6. Ask them to close the browser.
+7. Ask them not to let anyone else use that device until the membership lead or platform owner helps.
+8. Keep the safer source behavior below marked [NOT LIVE](#my-account-sign-out-result--source-only-not-live) until exact website proof exists.
+9. Open a new redacted incident through [Request a change](./REQUEST_A_CHANGE.md).
+10. Use #118 only as engineering context. Do not add member incidents or private details to it.
+11. Wait for the platform owner to test with a made-up account.
+12. Tell the member to retry only after the website, server Function, database permissions, and live behavior are each proven.
 
 **Expected result:** after all release proof is complete, the member sees a profile or a plain temporary-unavailable message. A missing profile is displayed as pending or unverified. The repair does not grant, remove, or change actual access. If displayed profile status and actual access disagree, stop and escalate.
 
@@ -777,6 +781,64 @@ Safe officer steps:
 **Undo:** ask the platform owner to prepare, approve, publish, and verify a reviewed revert or safe roll-forward. Never undo by deleting a member profile or login account.
 
 **Escalation:** membership lead plus identity/security owner. Add the privacy owner if private information appeared. Email landing in spam is a separate delivery problem; do not treat it as proof of this permission failure.
+
+## My Account sign-out result — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** hide account details immediately and give one truthful retry when the website cannot confirm sign-out.
+
+**Approver:** membership lead plus identity/platform owner. Add the privacy owner if account details appeared when they should have been hidden.
+
+**Prerequisites:** issue [#368](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/368), its exact reviewed pull request and merge commit, and synthetic test evidence. Calling this behavior live also requires a later protected website publication and an exact `runmprc.com` revision check. The source review must not use a real account or session. It does not change Firebase settings, provider settings, production data, or sessions on another device.
+
+```mermaid
+flowchart TD
+    A["Member chooses Sign out once"] --> B["Hide private My Account details immediately"]
+    B --> C["Show Signing out; disable the control"]
+    C --> D{"Current command result"}
+    D -- "Fulfilled" --> E["Stay private and pending"]
+    E --> F{"Existing Auth state removes My Account"}
+    F -- "Not yet" --> E
+    F -- "Yes" --> G["Existing route leaves My Account"]
+    D -- "First rejection" --> H["Say result is unconfirmed; allow one retry"]
+    H --> I["Member chooses retry once"]
+    I --> J["Hide details; disable the control"]
+    J --> K{"Current command result"}
+    K -- "Fulfilled" --> E
+    K -- "Second rejection" --> L["Assume still signed in"]
+    L --> M["Close browser; stop device use; get help"]
+```
+
+Text alternative: the first choice immediately hides private details and blocks repeats. A fulfilled command alone does not prove sign-out. Only the existing account-state change removes My Account. One rejected attempt allows one retry. A second rejection requires closing the browser, stopping use of that device, and getting help.
+
+Backup-officer source-review steps:
+
+1. Keep this procedure marked **NOT AVAILABLE YET**.
+2. Obtain the exact #368 issue, reviewed pull request, merge commit, and synthetic test evidence.
+3. Confirm the tests use only made-up accounts and a mocked sign-out command.
+4. Confirm the first choice immediately hides every private My Account surface.
+5. Confirm the pending result says `Signing out. Keep this page open.`
+6. Confirm the pending result disables the control.
+7. Confirm command fulfillment alone stays private and pending.
+8. Confirm the first rejection says `We could not confirm sign-out. You may still be signed in. Try sign out once more.`
+9. Confirm the retry locks immediately.
+10. Confirm the second rejection says `We still could not confirm sign-out. You may still be signed in. Close the browser and do not let anyone else use this device until the membership lead or platform owner helps.`
+11. Confirm a third request is not possible.
+12. Confirm rejected details do not reach the page, console, analytics, or storage.
+13. Record source, tests, merge, website publication, `runmprc.com`, Firebase, provider, production data, and live behavior as separate results.
+
+**Expected result:** the first sign-out choice creates an immediate private boundary. Only one retry is possible. A fulfilled command is not shown as local success; the existing Firebase Auth state remains the authority for leaving My Account.
+
+**Stop conditions:** a real account or session; a production sign-out test; a raw error detail; private details that remain visible; more than one retry; a claim that closing the browser proves sign-out or revokes another session; or a claim that source, tests, merge, preview, or green CI proves live behavior.
+
+**Success proof:** exact #368 issue, pull request, merge commit, RED evidence, green synthetic tests, relevant full checks, and independent security and backup-officer reviews. Record website publication and exact `runmprc.com` proof separately. Record Firebase, provider, production-data, and live actions as not performed unless each has separate evidence.
+
+**Undo:** before publication, use one reviewed revert or safe roll-forward. After a future publication, use the protected website rollback path and verify the exact revision. Never edit Auth accounts, sessions, profiles, or provider settings as an undo.
+
+**Escalation:** membership lead plus identity/platform security owner. Add the privacy owner and use the private incident path if any account detail appeared.
+
+This local state diagram records a changed My Account display boundary. Account ownership, permissions, data movement, data stores, and deployment topology do not change, so the system maps do not change.
 
 ## My Account phone collection pause — SOURCE ONLY, NOT LIVE
 

--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -790,7 +790,7 @@ Safe officer steps:
 
 **Approver:** membership lead plus identity/platform owner. Add the privacy owner if account details appeared when they should have been hidden.
 
-**Prerequisites:** issue [#368](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/368), its exact reviewed pull request and merge commit, and tests that use only made-up accounts and results. Before calling this source published, the club must also complete a protected website publication and an exact `runmprc.com` revision check. Those two checks prove only that the source was published. They do not prove a real sign-out, removal of an active sign-in, or sign-out on another device. The source review must not use a real account or active sign-in. It does not change Firebase settings, provider settings, production data, or sign-ins on another device.
+**Prerequisites:** issue [#368](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/368), its exact reviewed pull request and merge commit, and tests that use only made-up accounts and results. Calling this behavior published on the website also requires a protected website publication and a separate exact `runmprc.com` revision check. Those checks prove only that the reviewed website version is present. They do not prove a real sign-out, removal of an active sign-in, or sign-out on another device. The source review must not use a real account or active sign-in. It does not change Firebase settings, provider settings, production data, or sign-ins on another device.
 
 ```mermaid
 flowchart TD
@@ -798,9 +798,9 @@ flowchart TD
     B --> C["Show Signing out; disable the control"]
     C --> D{"Current sign-out request"}
     D -- "Finishes without an error" --> E["Stay private and pending"]
-    E --> F{"Existing website sign-in state removes My Account"}
+    E --> F{"Website sign-in state changes to signed out?"}
     F -- "Not yet" --> E
-    F -- "Yes" --> G["Existing route leaves My Account"]
+    F -- "Yes" --> G["Automatic redirect leaves My Account"]
     D -- "First request cannot confirm sign-out" --> H["Say result is unconfirmed; allow one retry"]
     H --> I["Member chooses retry once"]
     I --> J["Hide details; disable the control"]
@@ -810,7 +810,7 @@ flowchart TD
     L --> M["Close browser; stop device use; get help"]
 ```
 
-Text alternative: the first choice immediately hides private details and blocks repeats. A request that finishes without an error does not prove sign-out. Only the existing website sign-in state can remove My Account. If the first request cannot confirm sign-out, the page allows one retry. If the second request cannot confirm sign-out, the member must close the browser, stop use of that device, and get help.
+Text alternative: the first choice immediately hides private details and blocks repeats. A request that finishes without an error does not prove sign-out. Only the current website sign-in state changing to signed out confirms sign-out to My Account and causes its automatic redirect. Simply leaving the page does not prove sign-out. If the first request cannot confirm sign-out, the page allows one retry. If the second request cannot confirm sign-out, the member must close the browser, stop use of that device, and get help.
 
 Backup-officer source-review steps:
 
@@ -828,7 +828,7 @@ Backup-officer source-review steps:
 12. Confirm failed-request details do not reach the page, browser developer logs, tracking tools, or browser storage.
 13. Record source, tests, merge, website publication, `runmprc.com`, Firebase, provider, production data, and live behavior as separate results.
 
-**Expected result:** the first sign-out choice hides all private details immediately. Only one retry is possible. A request that finishes without an error is not shown as success. Only the existing website sign-in state decides when My Account closes.
+**Expected result:** the first sign-out choice hides all private details immediately. Only one retry is possible. A request that finishes without an error is not shown as success. Only the current website sign-in state changing to signed out confirms sign-out to My Account and triggers its existing redirect. Leaving the page alone does not confirm sign-out.
 
 **Stop conditions:** a real account or active sign-in; a production sign-out test; a raw error detail; private details that remain visible; more than one retry; a claim that closing the browser proves sign-out or removes another active sign-in; or a claim that source, tests, merge, preview, or green CI proves live behavior.
 

--- a/src/pages/account/Account.css
+++ b/src/pages/account/Account.css
@@ -84,6 +84,91 @@
   cursor: not-allowed;
 }
 
+.account-sign-out {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.account-sign-out__panel {
+  display: flex;
+  max-width: 42rem;
+  padding: 1rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  color: #111827;
+  background: #f9fafb;
+  border: 2px solid #9ca3af;
+  border-radius: 0.5rem;
+}
+
+.account-sign-out__heading,
+.account-sign-out__result {
+  margin: 0;
+}
+
+.account-sign-out__heading {
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.account-sign-out__result {
+  padding: 0.75rem;
+  border: 2px solid;
+  border-radius: 0.375rem;
+  line-height: 1.5;
+}
+
+.account-sign-out__result--pending {
+  color: #1e3a8a;
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.account-sign-out__result--retry {
+  color: #713f12;
+  background: #fefce8;
+  border-color: #facc15;
+}
+
+.account-sign-out__result--terminal {
+  color: #7f1d1d;
+  background: #fef2f2;
+  border-color: #fca5a5;
+}
+
+.account-sign-out__button {
+  min-height: 3rem;
+  padding: 0.7rem 1rem;
+  color: #fff;
+  background: #005bd8;
+  border: 2px solid #005bd8;
+  border-radius: 0.375rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.account-sign-out__button:hover:not(:disabled) {
+  color: #111827;
+  background: #facc15;
+  border-color: #111827;
+}
+
+.account-sign-out__button:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 5px #111827;
+}
+
+.account-sign-out__button:disabled {
+  color: #374151;
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  cursor: not-allowed;
+}
+
 @media (min-width: 640px) {
   .account-verification-notice {
     align-items: flex-start;

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -28,6 +28,9 @@ import {
 import { AccountContent } from './Account';
 import StravaCallback from './StravaCallback';
 
+const mockCaptureException = jest.fn();
+const mockTrack = jest.fn();
+
 jest.mock('../../services/ServiceLocatorContext', () => ({
   useServiceLocator: jest.fn(),
 }));
@@ -62,6 +65,15 @@ jest.mock('../../services/account/accountService', () => {
 jest.mock('../../components/SEO', () => function SEO() {
   return null;
 });
+
+jest.mock('../../services/monitoring/sentry', () => ({
+  captureException: mockCaptureException,
+}));
+
+jest.mock('../../services/analytics/analytics', () => ({
+  events: {},
+  track: mockTrack,
+}));
 
 jest.mock('./StravaSection', () => function StravaSection() {
   return <div data-testid="strava-section" />;
@@ -147,6 +159,29 @@ function accountView(user = USER) {
 
 function renderAccount(user = USER) {
   return render(accountView(user));
+}
+
+function AccountCommitProbe({
+  onCommit,
+  user = USER,
+}: {
+  onCommit: (text: string) => void;
+  user?: typeof USER;
+}) {
+  React.useLayoutEffect(() => {
+    onCommit(document.body.textContent || '');
+  });
+  return accountView(user);
+}
+
+function accountDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
 }
 
 describe('Account profile recovery', () => {
@@ -562,6 +597,552 @@ describe('Account profile recovery', () => {
     const css = readFileSync(join(__dirname, 'Account.css'), 'utf8');
     expect(css).toMatch(/\.verification-resend__button\s*\{[\s\S]*min-height:\s*3rem;/);
     expect(css).toMatch(/\.verification-resend__button:focus-visible\s*\{[\s\S]*outline:/);
+  });
+
+  describe('My Account sign-out result boundary', () => {
+    const SIGN_OUT_PENDING = 'Signing out. Keep this page open.';
+    const SIGN_OUT_RETRY = 'We could not confirm sign-out. You may still be signed in. Try sign out once more.';
+    const SIGN_OUT_TERMINAL = 'We still could not confirm sign-out. You may still be signed in. Close the browser and do not let anyone else use this device until the membership lead or platform owner helps.';
+
+    test('blocks rapid repeats and hides private account content immediately', async () => {
+      const request = accountDeferred<void>();
+      const futureStart = {
+        toDate: () => new Date('2099-01-01T12:00:00Z'),
+        toMillis: () => new Date('2099-01-01T12:00:00Z').getTime(),
+      };
+      signOut.mockReturnValueOnce(request.promise);
+      (listMyRegistrations as jest.Mock).mockResolvedValue({
+        registrations: [{
+          amountCents: 1234,
+          cancelledAt: null,
+          createdAt: null,
+          currency: 'usd',
+          eventId: 'private-event',
+          id: 'private-registration',
+          paidAt: null,
+          priceTier: 'synthetic-tier',
+          refundedAt: null,
+          runner: {
+            email: 'private-runner@example.test',
+            firstName: 'Private',
+            lastName: 'Runner',
+            shirtSize: null,
+          },
+          status: 'paid',
+        }],
+        events: {
+          'private-event': {
+            id: 'private-event',
+            location: 'Private Location',
+            slug: 'private-event',
+            startAt: futureStart,
+            title: 'Private Synthetic Race',
+          },
+        },
+      });
+      renderAccount();
+
+      expect(await screen.findByText('Synthetic Member')).toBeInTheDocument();
+      expect(await screen.findByText('Private Synthetic Race')).toBeInTheDocument();
+      expect(screen.getByText('$12.34')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      expect(screen.getByLabelText('Full name')).toBeInTheDocument();
+      const button = screen.getByRole('button', { name: 'Sign out' });
+      act(() => {
+        fireEvent.click(button);
+        fireEvent.click(button);
+      });
+
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+      expect(screen.getByRole('status')).toHaveAttribute('aria-atomic', 'true');
+      expect(screen.getByRole('button', { name: 'Sign out' }))
+        .toHaveAccessibleDescription(SIGN_OUT_PENDING);
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+      expect(screen.queryByText('Synthetic Member')).not.toBeInTheDocument();
+      expect(screen.queryByText(USER.email)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Full name')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {
+        name: 'Request another verification email',
+      })).not.toBeInTheDocument();
+      expect(screen.queryByText(/current paid membership and dues status/i))
+        .not.toBeInTheDocument();
+      expect(screen.queryByText('Private Synthetic Race')).not.toBeInTheDocument();
+      expect(screen.queryByText('$12.34')).not.toBeInTheDocument();
+      expect(screen.queryByText('private-registration')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('strava-section')).not.toBeInTheDocument();
+    });
+
+    test('keeps the private pending boundary after the command resolves', async () => {
+      const request = accountDeferred<void>();
+      signOut.mockReturnValueOnce(request.promise);
+      renderAccount();
+
+      const button = await screen.findByRole('button', { name: 'Sign out' });
+      fireEvent.click(button);
+      await act(async () => request.resolve());
+
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+      fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText(USER.email)).not.toBeInTheDocument();
+    });
+
+    test('keeps a fulfilled retry private and pending without claiming success', async () => {
+      const retryRequest = accountDeferred<void>();
+      signOut
+        .mockRejectedValueOnce(new Error('synthetic-first-sign-out-failure'))
+        .mockReturnValueOnce(retryRequest.promise);
+      renderAccount();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+      fireEvent.click(await screen.findByRole('button', {
+        name: 'Try sign out once more',
+      }), { detail: 0 });
+      await act(async () => retryRequest.resolve());
+
+      expect(signOut).toHaveBeenCalledTimes(2);
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+      expect(document.body).not.toHaveTextContent(/\bsigned out\b|\bsuccess\b/i);
+      expect(screen.queryByText(USER.email)).not.toBeInTheDocument();
+    });
+
+    test('uses the same synchronous repeat lock during StrictMode replay', async () => {
+      const request = accountDeferred<void>();
+      signOut.mockReturnValueOnce(request.promise);
+      render(
+        <React.StrictMode>
+          {accountView()}
+        </React.StrictMode>,
+      );
+
+      const button = await screen.findByRole('button', { name: 'Sign out' });
+      act(() => {
+        fireEvent.click(button, { detail: 0 });
+        fireEvent.click(button, { detail: 0 });
+      });
+
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      expect(screen.queryByText(USER.email)).not.toBeInTheDocument();
+    });
+
+    test('accepts keyboard activation once on each allowed attempt', async () => {
+      signOut
+        .mockRejectedValueOnce(new Error('synthetic-first-keyboard-failure'))
+        .mockRejectedValueOnce(new Error('synthetic-second-keyboard-failure'));
+      renderAccount();
+
+      const initial = await screen.findByRole('button', { name: 'Sign out' });
+      initial.focus();
+      expect(initial).toHaveFocus();
+      act(() => {
+        fireEvent.click(initial, { detail: 0 });
+        fireEvent.click(initial, { detail: 0 });
+      });
+      const retry = await screen.findByRole('button', {
+        name: 'Try sign out once more',
+      });
+      retry.focus();
+      expect(retry).toHaveFocus();
+      act(() => {
+        fireEvent.click(retry, { detail: 0 });
+        fireEvent.click(retry, { detail: 0 });
+      });
+
+      expect(signOut).toHaveBeenCalledTimes(2);
+      expect(await screen.findByRole('alert')).toHaveTextContent(SIGN_OUT_TERMINAL);
+      expect(screen.getByRole('button', { name: 'Sign out unavailable' }))
+        .toBeDisabled();
+    });
+
+    test('allows one deliberate retry, then shows a fixed terminal result', async () => {
+      signOut
+        .mockRejectedValueOnce(new Error('synthetic-provider-canary@example.test'))
+        .mockRejectedValueOnce(new Error('second-synthetic-provider-canary@example.test'));
+      renderAccount();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+      const firstResult = await screen.findByRole('alert');
+      expect(firstResult).toHaveTextContent(SIGN_OUT_RETRY);
+      expect(firstResult).toHaveAttribute('aria-live', 'assertive');
+      expect(firstResult).toHaveAttribute('aria-atomic', 'true');
+      expect(document.body).not.toHaveTextContent(/synthetic-provider-canary/i);
+      const retry = screen.getByRole('button', { name: 'Try sign out once more' });
+      expect(retry).toBeEnabled();
+      expect(retry).toHaveAccessibleDescription(SIGN_OUT_RETRY);
+      act(() => {
+        fireEvent.click(retry);
+        fireEvent.click(retry);
+      });
+
+      const terminalResult = await screen.findByRole('alert');
+      expect(terminalResult).toHaveTextContent(SIGN_OUT_TERMINAL);
+      expect(terminalResult).toHaveAttribute('aria-live', 'assertive');
+      expect(terminalResult).toHaveAttribute('aria-atomic', 'true');
+      const terminalButton = screen.getByRole('button', {
+        name: 'Sign out unavailable',
+      });
+      expect(terminalButton).toBeDisabled();
+      expect(terminalButton).toHaveAccessibleDescription(SIGN_OUT_TERMINAL);
+      fireEvent.click(screen.getByRole('button', { name: 'Sign out unavailable' }));
+      expect(signOut).toHaveBeenCalledTimes(2);
+      expect(document.body).not.toHaveTextContent(/synthetic-provider-canary/i);
+    });
+
+    test.each([
+      ['Error', () => ({
+        reads: () => 0,
+        reason: new Error('hostile-sign-out-canary@example.test'),
+      })],
+      ['primitive', () => ({
+        reads: () => 0,
+        reason: 409,
+      })],
+      ['accessor-backed object', () => {
+        let reads = 0;
+        const reason = {};
+        Object.defineProperty(reason, 'message', {
+          get() {
+            reads += 1;
+            throw new Error('accessor-sign-out-canary@example.test');
+          },
+        });
+        return { reads: () => reads, reason };
+      }],
+      ['Proxy', () => {
+        let reads = 0;
+        const reason = new Proxy({}, {
+          get() {
+            reads += 1;
+            throw new Error('proxy-sign-out-canary@example.test');
+          },
+        });
+        return { reads: () => reads, reason };
+      }],
+      ['coercible object', () => {
+        let reads = 0;
+        const reason = {
+          [Symbol.toPrimitive]() {
+            reads += 1;
+            throw new Error('coercion-sign-out-canary@example.test');
+          },
+          toString() {
+            reads += 1;
+            throw new Error('coercion-sign-out-canary@example.test');
+          },
+        };
+        return { reads: () => reads, reason };
+      }],
+      ['thenable-style object', () => {
+        let reads = 0;
+        const reason = {};
+        Object.defineProperty(reason, 'then', {
+          get() {
+            reads += 1;
+            throw new Error('thenable-sign-out-canary@example.test');
+          },
+        });
+        return { reads: () => reads, reason };
+      }],
+    ])(
+      'does not inspect or send a %s rejection on either attempt',
+      async (_label, createReason) => {
+        const firstReason = createReason();
+        const secondReason = createReason();
+        const storageSpies = [
+          jest.spyOn(Storage.prototype, 'clear'),
+          jest.spyOn(Storage.prototype, 'getItem'),
+          jest.spyOn(Storage.prototype, 'removeItem'),
+          jest.spyOn(Storage.prototype, 'setItem'),
+        ];
+      const consoleSpies = [
+        jest.spyOn(console, 'log').mockImplementation(() => undefined),
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined),
+        jest.spyOn(console, 'error').mockImplementation(() => undefined),
+      ];
+        signOut
+          .mockRejectedValueOnce(firstReason.reason)
+          .mockRejectedValueOnce(secondReason.reason);
+        renderAccount();
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+        fireEvent.click(await screen.findByRole('button', {
+          name: 'Try sign out once more',
+        }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(SIGN_OUT_TERMINAL);
+        expect(firstReason.reads()).toBe(0);
+        expect(secondReason.reads()).toBe(0);
+        expect(consoleSpies.every((spy) => spy.mock.calls.length === 0)).toBe(true);
+        expect(storageSpies.every((spy) => spy.mock.calls.length === 0)).toBe(true);
+        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(mockTrack).not.toHaveBeenCalled();
+        expect(document.body).not.toHaveTextContent(/sign-out-canary/i);
+      },
+    );
+
+    test('keeps a pending result across a new wrapper with the same identity and app', async () => {
+      const request = accountDeferred<void>();
+      const stableIdentityService = { signOut, resendVerificationEmail };
+      signOut.mockReturnValueOnce(request.promise);
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: {
+          firebaseResources: { app, firestore },
+          identityService: stableIdentityService,
+        },
+        isReady: true,
+      });
+      const view = renderAccount();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: {
+          firebaseResources: { app, firestore },
+          identityService: stableIdentityService,
+        },
+        isReady: true,
+      });
+      await act(async () => {
+        view.rerender(accountView());
+        await Promise.resolve();
+      });
+
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText(USER.email)).not.toBeInTheDocument();
+    });
+
+    test('keeps a newer attempt current after an A to B to A service change', async () => {
+      const obsoleteRequest = accountDeferred<void>();
+      const currentRequest = accountDeferred<void>();
+      const identityServiceA = {
+        resendVerificationEmail,
+        signOut: jest.fn()
+          .mockReturnValueOnce(obsoleteRequest.promise)
+          .mockReturnValueOnce(currentRequest.promise),
+      };
+      const identityServiceB = {
+        resendVerificationEmail,
+        signOut: jest.fn(),
+      };
+      const view = renderAccount();
+      expect(await screen.findByText('Synthetic Member')).toBeInTheDocument();
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: {
+          firebaseResources: { app, firestore },
+          identityService: identityServiceA,
+        },
+        isReady: true,
+      });
+      await act(async () => {
+        view.rerender(accountView());
+        await Promise.resolve();
+      });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: {
+          firebaseResources: { app, firestore },
+          identityService: identityServiceB,
+        },
+        isReady: true,
+      });
+      await act(async () => {
+        view.rerender(accountView());
+        await Promise.resolve();
+      });
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services: {
+          firebaseResources: { app, firestore },
+          identityService: identityServiceA,
+        },
+        isReady: true,
+      });
+      await act(async () => {
+        view.rerender(accountView());
+        await Promise.resolve();
+      });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+
+      await act(async () => obsoleteRequest.reject(
+        new Error('obsolete-sign-out-canary@example.test'),
+      ));
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+      await act(async () => currentRequest.reject(
+        new Error('current-sign-out-canary@example.test'),
+      ));
+
+      expect(screen.getByRole('alert')).toHaveTextContent(SIGN_OUT_RETRY);
+      expect(screen.getByRole('button', { name: 'Try sign out once more' }))
+        .toBeEnabled();
+      expect(identityServiceA.signOut).toHaveBeenCalledTimes(2);
+      expect(identityServiceB.signOut).not.toHaveBeenCalled();
+      expect(document.body).not.toHaveTextContent(/obsolete-sign-out-canary/i);
+    });
+
+    test.each([
+      'UID',
+      'identity service',
+      'Firebase app',
+    ])(
+      'never commits prior profile or registration data after a %s-only change',
+      async (transition) => {
+        const request = accountDeferred<void>();
+        const replacementProfile = accountDeferred<typeof PROFILE>();
+        const stableIdentityService = {
+          resendVerificationEmail,
+          signOut: jest.fn().mockReturnValueOnce(request.promise),
+        };
+        const replacementIdentityService = transition === 'identity service'
+          ? { resendVerificationEmail, signOut: jest.fn() }
+          : stableIdentityService;
+        const replacementApp = transition === 'Firebase app'
+          ? { name: 'replacement-synthetic-app' }
+          : app;
+        const replacementUser = transition === 'UID'
+          ? {
+            uid: 'replacement-sign-out-user',
+            email: 'replacement-sign-out-user@example.test',
+            role: 'unverified' as const,
+          }
+          : USER;
+        const oldStart = {
+          toDate: () => new Date('2099-01-01T12:00:00Z'),
+          toMillis: () => new Date('2099-01-01T12:00:00Z').getTime(),
+        };
+        (useServiceLocator as jest.Mock).mockReturnValue({
+          services: {
+            firebaseResources: { app, firestore },
+            identityService: stableIdentityService,
+          },
+          isReady: true,
+        });
+        (getMyProfile as jest.Mock)
+          .mockResolvedValueOnce(PROFILE)
+          .mockReturnValueOnce(replacementProfile.promise);
+        (listMyRegistrations as jest.Mock).mockResolvedValueOnce({
+          registrations: [{
+            amountCents: 4321,
+            cancelledAt: null,
+            createdAt: null,
+            currency: 'usd',
+            eventId: 'old-private-event',
+            id: 'old-private-registration',
+            paidAt: null,
+            priceTier: 'synthetic-tier',
+            refundedAt: null,
+            runner: {
+              email: 'old-runner@example.test',
+              firstName: 'Old',
+              lastName: 'Runner',
+              shirtSize: null,
+            },
+            status: 'paid',
+          }],
+          events: {
+            'old-private-event': {
+              id: 'old-private-event',
+              location: 'Old Private Location',
+              slug: 'old-private-event',
+              startAt: oldStart,
+              title: 'Old Private Race',
+            },
+          },
+        });
+        const commits: string[] = [];
+        const onCommit = (text: string) => commits.push(text);
+        const view = render(<AccountCommitProbe onCommit={onCommit} />);
+
+        expect(await screen.findByText('Synthetic Member')).toBeInTheDocument();
+        expect(await screen.findByText('Old Private Race')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+        commits.length = 0;
+        (useServiceLocator as jest.Mock).mockReturnValue({
+          services: {
+            firebaseResources: { app: replacementApp, firestore },
+            identityService: replacementIdentityService,
+          },
+          isReady: true,
+        });
+        await act(async () => {
+          view.rerender(
+            <AccountCommitProbe onCommit={onCommit} user={replacementUser} />,
+          );
+        });
+
+        expect(commits.length).toBeGreaterThan(0);
+        expect(commits.join(' ')).toContain('Loading profile...');
+        expect(commits.join(' ')).not.toMatch(
+          /Synthetic Member|member@example\.com|Old Private Race|\$43\.21|old-private-registration/,
+        );
+        expect(document.body).not.toHaveTextContent(/Synthetic Member|Old Private Race/);
+        expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+        await act(async () => request.reject(
+          new Error('obsolete-account-canary@example.test'),
+        ));
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(stableIdentityService.signOut).toHaveBeenCalledTimes(1);
+        expect(document.body).not.toHaveTextContent(/obsolete-account-canary/i);
+      },
+    );
+
+    test('makes a pending rejection inert after unmount', async () => {
+      const request = accountDeferred<void>();
+      signOut.mockReturnValueOnce(request.promise);
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const view = renderAccount();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+      view.unmount();
+      await act(async () => request.reject(new Error('unmounted-sign-out-canary@example.test')));
+
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(consoleError.mock.calls))
+        .not.toMatch(/unmounted-sign-out-canary|state update on an unmounted/i);
+    });
+
+    test('makes a pending fulfillment inert after unmount', async () => {
+      const request = accountDeferred<void>();
+      signOut.mockReturnValueOnce(request.promise);
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const view = renderAccount();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+      view.unmount();
+      await act(async () => request.resolve());
+
+      expect(signOut).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(consoleError.mock.calls))
+        .not.toMatch(/state update on an unmounted/i);
+    });
+
+    test('uses a native 48px sign-out button with a visible focus target', async () => {
+      const view = render(
+        <main id="main-content">
+          {accountView()}
+        </main>,
+      );
+      const button = await screen.findByRole('button', { name: 'Sign out' });
+
+      expect(button).toHaveAttribute('type', 'button');
+      button.focus();
+      expect(button).toHaveFocus();
+      fireEvent.click(button);
+      expect(view.container.querySelectorAll('main')).toHaveLength(1);
+      expect(screen.getByRole('status')).toHaveTextContent(SIGN_OUT_PENDING);
+
+      const css = readFileSync(join(__dirname, 'Account.css'), 'utf8');
+      expect(css).toMatch(/\.account-sign-out__button\s*\{[\s\S]*min-height:\s*3rem;/);
+      expect(css).toMatch(/\.account-sign-out__button:focus-visible\s*\{[\s\S]*outline:/);
+    });
   });
 });
 

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useRef, useState,
+  useEffect, useLayoutEffect, useRef, useState,
 } from 'react';
 import { Link, Navigate, useLocation } from 'react-router-dom';
 import { Timestamp } from 'firebase/firestore';
@@ -219,6 +219,9 @@ function RegistrationRow({
 
 const PROFILE_UNAVAILABLE_MESSAGE = 'Your profile is temporarily unavailable. Sign out and try again later. No membership or payment status was changed.';
 const PROFILE_CHANGE_UNCONFIRMED_MESSAGE = 'We could not confirm your profile change. Try the profile again before making another change.';
+const SIGN_OUT_PENDING_MESSAGE = 'Signing out. Keep this page open.';
+const SIGN_OUT_RETRY_MESSAGE = 'We could not confirm sign-out. You may still be signed in. Try sign out once more.';
+const SIGN_OUT_TERMINAL_MESSAGE = 'We still could not confirm sign-out. You may still be signed in. Close the browser and do not let anyone else use this device until the membership lead or platform owner helps.';
 
 export function AccountContent({
   user,
@@ -240,14 +243,67 @@ export function AccountContent({
   const [regsData, setRegsData] = useState<MyRegistrationsResponse | null>(null);
   const [regsLoading, setRegsLoading] = useState(true);
   const [regsError, setRegsError] = useState<string | null>(null);
+  const identityService = services?.identityService || null;
+  const firebaseApp = services?.firebaseResources.app || null;
+  type AccountContext = {
+    firebaseApp: typeof firebaseApp;
+    identityService: typeof identityService;
+    uid: string;
+  };
+  type SignOutOutcome = AccountContext & {
+    attemptId: number;
+    attemptNumber: 1 | 2;
+    generation: number;
+    status: 'pending' | 'retry' | 'terminal';
+  };
+  const [profileContext, setProfileContext] = useState<AccountContext | null>(null);
+  const [registrationsContext, setRegistrationsContext] = useState<
+    AccountContext | null
+  >(null);
+  const [signOutOutcome, setSignOutOutcome] = useState<SignOutOutcome | null>(null);
+  const signOutAttemptIdRef = useRef(0);
+  const signOutAttemptsRef = useRef(0);
+  const signOutBlockedRef = useRef(false);
+  const signOutGenerationRef = useRef(0);
+  const signOutMountedRef = useRef(false);
+  const currentSignOutContextRef = useRef({
+    firebaseApp,
+    identityService,
+    uid: user.uid,
+  });
+
+  useLayoutEffect(() => {
+    currentSignOutContextRef.current = {
+      firebaseApp,
+      identityService,
+      uid: user.uid,
+    };
+    signOutMountedRef.current = true;
+    signOutGenerationRef.current += 1;
+    signOutBlockedRef.current = false;
+    signOutAttemptsRef.current = 0;
+    setSignOutOutcome(null);
+
+    return () => {
+      signOutMountedRef.current = false;
+      signOutGenerationRef.current += 1;
+      signOutBlockedRef.current = true;
+    };
+  }, [firebaseApp, identityService, user.uid]);
 
   useEffect(() => {
     if (!services) return undefined;
     const activeServices = services;
+    const loadContext = {
+      firebaseApp: activeServices.firebaseResources.app,
+      identityService: activeServices.identityService,
+      uid: user.uid,
+    };
     let active = true;
 
     async function loadProfile() {
       setProfileState('loading');
+      setProfileContext(null);
       setProfile(null);
       setProfileError(null);
       setEditing(false);
@@ -263,10 +319,12 @@ export function AccountContent({
         if (!active) return;
         setProfile(nextProfile);
         setFullName(nextProfile.fullName || '');
+        setProfileContext(loadContext);
         setProfileState('ready');
       } catch {
         if (!active) return;
         setProfileError(PROFILE_UNAVAILABLE_MESSAGE);
+        setProfileContext(loadContext);
         setProfileState('unavailable');
       }
     }
@@ -277,19 +335,27 @@ export function AccountContent({
 
   useEffect(() => {
     if (!services || profileState !== 'ready') return undefined;
+    const loadContext = {
+      firebaseApp: services.firebaseResources.app,
+      identityService: services.identityService,
+      uid: user.uid,
+    };
     let active = true;
     setRegsData(null);
+    setRegistrationsContext(null);
     setRegsError(null);
     setRegsLoading(true);
     listMyRegistrations(services.firebaseResources.app)
       .then((result) => {
         if (!active) return;
         setRegsData(result);
+        setRegistrationsContext(loadContext);
         setRegsLoading(false);
       })
       .catch(() => {
         if (!active) return;
         setRegsError('We could not load your registrations right now.');
+        setRegistrationsContext(loadContext);
         setRegsLoading(false);
       });
     return () => { active = false; };
@@ -329,11 +395,131 @@ export function AccountContent({
   }
 
   async function handleSignOut() {
-    if (!services) return;
-    await services.identityService.signOut();
+    const currentContext = currentSignOutContextRef.current;
+    if (
+      !currentContext.firebaseApp
+      || !currentContext.identityService
+      || signOutBlockedRef.current
+      || signOutAttemptsRef.current >= 2
+    ) return;
+
+    signOutBlockedRef.current = true;
+    signOutAttemptsRef.current += 1;
+    const attemptNumber = signOutAttemptsRef.current as 1 | 2;
+    const attemptId = signOutAttemptIdRef.current + 1;
+    signOutAttemptIdRef.current = attemptId;
+    const generation = signOutGenerationRef.current;
+    const outcomeContext = {
+      attemptId,
+      attemptNumber,
+      firebaseApp: currentContext.firebaseApp,
+      generation,
+      identityService: currentContext.identityService,
+      status: 'pending' as const,
+      uid: currentContext.uid,
+    };
+    setSignOutOutcome(outcomeContext);
+
+    try {
+      await currentContext.identityService.signOut();
+    } catch {
+      const latestContext = currentSignOutContextRef.current;
+      if (
+        !signOutMountedRef.current
+        || signOutGenerationRef.current !== generation
+        || signOutAttemptIdRef.current !== attemptId
+        || latestContext.uid !== outcomeContext.uid
+        || latestContext.identityService !== outcomeContext.identityService
+        || latestContext.firebaseApp !== outcomeContext.firebaseApp
+      ) return;
+
+      if (attemptNumber === 1) {
+        signOutBlockedRef.current = false;
+        setSignOutOutcome({
+          ...outcomeContext,
+          status: 'retry',
+        });
+        return;
+      }
+
+      setSignOutOutcome({
+        ...outcomeContext,
+        status: 'terminal',
+      });
+    }
   }
 
-  if (profileState === 'loading') {
+  const currentSignOutOutcome = signOutOutcome
+    && signOutOutcome.uid === user.uid
+    && signOutOutcome.identityService === identityService
+    && signOutOutcome.firebaseApp === firebaseApp
+    && signOutOutcome.generation === signOutGenerationRef.current
+    ? signOutOutcome
+    : null;
+  const profileBelongsToCurrentContext = profileContext
+    && profileContext.uid === user.uid
+    && profileContext.identityService === identityService
+    && profileContext.firebaseApp === firebaseApp;
+  const registrationsBelongToCurrentContext = registrationsContext
+    && registrationsContext.uid === user.uid
+    && registrationsContext.identityService === identityService
+    && registrationsContext.firebaseApp === firebaseApp;
+
+  if (currentSignOutOutcome) {
+    const isRetry = currentSignOutOutcome.status === 'retry';
+    const isTerminal = currentSignOutOutcome.status === 'terminal';
+    let message = SIGN_OUT_PENDING_MESSAGE;
+    if (isRetry) {
+      message = SIGN_OUT_RETRY_MESSAGE;
+    } else if (isTerminal) {
+      message = SIGN_OUT_TERMINAL_MESSAGE;
+    }
+    let buttonLabel = 'Sign out';
+    if (isRetry) {
+      buttonLabel = 'Try sign out once more';
+    } else if (isTerminal) {
+      buttonLabel = 'Sign out unavailable';
+    }
+
+    return (
+      <>
+        <SEO title="My Account" noindex />
+        <div className="account-sign-out container mx-auto p-4 max-w-3xl">
+          <h1 className="text-2xl font-bold">My Account</h1>
+          <section className="account-sign-out__panel" aria-labelledby="sign-out-heading">
+            <h2 id="sign-out-heading" className="account-sign-out__heading">
+              Sign out
+            </h2>
+            <p
+              id="account-sign-out-result"
+              role={currentSignOutOutcome.status === 'pending' ? 'status' : 'alert'}
+              aria-live={
+                currentSignOutOutcome.status === 'pending' ? 'polite' : 'assertive'
+              }
+              aria-atomic="true"
+              className={[
+                'account-sign-out__result',
+                `account-sign-out__result--${currentSignOutOutcome.status}`,
+              ].join(' ')}
+            >
+              {message}
+            </p>
+            <button
+              type="button"
+              onClick={handleSignOut}
+              disabled={!isRetry}
+              aria-describedby="account-sign-out-result"
+              className="account-sign-out__button"
+            >
+              {buttonLabel}
+            </button>
+          </section>
+        </div>
+      </>
+    );
+  }
+
+  if (!profileBelongsToCurrentContext || profileState === 'loading') {
     return (
       <div role="status" className="container mx-auto p-6">
         Loading profile...
@@ -341,15 +527,26 @@ export function AccountContent({
     );
   }
 
-  const upcoming = regsData?.registrations.filter((r) => {
-    const ev = regsData.events[r.eventId];
+  const currentRegistrations = registrationsBelongToCurrentContext
+    ? regsData
+    : null;
+  const currentRegistrationsLoading = registrationsBelongToCurrentContext
+    ? regsLoading
+    : true;
+  const currentRegistrationsError = registrationsBelongToCurrentContext
+    ? regsError
+    : null;
+  const upcoming = currentRegistrations?.registrations.filter((r) => {
+    const ev = currentRegistrations.events[r.eventId];
     if (!ev?.startAt) return false;
     const ms = typeof (ev.startAt as any).toMillis === 'function'
       ? (ev.startAt as any).toMillis()
       : new Date(ev.startAt as any).getTime();
     return ms > Date.now();
   }) || [];
-  const past = regsData?.registrations.filter((r) => !upcoming.includes(r)) || [];
+  const past = currentRegistrations?.registrations.filter(
+    (r) => !upcoming.includes(r),
+  ) || [];
 
   return (
     <>
@@ -360,7 +557,8 @@ export function AccountContent({
           <button
             type="button"
             onClick={handleSignOut}
-            className="text-sm text-gray-600 hover:underline"
+            disabled={!identityService || !firebaseApp}
+            className="account-sign-out__button"
           >
             Sign out
           </button>
@@ -495,9 +693,15 @@ export function AccountContent({
         {profileState === 'ready' && (
           <section className="mt-6">
             <h2 className="text-lg font-semibold mb-3">Upcoming events</h2>
-            {regsLoading && <p className="text-gray-500 text-sm">Loading...</p>}
-            {regsError && <p role="alert" className="text-red-500 text-sm">{regsError}</p>}
-            {!regsLoading && upcoming.length === 0 && (
+            {currentRegistrationsLoading && (
+              <p className="text-gray-500 text-sm">Loading...</p>
+            )}
+            {currentRegistrationsError && (
+              <p role="alert" className="text-red-500 text-sm">
+                {currentRegistrationsError}
+              </p>
+            )}
+            {!currentRegistrationsLoading && upcoming.length === 0 && (
               <p className="text-gray-500 text-sm">
                 You haven&apos;t registered for any upcoming events.
                 {' '}
@@ -511,7 +715,7 @@ export function AccountContent({
               <RegistrationRow
                 key={r.id}
                 reg={r}
-                event={regsData?.events[r.eventId]}
+                event={currentRegistrations?.events[r.eventId]}
               />
             ))}
           </section>
@@ -524,7 +728,7 @@ export function AccountContent({
               <RegistrationRow
                 key={r.id}
                 reg={r}
-                event={regsData?.events[r.eventId]}
+                event={currentRegistrations?.events[r.eventId]}
               />
             ))}
           </section>


### PR DESCRIPTION
Closes #368

Officer impact: After a future approved website publication, choosing Sign out once will immediately hide My Account details, block rapid repeats, allow one deliberate retry when the command is unconfirmed, and give a shared-device stop instruction after a second unconfirmed result.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`; `docs/officers/EMERGENCY_AND_RECOVERY.md`.

Deployment evidence: Source and synthetic tests only in this pull request. No website publication, `runmprc.com` verification, Firebase deployment, provider/configuration change, production account/session/data action, or live behavior check was performed. A preview or green CI result is not production proof.

## Outcome

- Lock the current sign-out attempt synchronously before React state commits.
- Hide profile, email, resend, membership, registration/price, edit/save, and Strava surfaces immediately.
- Keep a fulfilled command private and pending until the existing Auth listener removes My Account.
- Discard rejected values without inspection, logging, monitoring, analytics, storage, or rendering.
- Permit exactly one retry, then fail closed with a shared-device stop instruction.
- Invalidate stale UID, identity-service, Firebase-app, A→B→A, newer-attempt, and unmount settlements.
- Prevent cached prior-account profile or registration results from appearing during a context change.
- Preserve one main landmark, native keyboard behavior, visible focus, exact live-region copy, and a 3rem target.

## Invariant and compatibility

Firebase Auth and the existing route remain the only UI authority for completed sign-out. This browser state machine does not revoke sessions, sign out another device, change Identity/Firebase/provider settings, or migrate data. Existing profile, save, resend, registration, membership, Strava, and redirect behavior remains authoritative.

## RED evidence

Against exact base `73b46cbf37e204bd1e69000c396e0736d500cb07`, four focused tests failed as intended: rapid repeat made two calls; no pending/private boundary existed; rejection escaped without fixed recovery; and the minimum target/focus contract was absent. Test-only diff SHA-256: `fa606122deb36feaabc4a6c9242a31cde3b021a6edabfbe4f98a6ebe644bc2a4`.

## Verification

Using Node 20.19.5 and only synthetic/demo inputs:

- Focused sign-out boundary: 20/20 passed.
- Full frontend: 13 suites / 589 tests passed.
- TypeScript: passed.
- Direct ESLint for changed source/tests: passed.
- Non-mutating lint ledger: 108 files / 121 reviewed errors / 6 reviewed warnings.
- Repository workflow/release/artifact/dependency safety: 50 checks passed.
- Functions lint: passed.
- Functions: 33 active suites / 2,968 active tests passed; 64 intentionally skipped.
- Firestore Rules on `demo-rules-test`: 378/378 passed.
- Commerce journal on `demo-pay002b2-test`: 63/63 passed.
- Diagnostic production build: passed.
- Changed officer-guide relative links and anchors: passed.
- Generated focused-test artifact safety scan: passed.
- Added-line credential-shaped literal scan: passed.
- `git diff --check`: passed.

Exact reviewed head: `a2cc0c67032f0892633df77f7729f7fcab674119`.
Exact five-file diff SHA-256: `aa0a447f35f2f5024b8e54ceaadcef876a882c1a83eeac3a819485ce298573d9`.