### PR TITLE
MEMBERS-ADMIN-001A: project officer manual off-platform dues-evidence into an approved term decision (#395)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -566,6 +566,27 @@ This contract does not verify a person, payment, plan, evidence item, refund, di
 
 The module is imported by no runtime or Functions index. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, changes no current profile/role/claim, and cannot make #81, annual renewal, discounts, roster export, or officer membership tools available. Source tests and a merge are not Firebase deployment or live behavior proof.
 
+### 8.0b Officer manual off-platform dues-evidence command — SOURCE ONLY, UNUSED
+
+MEMBERS-ADMIN-001A [#395](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/395) defines one unused pure contract for the first MEMBERS-ADMIN-001 [#115](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/115) behavior: recording an owner-approved off-platform dues confirmation for a membership term without creating or claiming a Stripe payment. It turns one exact officer-audit envelope into the exact approved `record_term_decision` command the §8.0a reducer already accepts, plus a paired immutable audit record stamped with an off-platform provenance. It decides no policy; every owner-meaningful value is carried through as an opaque token.
+
+```mermaid
+flowchart LR
+    O["Officer-attested off-platform dues-evidence envelope"] --> V{"Exact envelope: opaque actor / capability / recent-auth / evidence references, safe-integer revisions, half-open term window?"}
+    V -- "Missing, malformed, non-opaque, out of range, reversed, or wrong version" --> F["One fixed fail-closed error, no command"]
+    V -- "Valid" --> C["Approved record_term_decision command, owner values carried through verbatim"]
+    V -- "Valid" --> A["Paired audit record: provenance manual_off_platform, no Stripe or charge identifier"]
+    C --> R["§8.0a reducer accepts the command and approves the linked term"]
+```
+
+Text alternative: a well-formed officer envelope — bounded opaque references for actor, capability, recent authentication, membership, evidence category, evidence, reason, and correlation; safe-integer expected and term revisions; an opaque term ID, plan reference, and policy version; and a half-open start/end window — projects the exact approved `record_term_decision` command the §8.0a reducer accepts, plus a paired immutable audit record stamped with an off-platform provenance and carrying no Stripe or charge identifier. Any missing, extra, non-opaque, out-of-range, reversed, wrong-version, accessor, or proxy input fails closed through one fixed error and produces no command.
+
+The CommonJS module validates one exact envelope with the same fail-closed primitives as §8.0a — bounded server-minted opaque identifiers, safe-integer revisions and half-open time bounds, exact plain objects only — and returns two frozen values: the reducer command, whose command type and `approved` term state are the fixed identity of this manual path, and the audit record, which names who acted, under what capability and recent re-authentication, on which membership and term, with what off-platform evidence category and reference, and why. The audit record carries no Stripe, charge, session, or contact identifier, so "records dues without claiming an external charge" is a testable invariant. The module re-declares the reducer's validation primitives and its command schema version locally so the contract stays standalone; an integration test imports the shipped reducer and fails if that version ever drifts.
+
+This contract does not verify an actor, capability, recent authentication, evidence item, plan, price, term calendar, or policy decision. It does not read or write the authoritative record, mint the applied prior/new revision, stamp a server time, record a command result, associate a UID, refresh or revoke entitlement, or register a durable command ID for replay. Its identifier grammar is not a semantic privacy classifier; a future trusted runtime must mint every opaque value, verify the officer's capability and recent authentication under AUTH-003, establish each referenced fact, apply the command against the current record, and persist the completed audit entry.
+
+The module is imported by no runtime or Functions index. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, changes no current profile/role/claim, mints no identifier, and cannot make manual dues recording, an officer review queue, or any officer membership tool available. Source tests and a merge are not Firebase deployment or live behavior proof.
+
 ### 8.1 Paid race registration
 
 PAY-001B1 [#219](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/219) adds only the browser projection and first two server validation steps below. The website sends the active field set and omits volunteer tier. The callable preserves the opaque event ID, accepts an exact bounded envelope before Firestore, matches answers against the admitted selected server fields, and encodes callback values. It does not add the target request ID, snapshot, transaction, reservation, idempotent Session saga, safe confirmation capability, deployment, or live proof.

--- a/functions/membershipManualEvidence.js
+++ b/functions/membershipManualEvidence.js
@@ -1,0 +1,222 @@
+'use strict';
+
+// Source-only, unused contract (MEMBERS-ADMIN-001A). Given one officer-attested
+// off-platform dues-evidence command, it validates an exact officer-audit
+// envelope and projects two paired, frozen values: the exact
+// `record_term_decision` input the shipped membership authority reducer accepts,
+// and an immutable audit record stamped with a manual, off-platform provenance.
+// It invents no policy (every owner-meaningful value is carried through as an
+// opaque token), reads no stored record, contacts no provider, and fabricates
+// no external charge state. No runtime imports it.
+
+const { types: { isProxy } } = require('node:util');
+
+// This slice owns the audit-record schema version.
+const membershipManualEvidenceSchemaVersion = 1;
+// The shipped reducer's command schema version, re-declared locally so this
+// contract stays standalone. The integration test imports the real reducer and
+// fails if this constant ever drifts from it.
+const MEMBERSHIP_AUTHORITY_SCHEMA_VERSION = 1;
+
+const MEMBERSHIP_MANUAL_EVIDENCE_ERROR_MESSAGE = 'Membership manual evidence input is invalid.';
+const MAX_TIME_MS = 8_640_000_000_000_000;
+const OPAQUE_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+// Structural constants this slice always emits; none is an owner policy value.
+const RECORD_TERM_DECISION_COMMAND_TYPE = 'record_term_decision';
+const APPROVED_TERM_STATE = 'approved';
+const MANUAL_OFF_PLATFORM_PROVENANCE = 'manual_off_platform';
+
+const OFFICER_COMMAND_FIELDS = Object.freeze([
+  'membershipManualEvidenceSchemaVersion',
+  'commandId',
+  'actorRef',
+  'capabilityRef',
+  'recentAuthRef',
+  'membershipId',
+  'evidenceCategoryRef',
+  'evidenceRef',
+  'reasonRef',
+  'correlationRef',
+  'expectedRevision',
+  'termRevision',
+  'termId',
+  'startsAtMs',
+  'endsAtMs',
+  'planRef',
+  'policyVersion',
+]);
+
+const MEMBERSHIP_MANUAL_EVIDENCE_ENUMS = Object.freeze({
+  provenance: Object.freeze([MANUAL_OFF_PLATFORM_PROVENANCE]),
+  termState: Object.freeze([APPROVED_TERM_STATE]),
+});
+
+class MembershipManualEvidenceError extends Error {
+  constructor() {
+    super(MEMBERSHIP_MANUAL_EVIDENCE_ERROR_MESSAGE);
+    Object.defineProperty(this, 'name', {
+      value: 'MembershipManualEvidenceError',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'message', {
+      value: MEMBERSHIP_MANUAL_EVIDENCE_ERROR_MESSAGE,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'code', {
+      value: 'invalid_membership_manual_evidence',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Error.captureStackTrace?.(this, MembershipManualEvidenceError);
+    Object.freeze(this);
+  }
+}
+
+function fail() {
+  throw new MembershipManualEvidenceError();
+}
+
+function readDataObject(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+  if (prototype !== Object.prototype) fail();
+
+  const data = Object.create(null);
+  for (const key of keys) {
+    if (typeof key !== 'string' || Object.prototype.hasOwnProperty.call(data, key)) fail();
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    data[key] = descriptor.value;
+  }
+  return { data, keys };
+}
+
+function readExactObject(value, expectedFields) {
+  const { data, keys } = readDataObject(value);
+  if (keys.length !== expectedFields.length) fail();
+  const keySet = new Set(keys);
+  if (expectedFields.some((field) => !keySet.has(field))) fail();
+  return data;
+}
+
+function requireVersion(value) {
+  if (value !== membershipManualEvidenceSchemaVersion) fail();
+}
+
+function requireOpaqueIdentifier(value) {
+  if (typeof value !== 'string' || !OPAQUE_IDENTIFIER_PATTERN.test(value)) fail();
+  return value;
+}
+
+function requireRevision(value, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) fail();
+  return value;
+}
+
+function requireTime(value) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_TIME_MS) fail();
+  return value;
+}
+
+function projectManualDuesEvidence(input) {
+  const command = readExactObject(input, OFFICER_COMMAND_FIELDS);
+  requireVersion(command.membershipManualEvidenceSchemaVersion);
+
+  const commandId = requireOpaqueIdentifier(command.commandId);
+  const actorRef = requireOpaqueIdentifier(command.actorRef);
+  const capabilityRef = requireOpaqueIdentifier(command.capabilityRef);
+  const recentAuthRef = requireOpaqueIdentifier(command.recentAuthRef);
+  const membershipId = requireOpaqueIdentifier(command.membershipId);
+  const evidenceCategoryRef = requireOpaqueIdentifier(command.evidenceCategoryRef);
+  const evidenceRef = requireOpaqueIdentifier(command.evidenceRef);
+  const reasonRef = requireOpaqueIdentifier(command.reasonRef);
+  const correlationRef = requireOpaqueIdentifier(command.correlationRef);
+  const expectedRevision = requireRevision(command.expectedRevision, 1);
+  const termRevision = requireRevision(command.termRevision, 1);
+  const termId = requireOpaqueIdentifier(command.termId);
+  const startsAtMs = requireTime(command.startsAtMs);
+  const endsAtMs = requireTime(command.endsAtMs);
+  if (startsAtMs >= endsAtMs) fail();
+  const planRef = requireOpaqueIdentifier(command.planRef);
+  const policyVersion = requireOpaqueIdentifier(command.policyVersion);
+
+  // The exact `record_term_decision` command the shipped reducer accepts. The
+  // command type and the approved term state are the fixed identity of this
+  // slice; every other value is carried through from the officer envelope.
+  const reducerCommand = Object.freeze({
+    membershipAuthoritySchemaVersion: MEMBERSHIP_AUTHORITY_SCHEMA_VERSION,
+    commandType: RECORD_TERM_DECISION_COMMAND_TYPE,
+    commandId,
+    expectedRevision,
+    termRevision,
+    termState: APPROVED_TERM_STATE,
+    termId,
+    startsAtMs,
+    endsAtMs,
+    planRef,
+    evidenceRef,
+    policyVersion,
+  });
+
+  // The paired audit record: who acted, under what capability and recent
+  // re-auth, on which membership and term, with what off-platform evidence, and
+  // why. It is stamped manual/off-platform and carries no external charge
+  // identifier, so "records dues without claiming an external charge" stays a
+  // testable invariant.
+  const auditRecord = Object.freeze({
+    membershipManualEvidenceSchemaVersion,
+    provenance: MANUAL_OFF_PLATFORM_PROVENANCE,
+    membershipId,
+    commandId,
+    actorRef,
+    capabilityRef,
+    recentAuthRef,
+    evidenceCategoryRef,
+    evidenceRef,
+    reasonRef,
+    correlationRef,
+    termId,
+    termState: APPROVED_TERM_STATE,
+    startsAtMs,
+    endsAtMs,
+    planRef,
+    policyVersion,
+  });
+
+  return Object.freeze({ reducerCommand, auditRecord });
+}
+
+Object.freeze(MembershipManualEvidenceError.prototype);
+Object.freeze(MembershipManualEvidenceError);
+
+module.exports = Object.freeze({
+  membershipManualEvidenceSchemaVersion,
+  MEMBERSHIP_MANUAL_EVIDENCE_ENUMS,
+  MembershipManualEvidenceError,
+  projectManualDuesEvidence,
+});

--- a/functions/membershipManualEvidence.test.js
+++ b/functions/membershipManualEvidence.test.js
@@ -1,0 +1,391 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { inspect } = require('node:util');
+
+const {
+  membershipManualEvidenceSchemaVersion,
+  MEMBERSHIP_MANUAL_EVIDENCE_ENUMS,
+  MembershipManualEvidenceError,
+  projectManualDuesEvidence,
+} = require('./membershipManualEvidence');
+
+const {
+  membershipAuthoritySchemaVersion,
+  createMembershipAuthority,
+  applyMembershipAuthorityCommand,
+  deriveMembershipEntitlement,
+} = require('./membershipAuthority');
+
+const HOSTILE_CANARY = 'private-member@example.test/+12025550208?token=do-not-copy';
+const TERM_START_MS = 1_000_000;
+const TERM_END_MS = 2_000_000;
+
+const OPAQUE_FIELDS = [
+  'commandId',
+  'actorRef',
+  'capabilityRef',
+  'recentAuthRef',
+  'membershipId',
+  'evidenceCategoryRef',
+  'evidenceRef',
+  'reasonRef',
+  'correlationRef',
+  'termId',
+  'planRef',
+  'policyVersion',
+];
+
+function officerCommand(overrides = {}) {
+  return {
+    membershipManualEvidenceSchemaVersion: 1,
+    commandId: 'cmd_manual_001',
+    actorRef: 'officer_001',
+    capabilityRef: 'cap_record_dues_001',
+    recentAuthRef: 'reauth_001',
+    membershipId: 'mbr_test_001',
+    evidenceCategoryRef: 'evcat_check_001',
+    evidenceRef: 'evidence_test_001',
+    reasonRef: 'reason_manual_001',
+    correlationRef: 'corr_001',
+    expectedRevision: 2,
+    termRevision: 1,
+    termId: 'term_test_2026',
+    startsAtMs: TERM_START_MS,
+    endsAtMs: TERM_END_MS,
+    planRef: 'plan_test_001',
+    policyVersion: 'policy_test_001',
+    ...overrides,
+  };
+}
+
+function createLinkedRecord() {
+  return applyMembershipAuthorityCommand(
+    createMembershipAuthority({
+      membershipAuthoritySchemaVersion: 1,
+      membershipId: 'mbr_test_001',
+      commandId: 'cmd_create_001',
+    }),
+    {
+      membershipAuthoritySchemaVersion: 1,
+      commandType: 'associate_account',
+      commandId: 'cmd_link_001',
+      expectedRevision: 1,
+      uid: 'uid_test_001',
+    },
+  );
+}
+
+function captureError(callback) {
+  try {
+    callback();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected callback to throw');
+}
+
+function expectSafeError(callback, rawValue = HOSTILE_CANARY) {
+  const error = captureError(callback);
+  expect(error).toBeInstanceOf(MembershipManualEvidenceError);
+  expect(error).toMatchObject({
+    name: 'MembershipManualEvidenceError',
+    code: 'invalid_membership_manual_evidence',
+    message: 'Membership manual evidence input is invalid.',
+  });
+  expect(Object.isFrozen(error)).toBe(true);
+  const rendered = [
+    error.message,
+    String(error),
+    JSON.stringify(error),
+    inspect(error),
+    error.stack,
+  ].join('\n');
+  if (rawValue) expect(rendered).not.toContain(rawValue);
+  expect(rendered).not.toContain(HOSTILE_CANARY);
+  return error;
+}
+
+function expectDeepFrozen(value) {
+  expect(Object.isFrozen(value)).toBe(true);
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value)) expectDeepFrozen(child);
+  }
+}
+
+describe('officer manual off-platform dues-evidence projection', () => {
+  test('exports one frozen versioned API and enum catalog', () => {
+    const api = require('./membershipManualEvidence');
+    expect(membershipManualEvidenceSchemaVersion).toBe(1);
+    expect(Object.isFrozen(api)).toBe(true);
+    expect(Object.isFrozen(MEMBERSHIP_MANUAL_EVIDENCE_ENUMS)).toBe(true);
+    for (const values of Object.values(MEMBERSHIP_MANUAL_EVIDENCE_ENUMS)) {
+      expect(Object.isFrozen(values)).toBe(true);
+    }
+    expect(MEMBERSHIP_MANUAL_EVIDENCE_ENUMS).toEqual({
+      provenance: ['manual_off_platform'],
+      termState: ['approved'],
+    });
+    expect(Object.isFrozen(MembershipManualEvidenceError)).toBe(true);
+    expect(Object.isFrozen(MembershipManualEvidenceError.prototype)).toBe(true);
+  });
+
+  test('projects the exact record_term_decision command and a paired manual audit record', () => {
+    const input = officerCommand();
+    const before = JSON.stringify(input);
+    const result = projectManualDuesEvidence(input);
+
+    expect(Object.keys(result)).toEqual(['reducerCommand', 'auditRecord']);
+    expect(result.reducerCommand).toEqual({
+      membershipAuthoritySchemaVersion: 1,
+      commandType: 'record_term_decision',
+      commandId: 'cmd_manual_001',
+      expectedRevision: 2,
+      termRevision: 1,
+      termState: 'approved',
+      termId: 'term_test_2026',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      evidenceRef: 'evidence_test_001',
+      policyVersion: 'policy_test_001',
+    });
+    expect(result.auditRecord).toEqual({
+      membershipManualEvidenceSchemaVersion: 1,
+      provenance: 'manual_off_platform',
+      membershipId: 'mbr_test_001',
+      commandId: 'cmd_manual_001',
+      actorRef: 'officer_001',
+      capabilityRef: 'cap_record_dues_001',
+      recentAuthRef: 'reauth_001',
+      evidenceCategoryRef: 'evcat_check_001',
+      evidenceRef: 'evidence_test_001',
+      reasonRef: 'reason_manual_001',
+      correlationRef: 'corr_001',
+      termId: 'term_test_2026',
+      termState: 'approved',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      policyVersion: 'policy_test_001',
+    });
+
+    expectDeepFrozen(result);
+    // Never mutates caller input.
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  test('returns distinct frozen records on each call so results cannot alias', () => {
+    const first = projectManualDuesEvidence(officerCommand());
+    const second = projectManualDuesEvidence(officerCommand());
+    expect(first).not.toBe(second);
+    expect(first.reducerCommand).not.toBe(second.reducerCommand);
+    expect(first.auditRecord).not.toBe(second.auditRecord);
+    expect(first).toEqual(second);
+  });
+
+  test('carries owner-meaningful values through verbatim, inventing none', () => {
+    const result = projectManualDuesEvidence(officerCommand({
+      termId: 'term_other_2027',
+      planRef: 'plan_other_002',
+      policyVersion: 'policy_other_002',
+      evidenceRef: 'evidence_other_002',
+      startsAtMs: 5,
+      endsAtMs: 6,
+    }));
+    expect(result.reducerCommand.termId).toBe('term_other_2027');
+    expect(result.reducerCommand.planRef).toBe('plan_other_002');
+    expect(result.reducerCommand.policyVersion).toBe('policy_other_002');
+    expect(result.reducerCommand.evidenceRef).toBe('evidence_other_002');
+    expect(result.reducerCommand.startsAtMs).toBe(5);
+    expect(result.reducerCommand.endsAtMs).toBe(6);
+    expect(result.auditRecord.termId).toBe('term_other_2027');
+    expect(result.auditRecord.planRef).toBe('plan_other_002');
+  });
+
+  test('emitted values carry no external charge or contact identifier', () => {
+    const result = projectManualDuesEvidence(officerCommand());
+    const rendered = JSON.stringify(result);
+    expect(rendered).not.toMatch(/stripe|session|payment|intent|charge|refund/i);
+    for (const key of [
+      ...Object.keys(result.reducerCommand),
+      ...Object.keys(result.auditRecord),
+    ]) {
+      expect(key).not.toMatch(/stripe|session|payment|intent|charge|refund|email|phone|price/i);
+    }
+    expect(result.auditRecord.provenance).toBe('manual_off_platform');
+  });
+});
+
+describe('acceptance by the shipped membership authority reducer', () => {
+  test('the projected command is accepted and approves the linked term', () => {
+    const linked = createLinkedRecord();
+    expect(linked.revision).toBe(2);
+
+    const { reducerCommand } = projectManualDuesEvidence(officerCommand());
+    // Re-declared version constant matches the shipped reducer's own version.
+    expect(reducerCommand.membershipAuthoritySchemaVersion)
+      .toBe(membershipAuthoritySchemaVersion);
+
+    const approved = applyMembershipAuthorityCommand(linked, reducerCommand);
+    expect(approved.revision).toBe(3);
+    expect(approved.term).toEqual({
+      state: 'approved',
+      termId: 'term_test_2026',
+      startsAtMs: TERM_START_MS,
+      endsAtMs: TERM_END_MS,
+      planRef: 'plan_test_001',
+      evidenceRef: 'evidence_test_001',
+      policyVersion: 'policy_test_001',
+      revision: 1,
+    });
+
+    const entitlement = deriveMembershipEntitlement({
+      membershipAuthoritySchemaVersion: 1,
+      record: approved,
+      uid: 'uid_test_001',
+      asOfMs: TERM_START_MS,
+    });
+    expect(entitlement).toEqual({
+      membershipAuthoritySchemaVersion: 1,
+      entitlement: 'current_member',
+      state: 'active',
+    });
+  });
+
+  test('the projected command stays an idempotent, replay-safe reducer command', () => {
+    const linked = createLinkedRecord();
+    const { reducerCommand } = projectManualDuesEvidence(officerCommand());
+    const approved = applyMembershipAuthorityCommand(linked, reducerCommand);
+    // Same command id + shape applied again is read-only, not a second write.
+    expect(applyMembershipAuthorityCommand(approved, reducerCommand)).toBe(approved);
+  });
+});
+
+describe('hostile input is rejected without leaking the raw value', () => {
+  test.each([
+    null,
+    undefined,
+    true,
+    false,
+    0,
+    1,
+    'string',
+    Symbol('s'),
+    [],
+    [officerCommand()],
+    () => officerCommand(),
+    Object.create(null),
+    Object.create({ email: HOSTILE_CANARY }),
+    new Date(0),
+    // eslint-disable-next-line no-new-wrappers
+    new Number(1),
+  ])('rejects non-plain root input case %#', (input) => {
+    expectSafeError(() => projectManualDuesEvidence(input));
+  });
+
+  test('rejects missing, extra, symbol, inherited, accessor, and proxy fields', () => {
+    for (const field of Object.keys(officerCommand())) {
+      const input = officerCommand();
+      delete input[field];
+      expectSafeError(() => projectManualDuesEvidence(input));
+    }
+    expectSafeError(() => projectManualDuesEvidence({
+      ...officerCommand(),
+      email: HOSTILE_CANARY,
+    }));
+    const symbolInput = officerCommand();
+    symbolInput[Symbol(HOSTILE_CANARY)] = true;
+    expectSafeError(() => projectManualDuesEvidence(symbolInput));
+    expectSafeError(() => projectManualDuesEvidence(Object.assign(
+      Object.create({ email: HOSTILE_CANARY }),
+      officerCommand(),
+    )));
+    const getterInput = officerCommand();
+    Object.defineProperty(getterInput, 'evidenceRef', {
+      get() {
+        throw new Error(HOSTILE_CANARY);
+      },
+      enumerable: true,
+    });
+    expectSafeError(() => projectManualDuesEvidence(getterInput));
+    expectSafeError(() => projectManualDuesEvidence(new Proxy(officerCommand(), {})));
+  });
+
+  test.each([
+    'private-member@example.test',
+    '+12025550208',
+    'https://example.test/member',
+    'member with spaces',
+    'member/with/path',
+    'éxternal',
+    '',
+    'a'.repeat(129),
+  ])('rejects non-opaque identifier %p in every opaque field', (value) => {
+    for (const field of OPAQUE_FIELDS) {
+      expectSafeError(
+        () => projectManualDuesEvidence(officerCommand({ [field]: value })),
+        value,
+      );
+    }
+  });
+
+  test.each([
+    NaN,
+    Infinity,
+    -Infinity,
+    -1,
+    0,
+    1.5,
+    -0,
+    '1',
+    2n,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid revision %p', (bad) => {
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({ expectedRevision: bad })));
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({ termRevision: bad })));
+  });
+
+  test.each([
+    NaN,
+    Infinity,
+    -1,
+    1.5,
+    '1000',
+    2n,
+    8_640_000_000_000_001,
+  ])('rejects invalid term time %p', (bad) => {
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({ startsAtMs: bad })));
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({ endsAtMs: bad })));
+  });
+
+  test('rejects equal and reversed term bounds', () => {
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({ startsAtMs: TERM_END_MS })));
+    expectSafeError(
+      () => projectManualDuesEvidence(officerCommand({ startsAtMs: TERM_END_MS + 1 })),
+    );
+  });
+
+  test('rejects an unsupported schema version', () => {
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({
+      membershipManualEvidenceSchemaVersion: 2,
+    })));
+    expectSafeError(() => projectManualDuesEvidence(officerCommand({
+      membershipManualEvidenceSchemaVersion: '1',
+    })));
+  });
+});
+
+describe('static non-adoption and dependency boundary', () => {
+  test('has no runtime edge, external SDK, clock, random, logger, environment, or provider field', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'membershipManualEvidence.js'), 'utf8');
+    const index = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+    expect(index).not.toContain('membershipManualEvidence');
+    expect(source).not.toMatch(/firebase|firestore|stripe|google|whatsapp|strava/i);
+    expect(source).not.toMatch(/process\.env|Date\.now|new Date|Math\.random|console\.|fetch\s*\(|https?:/);
+    expect(source).not.toMatch(/email|phone|address|dob|emergency|price|payment/i);
+    const requires = [...source.matchAll(/require\(([^)]+)\)/g)].map((match) => match[1]);
+    expect(requires).toEqual(["'node:util'"]);
+  });
+});


