### PR TITLE
PAY-003B2: add commerce event-inbox deduplication and ordering classifier

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -801,6 +801,35 @@ This contract invents no policy. It fixes no maximum retry count, backoff schedu
 
 The module is imported by no runtime or Functions index and requires only `node:util`. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, and changes no delivery, email, role, or business record. It does not persist or replay an outbox, define Firestore schema or Rules, run a retry or quarantine worker, or wire into `sendConfirmationEmail.js` or `stripeWebhook.js`. Source tests and a merge are not Firebase deployment or live behavior proof.
 
+### 8.5b Idempotent event-inbox deduplication and ordering disposition — SOURCE ONLY, UNUSED
+
+PAY-003B2 [#397](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/397) defines one unused pure contract for the *event inbox* named by parent PAY-003 [#106](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/106) and by §8.5: the ingress decision of whether one verified event, already reduced to closed evidence, should be processed, ignored, or quarantined *before* any canonical reducer runs. PAY-003A already claims events by id inline in `stripeWebhook.js`; this contract extracts the *decision itself* as a standalone, owner-reviewable function, exactly as PAY-003C1 extracted the failure decision. The pure `classifyEventInboxDisposition` policy reads one exact flat revision-1 evidence record `{ eventInboxSchemaVersion, priorRecord, objectOrdering }` drawn only from closed vocabularies and returns one frozen disposition — `process`, `reprocess_incomplete`, `ignore_duplicate`, `ignore_stale`, or `quarantine` — each carrying a boolean `appliesEffect`. `priorRecord` is the durable inbox state for the exact event id (`absent`, `pending`, `applied`, `ignored`, `quarantined`); `objectOrdering` is the incoming event's position relative to the last-applied state for the same business object (`first_for_object`, `advances`, `equal`, `stale`, `indeterminate`), supplied as evidence from current domain state because event order is not guaranteed. It imports only `node:util`.
+
+```mermaid
+flowchart TD
+    E["Exact revision-1 inbox evidence"] --> S{"id already applied or ignored?"}
+    S -- "Yes" --> Ig["ignore_duplicate"]
+    S -- "No" --> Qp{"id quarantined?"}
+    Qp -- "Yes" --> Qz["quarantine"]
+    Qp -- "No" --> Oi{"order indeterminate?"}
+    Oi -- "Yes" --> Qz
+    Oi -- "No" --> Os{"order stale?"}
+    Os -- "Yes" --> St["ignore_stale"]
+    Os -- "No" --> Oe{"order equal?"}
+    Oe -- "Yes" --> Ig
+    Oe -- "No" --> Pp{"prior attempt pending?"}
+    Pp -- "Yes" --> Rp["reprocess_incomplete (appliesEffect)"]
+    Pp -- "No" --> Pr["process (appliesEffect)"]
+```
+
+Text alternative: an event id already applied or already decided a no-op is ignored regardless of any fresh ordering claim; a quarantined id or an event whose order cannot be established fails closed to quarantine; a strictly older event is dropped as stale and a same-position event as a duplicate; only a fresh, in-order event that is not yet settled applies an effect — resuming a crashed `pending` attempt as `reprocess_incomplete` or a first-seen `absent` id as `process`.
+
+The safety invariant is that `appliesEffect` is true only for `process` and `reprocess_incomplete`, and only for a `first_for_object`/`advances` event whose `priorRecord` is `absent` or `pending`: an already-`applied` id can never re-apply (exactly-once), an `indeterminate` or `stale` order never applies (fail closed to quarantine or drop), and an `equal` order is an idempotent replay. Because the event id is the deduplication key, `applied` and `ignored` short-circuit ahead of the ordering test, so no late-arriving ordering evidence can re-drive a settled effect; `reprocess_incomplete` is safe only because the downstream canonical apply is itself idempotent.
+
+This contract invents no policy and duplicates no sibling. It fixes no retry count, backoff schedule, TTL, or dead-letter threshold — those stay with the deferred PAY-003C worker, `commerceFailureDisposition` (PAY-003C1, [#377](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/377)), and retention approval [#110](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/110). It decides *whether to admit an event*, never *whether a delivery step is legal* (the `commerceOutboxState` outbox contract, PAY-003B1, [#364](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/364)) and never *which target a failure warrants* (PAY-003C1). It computes no business transition — `functions/commerceState.js` owns the payment/registration/refund reducers that run only after this gate returns an applying verdict — and it does not call the `commerceProviderResult`/`commerceProviderReconciliation` classifiers. `priorRecord` and `objectOrdering` are closed enums, so no id, amount, address, or other PII-shaped value can ride in; malformed, proxy, accessor, inherited, extra-or-missing-key, unknown-enum, or wrong-version input throws one fixed `CommerceEventInboxError` that never echoes the input.
+
+The module is imported by no runtime or Functions index and requires only `node:util`. It reads no clock, randomness, environment, network, Firestore, or provider service; is imported by no endpoint; stores and logs nothing; and creates no inbox record, claim, deduplication write, quarantine, or business record. It defines no Firestore schema or Rules, runs no ingress verifier or worker, and wires into no `stripeWebhook.js` or reducer. Source change, tests, merge, Firebase deployment, provider configuration, production data, website publication, and live behavior remain separate states; #397 changes no officer task and proves none of the external or live states.
+
 ## 9. Consistency and failure model
 
 Stripe and Firestore cannot share a distributed transaction. Checkout and refunds are therefore explicit sagas:

--- a/functions/commerceEventInboxDisposition.js
+++ b/functions/commerceEventInboxDisposition.js
@@ -1,0 +1,209 @@
+const { types: { isProxy } } = require('node:util');
+
+const eventInboxSchemaVersion = 1;
+const EVENT_INBOX_ERROR_MESSAGE = 'Commerce event inbox evidence is invalid.';
+
+const EXPECTED_FIELDS = Object.freeze([
+  'eventInboxSchemaVersion',
+  'priorRecord',
+  'objectOrdering',
+]);
+
+const EVENT_INBOX_ENUMS = Object.freeze({
+  // The durable state of the inbox record for the exact incoming event id.
+  // `absent` is a genuinely first-seen delivery; every other value means a
+  // record for this exact id already exists.
+  priorRecord: Object.freeze([
+    // No inbox record for this event id yet — first delivery.
+    'absent',
+    // A record was claimed but processing did not finish (a crash mid-flight);
+    // the canonical apply is idempotent, so reprocessing is safe.
+    'pending',
+    // This event id was already fully processed — exactly-once boundary.
+    'applied',
+    // This event id was already decided a deliberate no-op (duplicate/stale).
+    'ignored',
+    // This event id was set aside for manual reconciliation.
+    'quarantined',
+  ]),
+  // How the incoming event's position relates to the last-applied event for the
+  // same business object. The event source does not guarantee order, so this is
+  // supplied as evidence from current domain state; it is never derived here.
+  objectOrdering: Object.freeze([
+    // No event has been applied for this object yet.
+    'first_for_object',
+    // The incoming event is strictly newer than the last-applied state.
+    'advances',
+    // The incoming event is at the same object position already applied.
+    'equal',
+    // The incoming event is strictly older; a newer state was already applied.
+    'stale',
+    // The relative order cannot be established — fail closed.
+    'indeterminate',
+  ]),
+  // Output-only dispositions.
+  disposition: Object.freeze([
+    'process',
+    'reprocess_incomplete',
+    'ignore_duplicate',
+    'ignore_stale',
+    'quarantine',
+  ]),
+});
+
+// Only the input enums are validated against the incoming evidence.
+const ENUM_SETS = Object.freeze({
+  priorRecord: new Set(EVENT_INBOX_ENUMS.priorRecord),
+  objectOrdering: new Set(EVENT_INBOX_ENUMS.objectOrdering),
+});
+
+class CommerceEventInboxError extends Error {
+  constructor() {
+    super(EVENT_INBOX_ERROR_MESSAGE);
+    Object.defineProperty(this, 'name', {
+      value: 'CommerceEventInboxError',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'message', {
+      value: EVENT_INBOX_ERROR_MESSAGE,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'code', {
+      value: 'invalid_event_inbox_evidence',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Error.captureStackTrace?.(this, CommerceEventInboxError);
+    Object.freeze(this);
+  }
+}
+
+function fail() {
+  throw new CommerceEventInboxError();
+}
+
+function readExactEvidence(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+
+  if (prototype !== Object.prototype || keys.length !== EXPECTED_FIELDS.length) fail();
+
+  const keySet = new Set();
+  for (const key of keys) {
+    if (typeof key !== 'string' || keySet.has(key)) fail();
+    keySet.add(key);
+  }
+  if (EXPECTED_FIELDS.some((field) => !keySet.has(field))) fail();
+
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) fail();
+  }
+
+  const evidence = Object.create(null);
+  for (const field of EXPECTED_FIELDS) {
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, field);
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    evidence[field] = descriptor.value;
+  }
+
+  if (evidence.eventInboxSchemaVersion !== eventInboxSchemaVersion) fail();
+
+  for (const [field, allowedValues] of Object.entries(ENUM_SETS)) {
+    if (!allowedValues.has(evidence[field])) fail();
+  }
+
+  return evidence;
+}
+
+function frozenDisposition(disposition, appliesEffect) {
+  return Object.freeze({
+    eventInboxSchemaVersion,
+    disposition,
+    // True only when the deferred worker should apply canonical/provider
+    // business effects for this event; every ignore/quarantine verdict is
+    // false, so a duplicate, stale, or unorderable event never re-applies.
+    appliesEffect,
+  });
+}
+
+const RESULTS = Object.freeze({
+  process: frozenDisposition('process', true),
+  reprocessIncomplete: frozenDisposition('reprocess_incomplete', true),
+  ignoreDuplicate: frozenDisposition('ignore_duplicate', false),
+  ignoreStale: frozenDisposition('ignore_stale', false),
+  quarantine: frozenDisposition('quarantine', false),
+});
+
+function classifyEventInboxDisposition(input) {
+  const { priorRecord, objectOrdering } = readExactEvidence(input);
+
+  // 1. Exactly-once boundary: an event id already fully applied, or already
+  //    decided a deliberate no-op, is never acted on again — even if fresh
+  //    ordering evidence looks newer. The event id is the idempotency key.
+  if (priorRecord === 'applied' || priorRecord === 'ignored') {
+    return RESULTS.ignoreDuplicate;
+  }
+
+  // 2. A quarantined record stays parked for manual reconciliation; new
+  //    ordering evidence never auto-releases it.
+  if (priorRecord === 'quarantined') {
+    return RESULTS.quarantine;
+  }
+
+  // 3. Order that cannot be established fails closed — never apply on a guess.
+  if (objectOrdering === 'indeterminate') {
+    return RESULTS.quarantine;
+  }
+
+  // 4. A strictly older event carries no new truth; a newer object state was
+  //    already applied, so drop it.
+  if (objectOrdering === 'stale') {
+    return RESULTS.ignoreStale;
+  }
+
+  // 5. An event at the same object position already applied is an idempotent
+  //    replay (possibly under a different event id) — no new effect.
+  if (objectOrdering === 'equal') {
+    return RESULTS.ignoreDuplicate;
+  }
+
+  // 6. Fresh (`first_for_object` or `advances`) and not yet applied. A pending
+  //    record means a prior attempt began but did not finish; because the
+  //    canonical apply is idempotent, reprocessing it is safe. An absent record
+  //    is a clean first-seen delivery.
+  return priorRecord === 'pending' ? RESULTS.reprocessIncomplete : RESULTS.process;
+}
+
+Object.freeze(CommerceEventInboxError.prototype);
+Object.freeze(CommerceEventInboxError);
+
+module.exports = Object.freeze({
+  eventInboxSchemaVersion,
+  EVENT_INBOX_ENUMS,
+  CommerceEventInboxError,
+  classifyEventInboxDisposition,
+});

--- a/functions/commerceEventInboxDisposition.test.js
+++ b/functions/commerceEventInboxDisposition.test.js
@@ -1,0 +1,429 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  eventInboxSchemaVersion,
+  EVENT_INBOX_ENUMS,
+  CommerceEventInboxError,
+  classifyEventInboxDisposition,
+} = require('./commerceEventInboxDisposition');
+
+// A value that must never be echoed back by a rejection: it stands in for a
+// business reference / opaque id that could ride in on a malformed field.
+const HOSTILE_CANARY = 'private-order-ref@example.test/+12025550123?token=do-not-copy';
+
+const RESULT_KEYS = ['eventInboxSchemaVersion', 'disposition', 'appliesEffect'];
+
+const PRIOR = EVENT_INBOX_ENUMS.priorRecord;
+const ORDERING = EVENT_INBOX_ENUMS.objectOrdering;
+const DISPOSITIONS = EVENT_INBOX_ENUMS.disposition;
+
+// Independent oracle — deliberately written differently from the module (a
+// lookup map + array membership rather than an if-ladder) so agreement is a
+// real cross-check, not a copy of the implementation.
+const APPLIED_OR_IGNORED = ['applied', 'ignored'];
+const FRESH_ORDER = ['first_for_object', 'advances'];
+const APPLYING_DISPOSITIONS = ['process', 'reprocess_incomplete'];
+
+function expectedDisposition(e) {
+  // Exactly-once boundary: an id already settled dominates every ordering claim.
+  if (APPLIED_OR_IGNORED.includes(e.priorRecord)) return 'ignore_duplicate';
+  if (e.priorRecord === 'quarantined') return 'quarantine';
+  // Ordering gate for a not-yet-settled id.
+  const orderVerdict = {
+    indeterminate: 'quarantine',
+    stale: 'ignore_stale',
+    equal: 'ignore_duplicate',
+  }[e.objectOrdering];
+  if (orderVerdict) return orderVerdict;
+  // Fresh and in-order: resume a crashed pending attempt, else first-seen apply.
+  return e.priorRecord === 'pending' ? 'reprocess_incomplete' : 'process';
+}
+
+function expectedAppliesEffect(e) {
+  return APPLYING_DISPOSITIONS.includes(expectedDisposition(e));
+}
+
+function evidence(overrides = {}) {
+  return {
+    eventInboxSchemaVersion: 1,
+    priorRecord: 'absent',
+    objectOrdering: 'advances',
+    ...overrides,
+  };
+}
+
+function classifyError(input) {
+  try {
+    classifyEventInboxDisposition(input);
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected classifyEventInboxDisposition to throw');
+}
+
+function expectRejected(input) {
+  const err = classifyError(input);
+  expect(err).toBeInstanceOf(CommerceEventInboxError);
+  expect(err.code).toBe('invalid_event_inbox_evidence');
+  expect(err.message).toBe('Commerce event inbox evidence is invalid.');
+  // The rejection must never echo the input back in any serialization.
+  expect(JSON.stringify(err) || '').not.toContain(HOSTILE_CANARY);
+  expect(String(err)).not.toContain(HOSTILE_CANARY);
+  expect(err.stack || '').not.toContain(HOSTILE_CANARY);
+}
+
+describe('event-inbox disposition matrix', () => {
+  const combos = [];
+  for (const priorRecord of PRIOR) {
+    for (const objectOrdering of ORDERING) {
+      combos.push(evidence({ priorRecord, objectOrdering }));
+    }
+  }
+
+  test('covers every priorRecord x objectOrdering combination exactly once', () => {
+    expect(combos).toHaveLength(PRIOR.length * ORDERING.length);
+    expect(combos).toHaveLength(25);
+    const seen = new Set(combos.map((e) => `${e.priorRecord}|${e.objectOrdering}`));
+    expect(seen.size).toBe(combos.length);
+  });
+
+  test('each verdict is a frozen, exactly-shaped disposition that matches the oracle', () => {
+    for (const e of combos) {
+      const result = classifyEventInboxDisposition(e);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(Object.keys(result)).toEqual(RESULT_KEYS);
+      expect(result.eventInboxSchemaVersion).toBe(1);
+      expect(DISPOSITIONS).toContain(result.disposition);
+      expect(typeof result.appliesEffect).toBe('boolean');
+      expect(result.disposition).toBe(expectedDisposition(e));
+      expect(result.appliesEffect).toBe(expectedAppliesEffect(e));
+    }
+  });
+
+  test('all five dispositions are reachable across the matrix', () => {
+    const produced = new Set(combos.map((e) => classifyEventInboxDisposition(e).disposition));
+    expect([...produced].sort()).toEqual([...DISPOSITIONS].sort());
+  });
+
+  test('appliesEffect is true only for process and reprocess_incomplete', () => {
+    for (const e of combos) {
+      const result = classifyEventInboxDisposition(e);
+      if (result.appliesEffect) {
+        expect(APPLYING_DISPOSITIONS).toContain(result.disposition);
+        expect(FRESH_ORDER).toContain(e.objectOrdering);
+        expect(['absent', 'pending']).toContain(e.priorRecord);
+      }
+    }
+  });
+
+  test('the same evidence always yields the identical frozen result object', () => {
+    const a = classifyEventInboxDisposition(evidence({ priorRecord: 'absent', objectOrdering: 'advances' }));
+    const b = classifyEventInboxDisposition(evidence({ priorRecord: 'absent', objectOrdering: 'advances' }));
+    expect(a).toBe(b);
+  });
+
+  test('distinct combinations that share a disposition return the identical singleton', () => {
+    // (applied, advances) and (ignored, stale) both settle to ignore_duplicate.
+    const viaApplied = classifyEventInboxDisposition(evidence({ priorRecord: 'applied', objectOrdering: 'advances' }));
+    const viaIgnored = classifyEventInboxDisposition(evidence({ priorRecord: 'ignored', objectOrdering: 'stale' }));
+    expect(viaApplied).toBe(viaIgnored);
+    expect(viaApplied.disposition).toBe('ignore_duplicate');
+  });
+});
+
+describe('exactly-once and fail-closed invariants', () => {
+  test('an already-applied event id is ignored for EVERY ordering, even a fresh one', () => {
+    for (const objectOrdering of ORDERING) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord: 'applied', objectOrdering }));
+      expect(result.disposition).toBe('ignore_duplicate');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test('an already-ignored event id stays ignored for EVERY ordering', () => {
+    for (const objectOrdering of ORDERING) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord: 'ignored', objectOrdering }));
+      expect(result.disposition).toBe('ignore_duplicate');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test('a quarantined event id stays quarantined for EVERY ordering (no auto-release)', () => {
+    for (const objectOrdering of ORDERING) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord: 'quarantined', objectOrdering }));
+      expect(result.disposition).toBe('quarantine');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test('an unorderable event NEVER applies an effect, for every not-yet-settled prior', () => {
+    for (const priorRecord of ['absent', 'pending']) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering: 'indeterminate' }));
+      expect(result.disposition).toBe('quarantine');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test('a stale event NEVER applies an effect (a newer state was already applied)', () => {
+    for (const priorRecord of ['absent', 'pending']) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering: 'stale' }));
+      expect(result.disposition).toBe('ignore_stale');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test.each(ORDERING)('indeterminate/stale ordering is never applied — sweep prior at ordering %s', (objectOrdering) => {
+    for (const priorRecord of PRIOR) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering }));
+      if (objectOrdering === 'indeterminate' || objectOrdering === 'stale') {
+        expect(result.appliesEffect).toBe(false);
+      }
+    }
+  });
+
+  test('an applied effect only ever comes from a fresh, in-order, not-yet-settled event', () => {
+    for (const priorRecord of PRIOR) {
+      for (const objectOrdering of ORDERING) {
+        const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering }));
+        if (result.appliesEffect) {
+          expect(FRESH_ORDER).toContain(objectOrdering);
+          expect(['absent', 'pending']).toContain(priorRecord);
+          // Never re-apply a settled id.
+          expect(priorRecord).not.toBe('applied');
+          expect(priorRecord).not.toBe('ignored');
+          expect(priorRecord).not.toBe('quarantined');
+        }
+      }
+    }
+  });
+
+  test('process is reachable ONLY from a first-seen (absent) event id', () => {
+    for (const priorRecord of PRIOR) {
+      for (const objectOrdering of ORDERING) {
+        const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering }));
+        if (result.disposition === 'process') {
+          expect(priorRecord).toBe('absent');
+          expect(FRESH_ORDER).toContain(objectOrdering);
+        }
+      }
+    }
+  });
+
+  test('a crashed pending attempt safely reprocesses when fresh and in order', () => {
+    for (const objectOrdering of FRESH_ORDER) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord: 'pending', objectOrdering }));
+      expect(result.disposition).toBe('reprocess_incomplete');
+      expect(result.appliesEffect).toBe(true);
+    }
+  });
+
+  test('a clean first-seen event in order processes', () => {
+    for (const objectOrdering of FRESH_ORDER) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord: 'absent', objectOrdering }));
+      expect(result.disposition).toBe('process');
+      expect(result.appliesEffect).toBe(true);
+    }
+  });
+
+  test('an equal-position event is an idempotent replay for every not-yet-settled prior', () => {
+    for (const priorRecord of ['absent', 'pending']) {
+      const result = classifyEventInboxDisposition(evidence({ priorRecord, objectOrdering: 'equal' }));
+      expect(result.disposition).toBe('ignore_duplicate');
+      expect(result.appliesEffect).toBe(false);
+    }
+  });
+
+  test('the classifier itself performs no side effect (verdict is advisory only)', () => {
+    // An applies-effect verdict is still just a recommendation: nothing is
+    // processed, sent, or persisted. We assert the result is a plain frozen
+    // data object of primitives.
+    const result = classifyEventInboxDisposition(evidence());
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(typeof result).toBe('object');
+    expect(Object.values(result).every((v) =>
+      typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')).toBe(true);
+  });
+});
+
+describe('malformed and hostile input is rejected without echo', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['string', HOSTILE_CANARY],
+    ['number', 7],
+    ['boolean', true],
+    ['array', [HOSTILE_CANARY]],
+  ])('rejects a non-object (%s)', (_label, value) => {
+    expectRejected(value);
+  });
+
+  test('rejects the wrong schema version', () => {
+    expectRejected(evidence({ eventInboxSchemaVersion: 2 }));
+    expectRejected(evidence({ eventInboxSchemaVersion: '1' }));
+    expectRejected(evidence({ eventInboxSchemaVersion: 0 }));
+  });
+
+  test.each([
+    ['priorRecord', 'not_a_state'],
+    ['objectOrdering', 'sideways'],
+  ])('rejects an unknown %s enum value', (field, value) => {
+    expectRejected(evidence({ [field]: value }));
+  });
+
+  test('rejects an output-only disposition value smuggled into an input field', () => {
+    expectRejected(evidence({ priorRecord: 'process' }));
+    expectRejected(evidence({ objectOrdering: 'quarantine' }));
+    expectRejected(evidence({ priorRecord: 'reprocess_incomplete' }));
+  });
+
+  test('rejects a boolean or number where an enum is required', () => {
+    expectRejected(evidence({ priorRecord: false }));
+    expectRejected(evidence({ objectOrdering: 0 }));
+  });
+
+  test('rejects a missing required field', () => {
+    const e = evidence();
+    delete e.objectOrdering;
+    expectRejected(e);
+  });
+
+  test('rejects an extra field even when the known fields are valid', () => {
+    expectRejected(evidence({ note: HOSTILE_CANARY }));
+  });
+
+  test('rejects a Proxy without tripping its traps', () => {
+    const target = evidence();
+    const proxy = new Proxy(target, {
+      get() { throw new Error('proxy get trap must not run'); },
+    });
+    expectRejected(proxy);
+  });
+
+  test('rejects an accessor field without invoking the getter', () => {
+    let invoked = false;
+    const hostile = {
+      eventInboxSchemaVersion: 1,
+      priorRecord: 'absent',
+    };
+    Object.defineProperty(hostile, 'objectOrdering', {
+      enumerable: true,
+      configurable: true,
+      get() { invoked = true; return HOSTILE_CANARY; },
+    });
+    expectRejected(hostile);
+    expect(invoked).toBe(false);
+  });
+
+  test('rejects inherited (non-own) fields', () => {
+    const base = evidence();
+    const derived = Object.create(base);
+    expectRejected(derived);
+  });
+
+  test('rejects an object whose prototype is not Object.prototype', () => {
+    const nullProto = Object.assign(Object.create(null), evidence());
+    expectRejected(nullProto);
+  });
+});
+
+describe('frozen versioned surface', () => {
+  test('publishes revision 1 and deeply frozen enums', () => {
+    expect(eventInboxSchemaVersion).toBe(1);
+    expect(Object.isFrozen(EVENT_INBOX_ENUMS)).toBe(true);
+    for (const values of Object.values(EVENT_INBOX_ENUMS)) {
+      expect(Object.isFrozen(values)).toBe(true);
+    }
+  });
+
+  test('publishes the closed input and output vocabularies', () => {
+    expect(EVENT_INBOX_ENUMS.priorRecord).toEqual([
+      'absent',
+      'pending',
+      'applied',
+      'ignored',
+      'quarantined',
+    ]);
+    expect(EVENT_INBOX_ENUMS.objectOrdering).toEqual([
+      'first_for_object',
+      'advances',
+      'equal',
+      'stale',
+      'indeterminate',
+    ]);
+    expect([...EVENT_INBOX_ENUMS.disposition].sort()).toEqual([
+      'ignore_duplicate',
+      'ignore_stale',
+      'process',
+      'quarantine',
+      'reprocess_incomplete',
+    ]);
+  });
+
+  test('the error is frozen, carries no own enumerable state, and serializes empty', () => {
+    const err = new CommerceEventInboxError();
+    expect(Object.isFrozen(err)).toBe(true);
+    expect(Object.keys(err)).toEqual([]);
+    expect(JSON.stringify(err)).toBe('{}');
+    expect(err.name).toBe('CommerceEventInboxError');
+    expect(err.code).toBe('invalid_event_inbox_evidence');
+  });
+});
+
+describe('source boundary — pure, unused, provider-agnostic', () => {
+  const modulePath = path.join(__dirname, 'commerceEventInboxDisposition.js');
+  const source = fs.readFileSync(modulePath, 'utf8');
+
+  test('is not imported by the functions runtime entry point', () => {
+    const indexPath = path.join(__dirname, 'index.js');
+    const index = fs.readFileSync(indexPath, 'utf8');
+    expect(index).not.toContain('commerceEventInboxDisposition');
+  });
+
+  test('requires only node:util', () => {
+    const requires = [...source.matchAll(/require\(([^)]*)\)/g)].map((m) => m[1].trim());
+    expect(requires).toEqual(["'node:util'"]);
+  });
+
+  test('reads no clock, randomness, environment, network, or provider surface', () => {
+    for (const forbidden of [
+      /process\.env/,
+      /Date\.now/,
+      /new Date/,
+      /Math\.random/,
+      /console\./,
+      /fetch\(/,
+      /https?:/,
+      /firebase/i,
+      /firestore/i,
+      /stripe/i,
+    ]) {
+      expect(source).not.toMatch(forbidden);
+    }
+  });
+
+  test('carries no PII, credential, or provider-identifier field vocabulary', () => {
+    for (const forbidden of [
+      /phone/i,
+      /address/i,
+      /\bdob\b/i,
+      /\bssn\b/i,
+      /secret/i,
+      /\btoken\b/i,
+      /password/i,
+      /bearer/i,
+      /api[_-]?key/i,
+    ]) {
+      expect(source).not.toMatch(forbidden);
+    }
+  });
+
+  test('hard-codes the exactly-once and fail-closed invariants in the frozen results', () => {
+    expect(source).toContain('appliesEffect');
+    expect(source).toContain("frozenDisposition('process', true)");
+    expect(source).toContain("frozenDisposition('reprocess_incomplete', true)");
+    expect(source).toContain("frozenDisposition('ignore_duplicate', false)");
+    expect(source).toContain("frozenDisposition('ignore_stale', false)");
+    expect(source).toContain("frozenDisposition('quarantine', false)");
+  });
+});


