### PR TITLE
PAY-003C1: commerce attempt-failure disposition (source only, unused) (#377)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -477,6 +477,29 @@ Outputs are fresh frozen fixed three-field records: `untrusted_transport_binding
 
 CI-001B3 [#167](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/167) runs the exact opt-in command-journal emulator suite as a named hosted release prerequisite; #169, #173, #182, #206, #226, #232, and #238 expand that same suite. These are synthetic source checks only. Source change, tests, merge, Firebase deployment, Stripe configuration, production data, website publication, `runmprc.com` verification, and live behavior remain separate states. The current journal source remains unused and makes no endpoint, provider, production, website, or officer change.
 
+### PAY-003C1 commerce attempt-failure disposition — SOURCE ONLY, UNUSED
+
+PAY-003C1 is tracked in live [#377](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/377) under PAY-003 [#106](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/106). The pure `classifyAttemptFailure` policy reads one exact flat revision-1 evidence record `{ failureDispositionSchemaVersion, failureSignal, sideEffectIdempotency, retryBudget }` drawn only from closed vocabularies and returns one frozen disposition — `retry_transient`, `dead_letter`, `quarantine_permanent`, or `ignore_duplicate` — each carrying a boolean `retryable`. `failureSignal` reuses the house transient names (`timeout`, `connection_lost`, `rate_limited`, `server_failure`, `external_dependency_failure`) plus permanent (`permanent_client_error`, `malformed_response`), reconcile-needed (`conflict`, `unknown`), and already-applied (`duplicate_replay`); `sideEffectIdempotency` is `idempotent`/`non_idempotent` and `retryBudget` is `available`/`exhausted`. It imports only `node:util`.
+
+```mermaid
+flowchart TD
+    E["Exact revision-1 failure evidence"] --> D{"duplicate_replay?"}
+    D -- "Yes" --> Ig["ignore_duplicate"]
+    D -- "No" --> T{"Transient signal?"}
+    T -- "No" --> Q["quarantine_permanent"]
+    T -- "Yes" --> I{"Idempotent effect?"}
+    I -- "No" --> Q
+    I -- "Yes" --> B{"Retry budget available?"}
+    B -- "Yes" --> Rt["retry_transient (retryable)"]
+    B -- "No" --> Dl["dead_letter"]
+```
+
+Text alternative: an already-applied duplicate is ignored; any non-transient signal, or a transient signal on a non-idempotent effect, is quarantined; a transient failure on an idempotent effect retries while the caller's budget remains and otherwise dead-letters.
+
+The safety invariant is that a non-idempotent side effect is never `retry_transient`: a transient failure on a non-idempotent effect quarantines instead, so the deferred worker can never double-apply an external create, refund, or send (external effects must be idempotent and retry-safe). Only genuinely transient signals retry, and only while `retryBudget` is `available`; an exhausted budget dead-letters; `conflict` and `unknown` fail closed to `quarantine_permanent`; `duplicate_replay` yields `ignore_duplicate` with no new delivery. `retryable` is true only for `retry_transient`.
+
+The retry budget is an input, never a baked-in maximum count, backoff schedule, TTL, dead-letter threshold, or alert — those stay with the deferred PAY-003C worker and retention approval [#110](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/110). The module names no provider, recipient, address, money, or message and accepts no free-form identifiers, so nothing PII-shaped can ride in; malformed, proxy, accessor, inherited, extra-or-missing-key, unknown-enum, or wrong-version input throws one fixed `CommerceFailureDispositionError` that never echoes the input. The sibling `commerceOutboxState` (PAY-003B1, [#364](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/364)) validates whether a proposed delivery transition is legal but is handed the target state; this classifier derives which target a failure warrants. The `commerceProviderResult`/`commerceProviderReconciliation` classifiers answer business-advance-versus-reconcile and never emit a retry-versus-permanent verdict. It reads no clock, randomness, environment, network, Firestore, or Stripe; is imported by no runtime entry point or Functions index; stores and logs nothing; and creates no attempt, send, retry, deletion, or business record. Source change, tests, merge, Firebase deployment, Stripe configuration, production data, website publication, and live behavior remain separate states; #377 changes no officer task and proves none of the external or live states.
+
 ## 7. Business invariants
 
 The following are correctness rules, not UI preferences:

--- a/functions/commerceFailureDisposition.js
+++ b/functions/commerceFailureDisposition.js
@@ -1,0 +1,198 @@
+const { types: { isProxy } } = require('node:util');
+
+const failureDispositionSchemaVersion = 1;
+const FAILURE_DISPOSITION_ERROR_MESSAGE = 'Commerce failure disposition evidence is invalid.';
+
+const EXPECTED_FIELDS = Object.freeze([
+  'failureDispositionSchemaVersion',
+  'failureSignal',
+  'sideEffectIdempotency',
+  'retryBudget',
+]);
+
+const FAILURE_DISPOSITION_ENUMS = Object.freeze({
+  // The observed outcome of a side-effect delivery attempt that did not confirm
+  // clean success. Transient names reuse the house `responseEvidence` vocabulary.
+  failureSignal: Object.freeze([
+    // Transient — retryable only when the effect is idempotent and budget remains.
+    'timeout',
+    'connection_lost',
+    'rate_limited',
+    'server_failure',
+    'external_dependency_failure',
+    // Permanent — never retried.
+    'permanent_client_error',
+    'malformed_response',
+    // Needs reconciliation / unclassified — fail closed to quarantine.
+    'conflict',
+    'unknown',
+    // The effect was already applied (idempotent replay) — no new delivery.
+    'duplicate_replay',
+  ]),
+  // Whether repeating the side effect is safe. A non-idempotent effect is never
+  // auto-retried: a second external create, refund, or send could double-apply.
+  sideEffectIdempotency: Object.freeze(['idempotent', 'non_idempotent']),
+  // Whether the caller's retry allowance (count/backoff/TTL — owned by PAY-003C)
+  // still permits another attempt. Passed as evidence; never derived here.
+  retryBudget: Object.freeze(['available', 'exhausted']),
+  // Output-only dispositions.
+  disposition: Object.freeze([
+    'retry_transient',
+    'dead_letter',
+    'quarantine_permanent',
+    'ignore_duplicate',
+  ]),
+});
+
+// Only the input enums are validated against the incoming evidence.
+const ENUM_SETS = Object.freeze({
+  failureSignal: new Set(FAILURE_DISPOSITION_ENUMS.failureSignal),
+  sideEffectIdempotency: new Set(FAILURE_DISPOSITION_ENUMS.sideEffectIdempotency),
+  retryBudget: new Set(FAILURE_DISPOSITION_ENUMS.retryBudget),
+});
+
+// The subset of failureSignal values that are transient (retryable in principle).
+const TRANSIENT_SIGNALS = new Set([
+  'timeout',
+  'connection_lost',
+  'rate_limited',
+  'server_failure',
+  'external_dependency_failure',
+]);
+
+class CommerceFailureDispositionError extends Error {
+  constructor() {
+    super(FAILURE_DISPOSITION_ERROR_MESSAGE);
+    Object.defineProperty(this, 'name', {
+      value: 'CommerceFailureDispositionError',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'message', {
+      value: FAILURE_DISPOSITION_ERROR_MESSAGE,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'code', {
+      value: 'invalid_failure_disposition_evidence',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Error.captureStackTrace?.(this, CommerceFailureDispositionError);
+    Object.freeze(this);
+  }
+}
+
+function fail() {
+  throw new CommerceFailureDispositionError();
+}
+
+function readExactEvidence(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+
+  if (prototype !== Object.prototype || keys.length !== EXPECTED_FIELDS.length) fail();
+
+  const keySet = new Set();
+  for (const key of keys) {
+    if (typeof key !== 'string' || keySet.has(key)) fail();
+    keySet.add(key);
+  }
+  if (EXPECTED_FIELDS.some((field) => !keySet.has(field))) fail();
+
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) fail();
+  }
+
+  const evidence = Object.create(null);
+  for (const field of EXPECTED_FIELDS) {
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, field);
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    evidence[field] = descriptor.value;
+  }
+
+  if (evidence.failureDispositionSchemaVersion !== failureDispositionSchemaVersion) fail();
+
+  for (const [field, allowedValues] of Object.entries(ENUM_SETS)) {
+    if (!allowedValues.has(evidence[field])) fail();
+  }
+
+  return evidence;
+}
+
+function frozenDisposition(disposition, retryable) {
+  return Object.freeze({
+    failureDispositionSchemaVersion,
+    disposition,
+    // Only a transient failure on an idempotent effect with budget remaining is
+    // retryable; every other verdict is terminal for the current attempt so the
+    // deferred worker never re-hits the provider unsafely.
+    retryable,
+  });
+}
+
+const RESULTS = Object.freeze({
+  retryTransient: frozenDisposition('retry_transient', true),
+  deadLetter: frozenDisposition('dead_letter', false),
+  quarantinePermanent: frozenDisposition('quarantine_permanent', false),
+  ignoreDuplicate: frozenDisposition('ignore_duplicate', false),
+});
+
+function classifyAttemptFailure(input) {
+  const evidence = readExactEvidence(input);
+
+  // 1. An idempotent replay means the effect already landed: no new delivery.
+  if (evidence.failureSignal === 'duplicate_replay') {
+    return RESULTS.ignoreDuplicate;
+  }
+
+  // 2. Anything off the transient allow-list (permanent_client_error,
+  //    malformed_response, conflict, unknown) is never retried and is
+  //    quarantined for reprocessing/alerting — fail closed.
+  if (!TRANSIENT_SIGNALS.has(evidence.failureSignal)) {
+    return RESULTS.quarantinePermanent;
+  }
+
+  // 3. Transient, but a non-idempotent side effect must never be auto-retried
+  //    (a second external create, refund, or send could double-apply); quarantine
+  //    it for manual handling instead.
+  if (evidence.sideEffectIdempotency === 'non_idempotent') {
+    return RESULTS.quarantinePermanent;
+  }
+
+  // 4. Transient and idempotent: retry while the caller's budget remains,
+  //    otherwise dead-letter for operations.
+  return evidence.retryBudget === 'available' ? RESULTS.retryTransient : RESULTS.deadLetter;
+}
+
+Object.freeze(CommerceFailureDispositionError.prototype);
+Object.freeze(CommerceFailureDispositionError);
+
+module.exports = Object.freeze({
+  failureDispositionSchemaVersion,
+  FAILURE_DISPOSITION_ENUMS,
+  CommerceFailureDispositionError,
+  classifyAttemptFailure,
+});

--- a/functions/commerceFailureDisposition.test.js
+++ b/functions/commerceFailureDisposition.test.js
@@ -1,0 +1,386 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  failureDispositionSchemaVersion,
+  FAILURE_DISPOSITION_ENUMS,
+  CommerceFailureDispositionError,
+  classifyAttemptFailure,
+} = require('./commerceFailureDisposition');
+
+// A value that must never be echoed back by a rejection: it stands in for a
+// runner identifier / token that could ride in on a malformed field.
+const HOSTILE_CANARY = 'private-runner@example.test/+12025550123?token=do-not-copy';
+
+const RESULT_KEYS = ['failureDispositionSchemaVersion', 'disposition', 'retryable'];
+
+const SIGNALS = FAILURE_DISPOSITION_ENUMS.failureSignal;
+const IDEMPOTENCY = FAILURE_DISPOSITION_ENUMS.sideEffectIdempotency;
+const BUDGETS = FAILURE_DISPOSITION_ENUMS.retryBudget;
+const DISPOSITIONS = FAILURE_DISPOSITION_ENUMS.disposition;
+
+// Independent oracle — deliberately written differently from the module (array
+// membership + explicit branches) so agreement is a real cross-check.
+const TRANSIENT = [
+  'timeout',
+  'connection_lost',
+  'rate_limited',
+  'server_failure',
+  'external_dependency_failure',
+];
+
+function expectedDisposition(e) {
+  if (e.failureSignal === 'duplicate_replay') return 'ignore_duplicate';
+  if (!TRANSIENT.includes(e.failureSignal)) return 'quarantine_permanent';
+  if (e.sideEffectIdempotency === 'non_idempotent') return 'quarantine_permanent';
+  return e.retryBudget === 'available' ? 'retry_transient' : 'dead_letter';
+}
+
+function expectedRetryable(e) {
+  return expectedDisposition(e) === 'retry_transient';
+}
+
+function evidence(overrides = {}) {
+  return {
+    failureDispositionSchemaVersion: 1,
+    failureSignal: 'timeout',
+    sideEffectIdempotency: 'idempotent',
+    retryBudget: 'available',
+    ...overrides,
+  };
+}
+
+function classifyError(input) {
+  try {
+    classifyAttemptFailure(input);
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected classifyAttemptFailure to throw');
+}
+
+function expectRejected(input) {
+  const err = classifyError(input);
+  expect(err).toBeInstanceOf(CommerceFailureDispositionError);
+  expect(err.code).toBe('invalid_failure_disposition_evidence');
+  expect(err.message).toBe('Commerce failure disposition evidence is invalid.');
+  // The rejection must never echo the input back in any serialization.
+  expect(JSON.stringify(err) || '').not.toContain(HOSTILE_CANARY);
+  expect(String(err)).not.toContain(HOSTILE_CANARY);
+  expect(err.stack || '').not.toContain(HOSTILE_CANARY);
+}
+
+describe('attempt-failure disposition matrix', () => {
+  const combos = [];
+  for (const failureSignal of SIGNALS) {
+    for (const sideEffectIdempotency of IDEMPOTENCY) {
+      for (const retryBudget of BUDGETS) {
+        combos.push(evidence({ failureSignal, sideEffectIdempotency, retryBudget }));
+      }
+    }
+  }
+
+  test('covers every signal x idempotency x budget combination exactly once', () => {
+    expect(combos).toHaveLength(SIGNALS.length * IDEMPOTENCY.length * BUDGETS.length);
+    expect(combos).toHaveLength(40);
+    const seen = new Set(combos.map((e) =>
+      `${e.failureSignal}|${e.sideEffectIdempotency}|${e.retryBudget}`));
+    expect(seen.size).toBe(combos.length);
+  });
+
+  test('each verdict is a frozen, exactly-shaped disposition that matches the oracle', () => {
+    for (const e of combos) {
+      const result = classifyAttemptFailure(e);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(Object.keys(result)).toEqual(RESULT_KEYS);
+      expect(result.failureDispositionSchemaVersion).toBe(1);
+      expect(DISPOSITIONS).toContain(result.disposition);
+      expect(typeof result.retryable).toBe('boolean');
+      expect(result.disposition).toBe(expectedDisposition(e));
+      expect(result.retryable).toBe(expectedRetryable(e));
+    }
+  });
+
+  test('all four dispositions are reachable across the matrix', () => {
+    const produced = new Set(combos.map((e) => classifyAttemptFailure(e).disposition));
+    expect([...produced].sort()).toEqual([...DISPOSITIONS].sort());
+  });
+
+  test('retryable is true only for retry_transient (idempotent + transient + budget)', () => {
+    for (const e of combos) {
+      const result = classifyAttemptFailure(e);
+      if (result.retryable) {
+        expect(result.disposition).toBe('retry_transient');
+        expect(e.sideEffectIdempotency).toBe('idempotent');
+        expect(TRANSIENT).toContain(e.failureSignal);
+        expect(e.retryBudget).toBe('available');
+      }
+    }
+  });
+
+  test('the same evidence always yields the identical frozen result object', () => {
+    const a = classifyAttemptFailure(evidence({ failureSignal: 'server_failure' }));
+    const b = classifyAttemptFailure(evidence({ failureSignal: 'server_failure' }));
+    expect(a).toBe(b);
+  });
+});
+
+describe('retry-safety and fail-closed invariants', () => {
+  test('a non-idempotent side effect is NEVER retryable, for every signal and budget', () => {
+    for (const failureSignal of SIGNALS) {
+      for (const retryBudget of BUDGETS) {
+        const result = classifyAttemptFailure(
+          evidence({ failureSignal, sideEffectIdempotency: 'non_idempotent', retryBudget }),
+        );
+        expect(result.retryable).toBe(false);
+        expect(result.disposition).not.toBe('retry_transient');
+      }
+    }
+  });
+
+  test('a transient failure on a non-idempotent effect quarantines instead of retrying', () => {
+    for (const failureSignal of TRANSIENT) {
+      for (const retryBudget of BUDGETS) {
+        const result = classifyAttemptFailure(
+          evidence({ failureSignal, sideEffectIdempotency: 'non_idempotent', retryBudget }),
+        );
+        expect(result.disposition).toBe('quarantine_permanent');
+      }
+    }
+  });
+
+  test.each(['permanent_client_error', 'malformed_response', 'conflict', 'unknown'])(
+    '%s never retries and quarantines regardless of idempotency/budget',
+    (failureSignal) => {
+      for (const sideEffectIdempotency of IDEMPOTENCY) {
+        for (const retryBudget of BUDGETS) {
+          const result = classifyAttemptFailure(
+            evidence({ failureSignal, sideEffectIdempotency, retryBudget }),
+          );
+          expect(result.disposition).toBe('quarantine_permanent');
+          expect(result.retryable).toBe(false);
+        }
+      }
+    },
+  );
+
+  test('duplicate_replay is ignored (already applied) regardless of idempotency/budget', () => {
+    for (const sideEffectIdempotency of IDEMPOTENCY) {
+      for (const retryBudget of BUDGETS) {
+        const result = classifyAttemptFailure(
+          evidence({ failureSignal: 'duplicate_replay', sideEffectIdempotency, retryBudget }),
+        );
+        expect(result.disposition).toBe('ignore_duplicate');
+        expect(result.retryable).toBe(false);
+      }
+    }
+  });
+
+  test.each(TRANSIENT)(
+    'idempotent %s retries while budget remains and dead-letters when exhausted',
+    (failureSignal) => {
+      const withBudget = classifyAttemptFailure(
+        evidence({ failureSignal, sideEffectIdempotency: 'idempotent', retryBudget: 'available' }),
+      );
+      expect(withBudget.disposition).toBe('retry_transient');
+      expect(withBudget.retryable).toBe(true);
+
+      const exhausted = classifyAttemptFailure(
+        evidence({ failureSignal, sideEffectIdempotency: 'idempotent', retryBudget: 'exhausted' }),
+      );
+      expect(exhausted.disposition).toBe('dead_letter');
+      expect(exhausted.retryable).toBe(false);
+    },
+  );
+
+  test('the classifier itself performs no side effect (verdict is advisory only)', () => {
+    // A retryable verdict is still just a recommendation: nothing is retried,
+    // sent, or persisted. We assert the result is a plain frozen data object.
+    const result = classifyAttemptFailure(evidence());
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(typeof result).toBe('object');
+    expect(Object.values(result).every((v) =>
+      typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')).toBe(true);
+  });
+});
+
+describe('malformed and hostile input is rejected without echo', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['string', HOSTILE_CANARY],
+    ['number', 7],
+    ['boolean', true],
+    ['array', [HOSTILE_CANARY]],
+  ])('rejects a non-object (%s)', (_label, value) => {
+    expectRejected(value);
+  });
+
+  test('rejects the wrong schema version', () => {
+    expectRejected(evidence({ failureDispositionSchemaVersion: 2 }));
+    expectRejected(evidence({ failureDispositionSchemaVersion: '1' }));
+    expectRejected(evidence({ failureDispositionSchemaVersion: 0 }));
+  });
+
+  test.each([
+    ['failureSignal', 'not_a_signal'],
+    ['sideEffectIdempotency', 'maybe'],
+    ['retryBudget', 'infinite'],
+  ])('rejects an unknown %s enum value', (field, value) => {
+    expectRejected(evidence({ [field]: value }));
+  });
+
+  test('rejects an output-only disposition value smuggled into an input field', () => {
+    expectRejected(evidence({ failureSignal: 'retry_transient' }));
+    expectRejected(evidence({ failureSignal: 'quarantine_permanent' }));
+  });
+
+  test('rejects a boolean where an enum is required', () => {
+    expectRejected(evidence({ failureSignal: false }));
+    expectRejected(evidence({ retryBudget: 0 }));
+  });
+
+  test('rejects a missing required field', () => {
+    const e = evidence();
+    delete e.retryBudget;
+    expectRejected(e);
+  });
+
+  test('rejects an extra field even when the known fields are valid', () => {
+    expectRejected(evidence({ note: HOSTILE_CANARY }));
+  });
+
+  test('rejects a Proxy without tripping its traps', () => {
+    const target = evidence();
+    const proxy = new Proxy(target, {
+      get() { throw new Error('proxy get trap must not run'); },
+    });
+    expectRejected(proxy);
+  });
+
+  test('rejects an accessor field without invoking the getter', () => {
+    let invoked = false;
+    const hostile = {
+      failureDispositionSchemaVersion: 1,
+      failureSignal: 'timeout',
+      sideEffectIdempotency: 'idempotent',
+    };
+    Object.defineProperty(hostile, 'retryBudget', {
+      enumerable: true,
+      configurable: true,
+      get() { invoked = true; return HOSTILE_CANARY; },
+    });
+    expectRejected(hostile);
+    expect(invoked).toBe(false);
+  });
+
+  test('rejects inherited (non-own) fields', () => {
+    const base = evidence();
+    const derived = Object.create(base);
+    expectRejected(derived);
+  });
+
+  test('rejects an object whose prototype is not Object.prototype', () => {
+    const nullProto = Object.assign(Object.create(null), evidence());
+    expectRejected(nullProto);
+  });
+});
+
+describe('frozen versioned surface', () => {
+  test('publishes revision 1 and deeply frozen enums', () => {
+    expect(failureDispositionSchemaVersion).toBe(1);
+    expect(Object.isFrozen(FAILURE_DISPOSITION_ENUMS)).toBe(true);
+    for (const values of Object.values(FAILURE_DISPOSITION_ENUMS)) {
+      expect(Object.isFrozen(values)).toBe(true);
+    }
+  });
+
+  test('publishes the closed input and output vocabularies', () => {
+    expect(FAILURE_DISPOSITION_ENUMS.failureSignal).toEqual([
+      'timeout',
+      'connection_lost',
+      'rate_limited',
+      'server_failure',
+      'external_dependency_failure',
+      'permanent_client_error',
+      'malformed_response',
+      'conflict',
+      'unknown',
+      'duplicate_replay',
+    ]);
+    expect(FAILURE_DISPOSITION_ENUMS.sideEffectIdempotency).toEqual(['idempotent', 'non_idempotent']);
+    expect(FAILURE_DISPOSITION_ENUMS.retryBudget).toEqual(['available', 'exhausted']);
+    expect([...FAILURE_DISPOSITION_ENUMS.disposition].sort()).toEqual([
+      'dead_letter',
+      'ignore_duplicate',
+      'quarantine_permanent',
+      'retry_transient',
+    ]);
+  });
+
+  test('the error is frozen, carries no own enumerable state, and serializes empty', () => {
+    const err = new CommerceFailureDispositionError();
+    expect(Object.isFrozen(err)).toBe(true);
+    expect(Object.keys(err)).toEqual([]);
+    expect(JSON.stringify(err)).toBe('{}');
+    expect(err.name).toBe('CommerceFailureDispositionError');
+    expect(err.code).toBe('invalid_failure_disposition_evidence');
+  });
+});
+
+describe('source boundary — pure, unused, provider-agnostic', () => {
+  const modulePath = path.join(__dirname, 'commerceFailureDisposition.js');
+  const source = fs.readFileSync(modulePath, 'utf8');
+
+  test('is not imported by the functions runtime entry point', () => {
+    const indexPath = path.join(__dirname, 'index.js');
+    const index = fs.readFileSync(indexPath, 'utf8');
+    expect(index).not.toContain('commerceFailureDisposition');
+  });
+
+  test('requires only node:util', () => {
+    const requires = [...source.matchAll(/require\(([^)]*)\)/g)].map((m) => m[1].trim());
+    expect(requires).toEqual(["'node:util'"]);
+  });
+
+  test('reads no clock, randomness, environment, network, or provider surface', () => {
+    for (const forbidden of [
+      /process\.env/,
+      /Date\.now/,
+      /new Date/,
+      /Math\.random/,
+      /console\./,
+      /fetch\(/,
+      /https?:/,
+      /firebase/i,
+      /firestore/i,
+      /stripe/i,
+    ]) {
+      expect(source).not.toMatch(forbidden);
+    }
+  });
+
+  test('carries no PII, credential, or provider-identifier field vocabulary', () => {
+    for (const forbidden of [
+      /phone/i,
+      /address/i,
+      /\bdob\b/i,
+      /\bssn\b/i,
+      /secret/i,
+      /\btoken\b/i,
+      /password/i,
+      /bearer/i,
+      /api[_-]?key/i,
+    ]) {
+      expect(source).not.toMatch(forbidden);
+    }
+  });
+
+  test('hard-codes the retry-safety invariant in the frozen results', () => {
+    expect(source).toContain('retryable');
+    expect(source).toContain("frozenDisposition('retry_transient', true)");
+    expect(source).toContain("frozenDisposition('dead_letter', false)");
+    expect(source).toContain("frozenDisposition('quarantine_permanent', false)");
+    expect(source).toContain("frozenDisposition('ignore_duplicate', false)");
+  });
+});


### PR DESCRIPTION
## PAY-003C1 — commerce attempt-failure disposition (source only, unused)

**Draft for owner review.** Parent: #106 (PAY-003). Sibling of the delivery-topology validator (#364, `functions/commerceOutboxState.js`), and of `functions/commerceProviderResult.js` / `functions/commerceProviderReconciliation.js`. Closes #377.

### What this is
One new **pure, unused** CommonJS module, `functions/commerceFailureDisposition.js`, that classifies a single failed side-effect delivery attempt into a retry-vs-terminal disposition. The sibling `commerceOutboxState.js` (#364) validates the delivery-state *topology* but is handed its target state — it never derives *which* target a failure warrants; `commerceProviderResult.js` / `commerceProviderReconciliation.js` answer business-advance-vs-reconcile and never emit a retry-vs-permanent verdict. This slice fills only that classification gap as design source.

`classifyAttemptFailure(evidence)` maps an exact four-field revision-1 record over closed vocabularies:

- `failureDispositionSchemaVersion` (`1`)
- `failureSignal` — `timeout` · `connection_lost` · `rate_limited` · `server_failure` · `external_dependency_failure` · `permanent_client_error` · `malformed_response` · `conflict` · `unknown` · `duplicate_replay`
- `sideEffectIdempotency` — `idempotent` · `non_idempotent`
- `retryBudget` — `available` · `exhausted`

### The invariants it encodes
1. **A non-idempotent effect is never retried.** A transient failure on a `non_idempotent` side effect fails closed to `quarantine_permanent`, never `retry_transient` — so the deferred worker can never double-apply an external create/refund/send. This is the safety-critical rule; every non-`retry_transient` verdict carries `retryable: false`.
2. **Retry budget is an input, not a policy.** The module invents no count, backoff, TTL, threshold, or alert value — the caller's remaining allowance arrives as `retryBudget` evidence and is only *read*. Those policy values stay with the PAY-003C worker (#110).
3. **Fail closed on the unclassifiable.** `conflict` and `unknown` (and any non-transient signal) go to `quarantine_permanent` for reconciliation/alerting rather than being guessed at.

### Dispositions
`classifyAttemptFailure(evidence)` returns one of four frozen dispositions:

| disposition | retryable | when |
|---|---|---|
| `ignore_duplicate` | false | `duplicate_replay` — the effect already landed (idempotent replay); no new delivery |
| `quarantine_permanent` | false | any non-transient signal (`permanent_client_error`, `malformed_response`, `conflict`, `unknown`), **or** a transient signal on a `non_idempotent` effect |
| `retry_transient` | true | a transient signal on an `idempotent` effect while `retryBudget` is `available` |
| `dead_letter` | false | a transient signal on an `idempotent` effect once `retryBudget` is `exhausted` |

### Safety / boundary
- Throwing idiom mirrors `commerceProviderReconciliation.js`: one fixed `CommerceFailureDispositionError` on malformed / proxy / accessor / inherited / extra-or-missing-key / unknown-enum / wrong-version input, and it **never echoes the input**.
- Evidence values are drawn only from closed vocabularies — no free-form identifiers are accepted at all, so nothing PII-shaped can ride in.
- Requires only `node:util`; imported by no runtime path or Functions index; reads no clock/random/env/network; stores and logs nothing.

### Invents no policy
No retry counts, backoff schedules, TTLs, thresholds, or alerting SLAs — those stay with the PAY-003C worker (#110) and the owner. This module derives the disposition **verdict** only; it enqueues nothing, retries nothing, and touches no provider. The actual retry/quarantine/dead-letter execution and outbox transitions stay gated on the remaining PAY-003 worker work.

### Tests
44 source tests: an exhaustive `failureSignal` × `sideEffectIdempotency` × `retryBudget` matrix (40 combinations) checked against an **independent oracle** — every result is frozen, exact-shape, reachable, and `retryable` only for `retry_transient`, and identical input yields the identical frozen object; retry-safety invariants (non-idempotent never retryable; transient + non_idempotent → quarantine; permanent/malformed/conflict/unknown → quarantine; duplicate → ignore; transient idempotent available → retry, exhausted → dead_letter); hostile/malformed-input rejection without echo (primitives, wrong version, unknown enums, output value smuggled into input, boolean-where-enum, missing/extra field, Proxy, accessor getter, inherited, null-proto); a frozen versioned surface (deeply frozen enums, exact published vocabularies, error frozen with no own keys); and a source-boundary guard (no clock/env/network/PII/credential vocabulary, single `node:util` require, not imported by `index.js`, all four `frozenDisposition('X', bool)` literals hard-coded).

### SYSTEM_DESIGN
Adds a `### PAY-003C1 commerce attempt-failure disposition — SOURCE ONLY, UNUSED` subsection at the end of §6, immediately before §7, with a mermaid decision flowchart and a text alternative. Additive documentation only.

### Not deployment
Contract/source and a green workflow prove none of: website publication, Firebase deployment, provider configuration, or production verification. This module changes no officer task, changes no live behavior, and does not claim or complete PAY-003's implementation, which stays gated on the remaining worker work (#110).
