### PR TITLE
WEB-UX: polish shared page hero semantics

### DIFF
--- a/.github/lint-baseline.json
+++ b/.github/lint-baseline.json
@@ -10,20 +10,20 @@
   "targets": [
     "src"
   ],
-  "scannedFileCount": 108,
+  "scannedFileCount": 109,
   "scannedFilesByExtension": {
     ".js": 12,
     ".jsx": 35,
-    ".ts": 35,
+    ".ts": 36,
     ".tsx": 26
   },
-  "errorCount": 121,
+  "errorCount": 119,
   "warningCount": 6,
   "errorsByExtension": {
     ".js": 2,
     ".jsx": 26,
     ".ts": 2,
-    ".tsx": 91
+    ".tsx": 89
   },
   "warningsByExtension": {
     ".js": 0,
@@ -31,10 +31,11 @@
     ".ts": 0,
     ".tsx": 6
   },
-  "fingerprint": "sha256:47ec0995a4a8bcd84d2b0870cfccfc97c3eceada243fa62e5eac6c8eb7682409",
+  "fingerprint": "sha256:608fd51b4e05bce9a9c0a773f777c78daebec1e8b851471f3f87551b35a3c6a2",
   "scannedFiles": [
     "src/App.jsx",
     "src/App.test.jsx",
+    "src/assets.d.ts",
     "src/components/AnnouncementBanner.jsx",
     "src/components/Card.jsx",
     "src/components/ErrorBoundary.tsx",
@@ -1324,32 +1325,6 @@
       "message": "Do not nest ternary expressions.",
       "messageId": "noNestedTernary",
       "nodeType": "ConditionalExpression",
-      "fatal": false
-    },
-    {
-      "file": "src/pages/events/Events.tsx",
-      "line": 130,
-      "column": 47,
-      "endLine": 130,
-      "endColumn": 54,
-      "severity": 2,
-      "ruleId": "react/jsx-one-expression-per-line",
-      "message": "`Error: ` must be placed on a new line",
-      "messageId": "moveToNewLine",
-      "nodeType": "JSXText",
-      "fatal": false
-    },
-    {
-      "file": "src/pages/events/Events.tsx",
-      "line": 130,
-      "column": 54,
-      "endLine": 130,
-      "endColumn": 61,
-      "severity": 2,
-      "ruleId": "react/jsx-one-expression-per-line",
-      "message": "`{error}` must be placed on a new line",
-      "messageId": "moveToNewLine",
-      "nodeType": "JSXExpressionContainer",
       "fatal": false
     },
     {

--- a/docs/officers/UPDATE_PUBLIC_CONTENT.md
+++ b/docs/officers/UPDATE_PUBLIC_CONTENT.md
@@ -35,7 +35,7 @@ Helpful request:
 2. Confirm the correct name and role of each person shown.
 3. Use a clear JPG or PNG; a square photo works best for officers.
 4. Remove private location or device information when possible.
-5. Tell AI where the photo should appear and provide a short description for screen readers.
+5. Tell AI where the photo should appear. Provide a short description for screen readers unless the photo is only decorative.
 6. Review the crop on phone and computer views.
 7. Confirm the page title and first line of content begin below the blue navigation bar.
 
@@ -53,7 +53,7 @@ Do not publish photos of minors, private events, name badges, addresses, license
 
 - The exact change appears on `runmprc.com`.
 - Every new link opens correctly without requiring editor access.
-- Photos have correct names and descriptions.
+- Photos have correct names and descriptions, or are correctly marked decorative.
 - Each intended page shows its header photo, and no page text is hidden behind the navigation bar.
 - No unrelated page changed.
 - The delivery report separates “merged” from “verified live.”

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -226,8 +226,15 @@ test('renders the Auth action route and removes its query and fragment before us
 
   render(<App />);
 
+  expect(screen.getAllByRole('heading', {
+    level: 1,
+  })).toHaveLength(1);
   expect(screen.getByRole('heading', {
     level: 1,
+    name: /verify your email/i,
+  })).toBeInTheDocument();
+  expect(screen.getByRole('heading', {
+    level: 2,
     name: /email verification/i,
   })).toBeInTheDocument();
   expect(screen.queryByRole('heading', {

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.jpg' {
+  const source: string;
+  export default source;
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,11 +6,11 @@ function Header({ title, image, children }) {
     <header className="header">
       <div className="header__container">
         <div className="header__container-lg">
-          <img src={image} alt="Mid-Peninsula Running Club" />
+          <img src={image} alt="" aria-hidden="true" />
         </div>
         <div className="header__content">
-          <h2>{title}</h2>
-          <p>{children}</p>
+          <h1>{title}</h1>
+          {children && <p>{children}</p>}
         </div>
       </div>
     </header>
@@ -20,7 +20,7 @@ function Header({ title, image, children }) {
 Header.propTypes = {
   title: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 export default Header;

--- a/src/headerClearance.test.js
+++ b/src/headerClearance.test.js
@@ -1,7 +1,10 @@
 /* eslint-env jest */
 
+import React from 'react';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { render, screen } from '@testing-library/react';
+import Header from './components/Header';
 
 const readStylesheet = (...parts) => readFileSync(join(__dirname, ...parts), 'utf8');
 
@@ -97,17 +100,33 @@ describe('persistent navigation clearance', () => {
   });
 });
 
-describe('top-level page hero coverage', () => {
-  test.each([
-    ['Events', 'pages', 'events', 'Events.tsx'],
-    ['MPRC Shop', 'pages', 'shop', 'Shop.tsx'],
-    ['My Account', 'pages', 'account', 'Account.tsx'],
-  ])('%s includes the shared image header', (title, ...sourcePath) => {
-    const source = readStylesheet(...sourcePath);
+describe('shared page header semantics', () => {
+  test('renders one page heading, a decorative image, and its description', () => {
+    const view = render(
+      React.createElement(
+        Header,
+        { image: '/synthetic-events.jpg', title: 'Events' },
+        'Runs and social gatherings.',
+      ),
+    );
 
-    expect(source).toMatch(/import Header from ['"]\.\.\/\.\.\/components\/Header['"]/);
-    expect(source).toMatch(/import HeaderImage from ['"]\.\.\/\.\.\/images\/[^'"]+['"]/);
-    expect(source).toContain(`<Header title="${title}" image={HeaderImage}>`);
+    expect(screen.getByRole('heading', { level: 1, name: 'Events' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Runs and social gatherings.')).toBeInTheDocument();
+    const image = view.container.querySelector('.header__container-lg img');
+    expect(image).toHaveAttribute('alt', '');
+    expect(image).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('omits an empty description for self-closing page headers', () => {
+    const view = render(React.createElement(
+      Header,
+      { image: '/synthetic-activities.jpg', title: 'Activities' },
+    ));
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Activities' }))
+      .toBeInTheDocument();
+    expect(view.container.querySelector('.header__content p')).toBeNull();
   });
 });
 

--- a/src/index.css
+++ b/src/index.css
@@ -290,7 +290,8 @@ section {
   color: var(--color-gray-100);
 }
 
-.header__content h2 {
+.header__content h1 {
+  font-size: 2rem;
   margin-bottom: 1rem;
 }
 

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -25,7 +25,7 @@ import {
   stravaFetchStats,
   verifyStravaState,
 } from '../../services/strava/stravaService';
-import { AccountContent } from './Account';
+import AccountPage, { AccountContent, AccountPageShell } from './Account';
 import StravaCallback from './StravaCallback';
 
 const mockCaptureException = jest.fn();
@@ -152,7 +152,9 @@ function accountView(user = USER) {
         v7_startTransition: true,
       }}
     >
-      <AccountContent user={user} />
+      <AccountPageShell>
+        <AccountContent user={user} />
+      </AccountPageShell>
     </MemoryRouter>
   );
 }
@@ -226,6 +228,51 @@ describe('Account profile recovery', () => {
     expect(calls).toEqual(['ensure', 'read']);
     expect(ensureMyProfile).toHaveBeenCalledWith(app);
     expect(getMyProfile).toHaveBeenCalledWith(firestore, USER.uid);
+  });
+
+  test('shows the shared page hero while authentication is loading', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+      user: null,
+    });
+    const view = render(
+      <MemoryRouter
+        future={{
+          v7_relativeSplatPath: true,
+          v7_startTransition: true,
+        }}
+      >
+        <AccountPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: 'My Account' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Loading...');
+    expect(view.container.querySelectorAll('.header')).toHaveLength(1);
+  });
+
+  test('keeps one decorative page hero while the profile loads and becomes ready', async () => {
+    const request = accountDeferred<{ ready: true }>();
+    (ensureMyProfile as jest.Mock).mockReturnValueOnce(request.promise);
+    const view = renderAccount();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'My Account' }))
+      .toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    const image = view.container.querySelector('.header__container-lg img');
+    expect(image).toHaveAttribute('alt', '');
+    expect(image).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+
+    await act(async () => request.resolve({ ready: true }));
+
+    expect(await screen.findByText('Synthetic Member')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 2, name: 'Account details' }))
+      .toBeInTheDocument();
+    expect(view.container.querySelectorAll('.header')).toHaveLength(1);
   });
 
   test('describes an empty registration result as no current account link', async () => {
@@ -719,6 +766,12 @@ describe('Account profile recovery', () => {
       expect(screen.queryByText('$12.34')).not.toBeInTheDocument();
       expect(screen.queryByText('private-registration')).not.toBeInTheDocument();
       expect(screen.queryByTestId('strava-section')).not.toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 1, name: 'My Account' }))
+        .toBeInTheDocument();
+      expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+      expect(screen.getByRole('heading', { level: 2, name: 'Sign out' }))
+        .toBeInTheDocument();
+      expect(document.querySelectorAll('.header')).toHaveLength(1);
     });
 
     test('keeps the private pending boundary after the command resolves', async () => {

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -5,8 +5,6 @@ import { Link, Navigate, useLocation } from 'react-router-dom';
 import { Timestamp } from 'firebase/firestore';
 import SEO from '../../components/SEO';
 import Header from '../../components/Header';
-// TypeScript does not have an image-module declaration in this legacy app.
-// @ts-expect-error Webpack resolves imported JPG assets to public URLs.
 import HeaderImage from '../../images/joinus/header_bg_1.jpg';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { useAuth } from '../../services/hooks/useAuth';
@@ -33,6 +31,18 @@ function tsToDate(ts: Timestamp | null | undefined) {
 }
 
 const VERIFICATION_RESEND_COOLDOWN_SECONDS = 60;
+
+export function AccountPageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SEO title="My Account" noindex />
+      <Header title="My Account" image={HeaderImage}>
+        Manage your MPRC profile, registrations, and connected services.
+      </Header>
+      {children}
+    </>
+  );
+}
 
 function ResendVerificationButton() {
   const { services } = useServiceLocator();
@@ -486,10 +496,8 @@ export function AccountContent({
     }
 
     return (
-      <>
-        <SEO title="My Account" noindex />
+      <div className="account-content">
         <div className="account-sign-out container mx-auto p-4 max-w-3xl">
-          <h1 className="text-2xl font-bold">My Account</h1>
           <section className="account-sign-out__panel" aria-labelledby="sign-out-heading">
             <h2 id="sign-out-heading" className="account-sign-out__heading">
               Sign out
@@ -519,14 +527,16 @@ export function AccountContent({
             </button>
           </section>
         </div>
-      </>
+      </div>
     );
   }
 
   if (!profileBelongsToCurrentContext || profileState === 'loading') {
     return (
-      <div role="status" className="container mx-auto p-6">
-        Loading profile...
+      <div className="account-content">
+        <div role="status" className="container mx-auto p-6">
+          Loading profile...
+        </div>
       </div>
     );
   }
@@ -553,14 +563,10 @@ export function AccountContent({
   ) || [];
 
   return (
-    <>
-      <SEO title="My Account" noindex />
-      <Header title="My Account" image={HeaderImage}>
-        Manage your MPRC profile, registrations, and connected services.
-      </Header>
+    <div className="account-content">
       <div className="container mx-auto p-4 max-w-3xl">
         <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold">My Account</h1>
+          <h2 className="text-2xl font-bold">Account details</h2>
           <button
             type="button"
             onClick={handleSignOut}
@@ -752,15 +758,21 @@ export function AccountContent({
 
         {profileState === 'ready' && <StravaSection uid={user.uid} />}
       </div>
-    </>
+    </div>
   );
 }
 
-function Account() {
+export function Account() {
   const { user, isLoading, isAuthenticated } = useAuth();
   const location = useLocation();
 
-  if (isLoading) return <div className="container mx-auto p-6">Loading...</div>;
+  if (isLoading) {
+    return (
+      <AccountPageShell>
+        <div role="status" className="container mx-auto p-6">Loading...</div>
+      </AccountPageShell>
+    );
+  }
   if (!isAuthenticated || !user) {
     return (
       <Navigate
@@ -770,7 +782,11 @@ function Account() {
       />
     );
   }
-  return <AccountContent user={user} />;
+  return (
+    <AccountPageShell>
+      <AccountContent user={user} />
+    </AccountPageShell>
+  );
 }
 
 export default Account;

--- a/src/pages/events/Events.tsx
+++ b/src/pages/events/Events.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import SEO from '../../components/SEO';
 import Header from '../../components/Header';
-// @ts-expect-error Webpack resolves imported JPG assets to public URLs.
 import HeaderImage from '../../images/activities/header_bg_1.jpg';
 import {
   listPublicEvents,
@@ -127,7 +126,13 @@ function Events() {
           </Link>
         </div>
         {loading && <p className="text-gray-500">Loading events...</p>}
-        {error && <EventsSubscriptionAlertBox>Error: {error}</EventsSubscriptionAlertBox>}
+        {error && (
+          <EventsSubscriptionAlertBox>
+            Error:
+            {' '}
+            {error}
+          </EventsSubscriptionAlertBox>
+        )}
         {!loading && !error && events.length === 0 && (
           <p className="text-gray-500">No events scheduled at this time.</p>
         )}

--- a/src/pages/login/VerifyEmailAction.test.tsx
+++ b/src/pages/login/VerifyEmailAction.test.tsx
@@ -15,10 +15,6 @@ jest.mock('../../services/ServiceLocatorContext', () => ({
   useServiceLocator: jest.fn(),
 }));
 
-jest.mock('../../components/Header', () => function Header({ title }: { title: string }) {
-  return <div>{title}</div>;
-});
-
 jest.mock('../../components/SEO', () => function SEO() {
   return null;
 });
@@ -127,6 +123,11 @@ describe('VerifyEmailAction', () => {
     );
     expect(verifyEmailAction).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Verify email' })).toBeEnabled();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1, name: 'Verify your email' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Email verification' }))
+      .toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(token);
     expect(document.body).not.toHaveTextContent(fragment);
   });

--- a/src/pages/login/VerifyEmailAction.tsx
+++ b/src/pages/login/VerifyEmailAction.tsx
@@ -218,9 +218,9 @@ function VerifyEmailAction() {
       </Header>
       <div className="container mx-auto px-4 py-10 flex justify-center">
         <section className="verify-email-panel" aria-labelledby="verify-email-title">
-          <h1 id="verify-email-title" className="text-xl font-semibold">
+          <h2 id="verify-email-title" className="text-xl font-semibold">
             Email verification
-          </h1>
+          </h2>
 
           {viewState === 'ready' && (
             <p>

--- a/src/pages/shop/Shop.tsx
+++ b/src/pages/shop/Shop.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../components/SEO';
 import Header from '../../components/Header';
-// @ts-expect-error Webpack resolves imported JPG assets to public URLs.
 import HeaderImage from '../../images/home/mprc_home.jpg';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { Product } from '../../types/shop';
@@ -33,7 +32,7 @@ function Shop() {
         Club merchandise and gear for the MPRC community.
       </Header>
       <div className="container mx-auto p-4 max-w-5xl">
-        <h1 className="text-2xl font-bold mb-4">MPRC Shop</h1>
+        <h2 className="text-2xl font-bold mb-4">Available merchandise</h2>
         {loading && <p className="text-gray-500">Loading...</p>}
         {error && <p role="alert" aria-live="assertive" aria-atomic="true" className="text-red-500">{error}</p>}
         {!loading && !error && products.length === 0 && (

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -35,8 +35,8 @@ const CLEAN_COMMANDS = Object.freeze([
   'test -z "$frontend_git_status"',
 ]);
 const LINT_SCRIPT = 'node .github/scripts/check-frontend-lint.cjs';
-const EXPECTED_LINT_FILES = 108;
-const EXPECTED_LINT_ERRORS = 121;
+const EXPECTED_LINT_FILES = 109;
+const EXPECTED_LINT_ERRORS = 119;
 const EXPECTED_LINT_WARNINGS = 6;
 const YAML_TO_JSON = [
   'require "yaml"',


### PR DESCRIPTION
Closes #390

## Outcome

Corrects the shared page-hero and My Account shell findings discovered during post-merge review of #387:

- every shared page hero now supplies the single page `h1`;
- atmospheric hero photos are decorative (`alt=""`, `aria-hidden="true"`);
- optional hero descriptions no longer create empty paragraphs;
- Shop and My Account use meaningful `h2` section labels instead of repeating the page title;
- the email-verification action keeps its panel heading at `h2`, preserving one page `h1`;
- My Account keeps one hero through Auth loading, profile loading/ready, and sign-out-result states;
- one typed JPG module replaces three `@ts-expect-error` comments;
- rendered tests replace source-regex coverage and exercise Header semantics and Account states;
- two pre-existing Events JSX lint records are retired while touching that line.

The shared `#main-content` navigation clearance remains unchanged.

## Review findings addressed

- P2 malformed heading hierarchy — fixed across all shared Header consumers, including the email-verification action, with rendered assertions added.
- P2 misleading hero alt text — fixed with decorative semantics.
- P2 Account hero missing from loading/sign-out states — fixed with `AccountPageShell`.
- P3 brittle source-regex tests — replaced with Testing Library behavior assertions.
- P3 repeated image-import suppressions — replaced with `src/assets.d.ts`.
- P3 required children/empty paragraph — made optional and conditional.

## Verification

- `node .github/scripts/check-frontend-lint.cjs` — 109 files; 119 reviewed legacy errors; 6 warnings; passed
- `CI=true npm test -- --watchAll=false --runInBand` — 13 suites, 644 tests passed
- `CI=true npm test -- --watchAll=false --runInBand src/App.test.jsx src/headerClearance.test.js src/pages/account/Account.test.tsx src/pages/login/VerifyEmailAction.test.tsx` — 4 suites, 438 tests passed at final test head
- `npm run test:spa-navigation` — 11 tests passed
- protected workflow/release/artifact suite — 54 tests passed
- `CI=true DISABLE_ESLINT_PLUGIN=true npx --no-install react-scripts build` — passed
- Desktop local production build: Events navigation bottom 88px; hero top 88px; `h1 Events` then `h2 Upcoming Events`; decorative loaded image; no overflow
- 390x844 local production build: Shop navigation bottom 88px; hero top 88px; `h1 MPRC Shop` then `h2 Available merchandise`; decorative loaded image; no overflow

## Safety and release

No Firebase, Stripe, account permissions, member data, payment behavior, provider configuration, or production state changes. Undo is one revert of this PR; retain the shared navigation clearance.

**Merged/source-only warning:** #387 is merged but not released. Netlify production remains at `e86a0f702cff6495f50630c5de3337290db8b8cb`, 124 commits behind the #387 merge. Publishing current `main` ad hoc would release unrelated source-only changes, so this PR must not trigger or authorize production publication.

Officer impact: page titles have a coherent screen-reader hierarchy; atmospheric photos no longer announce misleading text; My Account keeps a stable header while loading or reporting sign-out status.

Officer documentation: `docs/officers/UPDATE_PUBLIC_CONTENT.md`

Deployment evidence: local production build only at this point. Firebase and providers unchanged. `runmprc.com` unchanged. Netlify production publication is explicitly out of scope and blocked pending a separately approved exact-delta release path.