### PR DESCRIPTION
## What this is

**Draft — awaiting review.** A **pure, source-only, unused** deterministic classifier for the commerce **event inbox** ingress decision. Child **#397** under parent **PAY-003 (#106)** and §8.5. No runtime path imports it; it changes no officer-observable, Firebase, provider, or website behavior.

Same throwing-classifier idiom as the merged siblings `commerceOutboxState.js` (PAY-003B1, #364), `commerceFailureDisposition.js` (PAY-003C1, #377), and `commerceState.js`.

## The decision it isolates

Given one already-verified event reduced to closed evidence, should the inbox **process** it, safely **reprocess** it after a crash, **ignore** it as a duplicate or stale redelivery, or **quarantine** it because its order cannot be established? PAY-003A claims event ids inline in `stripeWebhook.js`; no existing module holds this ingress verdict. This adds exactly that, as one fixed function a later inbox worker can wire to.

`classifyEventInboxDisposition(evidence)` reads an exact three-field revision-1 record and returns one frozen verdict:

| field | closed vocabulary |
|---|---|
| `priorRecord` | `absent · pending · applied · ignored · quarantined` — durable inbox state for the exact event id |
| `objectOrdering` | `first_for_object · advances · equal · stale · indeterminate` — incoming event's position vs. last-applied state for the same object (supplied as evidence; source order is not guaranteed) |
| → `disposition` | `process · reprocess_incomplete · ignore_duplicate · ignore_stale · quarantine`, each with an `appliesEffect` boolean |

## Safety invariants

- **Exactly-once:** an already-`applied` (or `ignored`) id short-circuits to `ignore_duplicate` **ahead of** the ordering test, so no late-arriving ordering evidence can re-drive a settled effect. The event id is the idempotency key.
- **Fail closed:** a `quarantined` prior and an `indeterminate` order both go to `quarantine`; a `stale` order drops as `ignore_stale`; an `equal` order is an idempotent `ignore_duplicate`.
- **`appliesEffect` is true only** for `process`/`reprocess_incomplete`, and only for a fresh (`first_for_object`/`advances`) event whose prior record is `absent` or `pending`. `reprocess_incomplete` is safe only because the downstream canonical apply is itself idempotent.
- Closed enums only — no id, amount, address, or other PII-shaped value can ride in. Malformed, proxy, accessor, inherited, extra/missing-key, unknown-enum, or wrong-version input throws one fixed `CommerceEventInboxError` that never echoes the input.

## Out of scope (unchanged here)

No Firestore schema, Rules, index, endpoint, or `stripeWebhook.js` wiring; no retry count, backoff, TTL, dead-letter threshold, or alert (those stay with the deferred PAY-003C worker and #110); no persistence, claim, clock, randomness, network, or provider call.

## Evidence

- `functions/commerceEventInboxDisposition.js` — `node:util`-only; imported by no runtime path.
- `functions/commerceEventInboxDisposition.test.js` — **47 cases** green (full 5×5 matrix sweep, exactly-once/fail-closed invariants, hostile/malformed rejection battery, frozen-surface + source-boundary guards). Run with production secrets unset.
- `eslint .` clean (exit 0).
- SYSTEM_DESIGN.md **§8.5b** "SOURCE ONLY, UNUSED" entry (flowchart + text alternative + safety + sibling distinctions).

Source change, colocated tests, lint, and a merge are **source states only**. Firebase deployment, provider configuration, production data, website publication, and live `runmprc.com` behavior remain separate and unproven — a green CI run is not deployment.

Closes #397 on merge. Parent: #106.