### PR DESCRIPTION
## MEMBERS-ADMIN-001A — officer manual off-platform dues-evidence → approved term decision

Closes #395. First slice of MEMBERS-ADMIN-001 (#115). **Source/test/design only — not deployed;** a green CI run does not make this live. Draft for review.

### What this adds

One unused, standalone pure module that turns an officer's **owner-approved, off-platform dues confirmation** into the exact `record_term_decision` command the shipped membership-authority reducer (#208, §8.0a) already accepts — **without creating or claiming a Stripe payment** (epic acceptance criterion #1). It decides no policy: every owner-meaningful value is carried through as an opaque token.

`projectManualDuesEvidence(envelope)` validates one exact officer-audit envelope with the **same fail-closed primitives as the reducer** (bounded opaque identifiers, safe-integer expected/term revisions, half-open start/end bounds, exact plain objects only) and returns two frozen values:

- **`reducerCommand`** — the exact 12-field `record_term_decision` input. `commandType` and the `approved` term state are the fixed identity of this manual path; `termId`, `planRef`, `policyVersion`, `evidenceRef`, and the term window are carried through verbatim.
- **`auditRecord`** — who acted, under what capability and recent re-authentication, on which membership and term, with what off-platform evidence category and reference, and why. Stamped `provenance: 'manual_off_platform'` and carrying **no Stripe / charge / session / contact identifier**, so "records dues without claiming an external charge" is a *testable* invariant.

### Proven against the shipped reducer

An integration test builds a real create→associate record (revision 2, linked) via the shipped `applyMembershipAuthorityCommand`, projects a command, and proves the reducer **accepts** it, advances to revision 3, approves the term to a `current_member` entitlement, and treats an exact replay as read-only. It also asserts the locally re-declared command schema version equals the reducer's own — so the standalone contract can't silently drift from #208.

### Boundary (why this is safe to land as source-only)

- The module imports only `node:util`, reads no clock/environment, calls no Firebase/Stripe/provider service, mints no identifier, and **is imported by no runtime or Functions index** — enforced by a static non-adoption test.
- **No `src/` change** — the website is byte-unaffected and the frontend lint baseline is untouched.
- Re-declares the reducer's primitives locally (like the sibling contracts) so it is independently reviewable.

### Deliberate deferrals (later children under #115 / owner-gated)

Runtime capability + recent-auth verification (AUTH-003); reading/writing the authoritative record; the applied prior/new revision, server time, and command result; the target-UID association (behavior #2, a separate command); entitlement refresh/revoke (behavior #3); the durable command-replay registry; append-only audit persistence; the officer review queue; Firestore schema/Rules; evidence-category vocabulary; prices, plans, grace, term calendars; migration; deployment; and live proof.

### Tests / validation

- New suite passes: **51 tests** (exact projection + paired audit shape, verbatim carry-through, distinct frozen results, no charge/contact identifier, full hostile-input matrix each failing closed through one fixed frozen error without leaking the raw value, static non-adoption boundary, and the reducer-acceptance integration).
- Functions **ESLint exits 0** on both new files. No Rules, type, build, or `src/` change.
- CI (Node 20) is the source of truth. *An unrelated Stripe-projection suite fails only on local Node 25 — a stricter `Error`-own-surface assertion sensitive to Node's internals; that file is byte-identical to `main` and green under CI's Node 20, and this slice does not touch it.*

### Not in scope / not claimed

Not deployed. No Firebase deploy, no Stripe/provider configuration, no production data, no live behavior, no officer capability. Deployment and live proof are recorded separately.
