### PR TITLE
INSTAGRAM-002A: approval-gated social-post lifecycle and audit state, source only (#401)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -852,6 +852,34 @@ This contract invents no policy and duplicates no sibling. It is a *projection*,
 
 The module is imported by no runtime or Functions index and requires only `node:util`. It reads no clock, randomness, environment, network, Firestore, or provider service; is imported by no endpoint; stores and logs nothing; and creates, publishes, or persists no event, draft, or public record. It defines no Firestore schema or Rules, runs no importer or publish worker, and wires into no endpoint or Google-Site sync. Source change, tests, merge, Firebase deployment, provider configuration, production data, website publication, and live behavior remain separate states; #399 changes no officer task and proves none of the external or live states.
 
+### 8.7 Approval-gated social post lifecycle and audit — SOURCE ONLY, UNUSED
+
+INSTAGRAM-002A [#401](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/401) builds the first **conservative, safe-by-default** slice of parent INSTAGRAM-002 [#92](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/92): one unused pure contract for the *approval-gated lifecycle of a social post*, in the same non-throwing frozen-verdict idiom as the commerce outbox sibling (`commerceOutboxState`, §8.5a). It governs only *whether a lifecycle transition is allowed and whether a publish is authorized*, never a caption, media reference, or provider. The pure `classifySocialPostTransition(current, command)` reducer reads the durable record `{ socialPostSchemaVersion, lifecycleStatus, sourceKind, payloadHash, approvedHash, authorActor, approverActor }` and one exact revision-1 command `{ socialPostSchemaVersion, type, expectedLifecycle, payloadHash, actor, capability, selfApprovalAllowed }`, both drawn only from closed vocabularies and opaque tokens, and returns one frozen verdict — `applied`, `unchanged`, or `rejected` with a fixed reason code — never throwing and never echoing raw input. A companion `validateSocialPostRecord` validates the same durable record and returns a frozen canonical projection or a fixed rejection reason. It imports only `node:util`.
+
+```mermaid
+flowchart LR
+    Df["draft"] -->|"submit (officer)"| Pr["pending_review"]
+    Pr -->|"approve (reviewer)"| Ap["approved"]
+    Pr -->|"reject (reviewer)"| Df
+    Ap -->|"schedule (reviewer)"| Sc["scheduled"]
+    Sc -->|"begin_publish (system)"| Pb["publishing"]
+    Pb -->|"provider confirmed"| Pd["published"]
+    Pb -->|"provider failed"| Fa["failed"]
+    Pb -->|"provider indeterminate"| Ou["outcome_unknown"]
+    Fa -->|"retry (system)"| Sc
+    Ou -->|"reconciled published"| Pd
+    Ou -->|"reconciled failed"| Fa
+    Df -->|"edit — new hash, approval cleared"| Df
+```
+
+Text alternative: a post starts `draft`; an officer editor `submit`s it to `pending_review`; a reviewer `approve`s it to `approved` or `reject`s it back to `draft`; a reviewer `schedule`s an approved post; only a system publisher may `begin_publish` a scheduled post into `publishing`; the provider outcome resolves `publishing` to `published`, `failed`, or `outcome_unknown`; a system publisher may `retry` a `failed` post back to `scheduled`, and a system reconciler may settle an `outcome_unknown` post to `published` or `failed`. Any `edit` from a non-terminal editable state returns the post to `draft`, mints a new payload hash, and clears any recorded approval; `cancel` moves any non-publishing, non-terminal post to the terminal `cancelled`. Every human edge requires an officer capability and every machine edge a system capability, so a client that presents neither can drive no edge.
+
+The safety invariant is that **no post is published without a recorded human approval bound to its exact current payload hash**: the record itself is invalid in any `approved`/`scheduled`/`publishing`/`published`/`failed`/`outcome_unknown` state unless `approvedHash === payloadHash` and an `approverActor` is present, so an approval can never outlive the content it approved. Approval is recorded only by the `approve` command, only from `pending_review`, and only under a reviewer capability; any `edit` resets the lifecycle to `draft` and clears the approval, so a post edited after approval must be re-reviewed before it can schedule or publish. Self-approval — the same actor authoring and approving — is refused unless an explicit `selfApprovalAllowed` owner flag is set on the command, and defaults closed. A command names the `expectedLifecycle` it believes current, so a duplicate or concurrent command against an already-advanced post fails as `state_conflict` rather than re-applying, and an approval carrying a stale `payloadHash` fails as `stale_approval`.
+
+This contract invents no policy and duplicates no sibling. It is an approval-and-lifecycle reducer, not a projection or an admission gate: it decides *whether a lifecycle transition is legal and whether a publish is authorized*, never *what a public view may contain* (the `projectPublicEvent` projection, §8.6), *whether an event should be admitted* (the `commerceEventInboxDisposition` inbox gate, §8.5b), or *whether a delivery step is legal* (the `commerceOutboxState` outbox contract, §8.5a). It holds only opaque hashes, closed enums, and opaque capability-scoped actor tokens — never a caption, media reference, alt text, URL, timezone, disclosure flag, recipient, or request body; the canonical `payloadHash` **binds** content by equality without holding it. Only an intentionally public event source (`sourceKind: 'public_event'`) may become a post; membership, discount, WhatsApp, and Strava sources have no representation. The provider adapter, audit store, scheduling clock, retry and reconciliation cadence, Firestore schema/Rules, and endpoints remain with #92, #93, and their gating owner decisions; schema is additive by construction (a `socialPostSchemaVersion` constant) with no migration to run. Malformed, proxy, accessor-backed, inherited, extra-or-missing-key, unknown-enum, or wrong-version input is rejected through a fixed reason that never echoes the input.
+
+The module is imported by no runtime or Functions index and requires only `node:util`. It reads no clock, randomness, environment, network, Firestore, or provider service; is imported by no endpoint; stores and logs nothing; and creates, approves, schedules, publishes, or persists no post, draft, approval, or audit record. It defines no Firestore schema or Rules, runs no publish or reconciliation worker, and wires into no endpoint or Instagram/provider adapter. Source change, tests, merge, Firebase deployment, provider configuration, production data, website publication, and live behavior remain separate states; #401 changes no officer task and proves none of the external or live states.
+
 ## 9. Consistency and failure model
 
 Stripe and Firestore cannot share a distributed transaction. Checkout and refunds are therefore explicit sagas:

--- a/functions/socialPostState.js
+++ b/functions/socialPostState.js
@@ -1,0 +1,506 @@
+const { types: { isProxy } } = require('node:util');
+
+// INSTAGRAM-002A approval-gated social-post lifecycle and audit-safe state.
+//
+// Pure, source-only, unused. A provider-neutral reducer for the lifecycle of an
+// approved-before-published social post: given one durable post record and one
+// server command, decide whether the transition is allowed and produce the next
+// audit-safe record projection -- or a fixed rejection reason.
+//
+// Safety model:
+//   * Human approval is mandatory before publish and is bound to an exact
+//     canonical payload hash. Approving records `approvedHash := payloadHash`;
+//     ANY edit mints a new `payloadHash` and clears the approval. Every edge
+//     that advances toward publication (schedule, begin_publish, retry) requires
+//     a CURRENT approval whose hash equals the record's payload hash, so a stale
+//     approval can never authorize a publish. No path reaches `published`
+//     without a recorded approval matching the published payload.
+//   * Scoped verified identity. Every command is issued under a closed server
+//     capability. Officer capabilities drive human edges (submit, edit, approve,
+//     reject, schedule, cancel); system capabilities drive machine edges
+//     (begin_publish, provider result, retry, reconcile). A client can never
+//     present a system capability, so a client can never write provider or audit
+//     state. Self-approval is an explicit owner policy, fail-closed.
+//   * Audit-safe by construction. The record and every verdict carry only
+//     opaque hashes, closed enums, and opaque capability-scoped actor
+//     identifiers -- never a caption, media reference, alt text, URL, or request
+//     body. The verdict is exactly the shape an append-oriented audit entry may
+//     store. Only a public-event source may become a draft; membership,
+//     discount, and other protected sources have no representation here.
+//   * Optimistic concurrency. A command names the lifecycle it believes current;
+//     a mismatch is a `state_conflict`, so a duplicate or concurrent command
+//     cannot double-apply. A cancel of an already-cancelled post is idempotent.
+//
+// The canonical payload hash is computed by the caller from the canonical
+// content; this contract only binds and compares it by equality, never computes
+// it. No runtime path imports this module. It reads no clock, randomness,
+// network, environment, or provider; it logs nothing and persists nothing.
+
+const socialPostSchemaVersion = 1;
+
+// Opaque identifier for payload hashes and capability-scoped actor references:
+// unreserved characters only, bounded length. Never a name, email, address, or
+// other contact detail -- an opaque server-minted reference.
+const OPAQUE_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function immutableEnum(values) {
+  return Object.freeze(Object.fromEntries(values.map((value) => [
+    value.toUpperCase(),
+    value,
+  ])));
+}
+
+// The versioned post lifecycle. Publication is reachable only through the
+// approval-gated middle; failed/outcome_unknown are the provider-result
+// branches; published and cancelled are terminal.
+const SocialPostLifecycle = immutableEnum([
+  'draft',
+  'pending_review',
+  'approved',
+  'scheduled',
+  'publishing',
+  'published',
+  'failed',
+  'outcome_unknown',
+  'cancelled',
+]);
+
+const LIFECYCLE_SET = new Set(Object.values(SocialPostLifecycle));
+
+// Closed command vocabulary. Human commands carry an actor; system commands do
+// not. Each maps to exactly one target lifecycle state.
+const SocialPostCommandType = immutableEnum([
+  'submit',
+  'edit',
+  'approve',
+  'reject',
+  'schedule',
+  'begin_publish',
+  'provider_confirmed',
+  'provider_failed',
+  'provider_indeterminate',
+  'retry',
+  'reconciled_published',
+  'reconciled_failed',
+  'cancel',
+]);
+
+const COMMAND_TYPE_SET = new Set(Object.values(SocialPostCommandType));
+
+// Closed server capability vocabulary. Officer capabilities are exercised by a
+// verified human; system capabilities by a verified server worker. A browser
+// client can present neither a system capability nor forge an officer one.
+const SocialPostCapability = immutableEnum([
+  'officer_editor',
+  'officer_reviewer',
+  'officer_admin',
+  'system_publisher',
+  'system_reconciler',
+]);
+
+const CAPABILITY_SET = new Set(Object.values(SocialPostCapability));
+const SYSTEM_CAPABILITIES = new Set(['system_publisher', 'system_reconciler']);
+
+// Only an intentionally public event may become a draft. Membership, discount,
+// messaging, and activity sources have no representation here at all.
+const SocialPostSource = immutableEnum(['public_event']);
+const SOURCE_SET = new Set(Object.values(SocialPostSource));
+
+const EDITOR_CAPABILITIES = new Set(['officer_editor', 'officer_admin']);
+const REVIEWER_CAPABILITIES = new Set(['officer_reviewer', 'officer_admin']);
+
+// Per command: the states it may leave, the single state it enters, the allowed
+// capability set, whether it is a human (actor-bearing) or system command, and
+// how it touches approval. The "no publish without a current approval" property
+// is a record invariant (see validateSocialPostRecord), not a per-edge gate, so
+// no command needs a separate approval flag.
+const COMMANDS = Object.freeze({
+  submit: commandSpec(['draft'], 'pending_review', EDITOR_CAPABILITIES, 'human', 'preserve'),
+  edit: commandSpec(
+    ['draft', 'pending_review', 'approved', 'scheduled'],
+    'draft', EDITOR_CAPABILITIES, 'human', 'reset',
+  ),
+  approve: commandSpec(['pending_review'], 'approved', REVIEWER_CAPABILITIES, 'human', 'record'),
+  reject: commandSpec(['pending_review'], 'draft', REVIEWER_CAPABILITIES, 'human', 'preserve'),
+  schedule: commandSpec(['approved'], 'scheduled', REVIEWER_CAPABILITIES, 'human', 'preserve'),
+  begin_publish: commandSpec(['scheduled'], 'publishing', publisherOnly(), 'system', 'preserve'),
+  provider_confirmed: commandSpec(['publishing'], 'published', publisherOnly(), 'system', 'preserve'),
+  provider_failed: commandSpec(['publishing'], 'failed', publisherOnly(), 'system', 'preserve'),
+  provider_indeterminate: commandSpec(
+    ['publishing'], 'outcome_unknown', publisherOnly(), 'system', 'preserve',
+  ),
+  retry: commandSpec(['failed'], 'scheduled', publisherOnly(), 'system', 'preserve'),
+  reconciled_published: commandSpec(
+    ['outcome_unknown'], 'published', reconcilerOnly(), 'system', 'preserve',
+  ),
+  reconciled_failed: commandSpec(
+    ['outcome_unknown'], 'failed', reconcilerOnly(), 'system', 'preserve',
+  ),
+  cancel: commandSpec(
+    ['draft', 'pending_review', 'approved', 'scheduled', 'failed', 'outcome_unknown'],
+    'cancelled', REVIEWER_CAPABILITIES, 'human', 'preserve',
+  ),
+});
+
+function commandSpec(from, to, capabilities, kind, approvalEffect) {
+  return Object.freeze({
+    from: new Set(from),
+    to,
+    capabilities,
+    kind,
+    approvalEffect,
+  });
+}
+
+function publisherOnly() {
+  return new Set(['system_publisher']);
+}
+
+function reconcilerOnly() {
+  return new Set(['system_reconciler']);
+}
+
+// Lifecycle states that require a recorded, current approval to be coherent.
+const APPROVED_LIFECYCLE = new Set([
+  'approved',
+  'scheduled',
+  'publishing',
+  'published',
+  'failed',
+  'outcome_unknown',
+]);
+// Lifecycle states that must NOT carry any approval yet.
+const UNAPPROVED_LIFECYCLE = new Set(['draft', 'pending_review']);
+
+const EXPECTED_RECORD_KEYS = Object.freeze([
+  'socialPostSchemaVersion',
+  'lifecycleStatus',
+  'sourceKind',
+  'payloadHash',
+  'approvedHash',
+  'authorActor',
+  'approverActor',
+]);
+
+const EXPECTED_COMMAND_KEYS = Object.freeze([
+  'socialPostSchemaVersion',
+  'type',
+  'expectedLifecycle',
+  'payloadHash',
+  'actor',
+  'capability',
+  'selfApprovalAllowed',
+]);
+
+const FIXED_REASONS = Object.freeze({
+  APPLIED: 'transition_applied',
+  IDEMPOTENT: 'same_state_idempotent',
+  FORBIDDEN: 'transition_forbidden',
+  INVALID_RECORD: 'invalid_record',
+  INVALID_COMMAND: 'invalid_command',
+  STATE_CONFLICT: 'state_conflict',
+  CAPABILITY_FORBIDDEN: 'capability_forbidden',
+  STALE_APPROVAL: 'stale_approval',
+  SELF_APPROVAL_FORBIDDEN: 'self_approval_forbidden',
+});
+
+function frozenReasons(reasons) {
+  return Object.freeze([...new Set(reasons)].sort());
+}
+
+function isOpaqueIdentifier(value) {
+  return typeof value === 'string' && OPAQUE_IDENTIFIER_PATTERN.test(value);
+}
+
+function isNullableIdentifier(value) {
+  return value === null || isOpaqueIdentifier(value);
+}
+
+// Strict own-data reader: rejects a proxy, a non-plain prototype, an accessor,
+// a non-enumerable own field, an inherited field, and any extra key. Returns a
+// Map of own string keys to plain data values, or null. Never invokes a getter.
+function safeOwnData(value, maximumEntries) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) return null;
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    return null;
+  }
+  if (prototype !== Object.prototype || keys.length > maximumEntries) return null;
+
+  const entries = new Map();
+  for (const key of keys) {
+    if (typeof key !== 'string') return null;
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch {
+      return null;
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      return null;
+    }
+    entries.set(key, descriptor.value);
+  }
+
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) return null;
+  }
+  return entries;
+}
+
+function readExactRecord(value, expectedKeys) {
+  const entries = safeOwnData(value, expectedKeys.length);
+  if (!entries
+    || entries.size !== expectedKeys.length
+    || !expectedKeys.every((key) => entries.has(key))) {
+    return null;
+  }
+  return entries;
+}
+
+function validationResult(accepted, status, reasons, projection) {
+  return Object.freeze({
+    accepted,
+    status,
+    reasons: frozenReasons(reasons),
+    projection,
+  });
+}
+
+// Validate the durable post record shape and its approval/lifecycle coherence.
+// A stale stored approval (approvedHash that does not equal payloadHash) is
+// incoherent and rejected: an edit must have cleared it. Approval hash and
+// approver actor always travel together.
+function validateSocialPostRecord(candidate) {
+  const entries = readExactRecord(candidate, EXPECTED_RECORD_KEYS);
+  if (!entries) {
+    return validationResult(false, 'rejected', [FIXED_REASONS.INVALID_RECORD], null);
+  }
+
+  const record = {
+    socialPostSchemaVersion: entries.get('socialPostSchemaVersion'),
+    lifecycleStatus: entries.get('lifecycleStatus'),
+    sourceKind: entries.get('sourceKind'),
+    payloadHash: entries.get('payloadHash'),
+    approvedHash: entries.get('approvedHash'),
+    authorActor: entries.get('authorActor'),
+    approverActor: entries.get('approverActor'),
+  };
+
+  if (record.socialPostSchemaVersion !== socialPostSchemaVersion
+    || !LIFECYCLE_SET.has(record.lifecycleStatus)
+    || !SOURCE_SET.has(record.sourceKind)
+    || !isOpaqueIdentifier(record.payloadHash)
+    || !isOpaqueIdentifier(record.authorActor)
+    || !isNullableIdentifier(record.approvedHash)
+    || !isNullableIdentifier(record.approverActor)) {
+    return validationResult(false, 'rejected', [FIXED_REASONS.INVALID_RECORD], null);
+  }
+
+  const hasApproval = record.approvedHash !== null;
+  const coherent =
+    // Approval hash and approver actor are present together or absent together.
+    hasApproval === (record.approverActor !== null)
+    // A stored approval is never stale: it always names the current payload.
+    && (!hasApproval || record.approvedHash === record.payloadHash)
+    // Pre-approval states carry no approval; post-approval states carry one.
+    && (!UNAPPROVED_LIFECYCLE.has(record.lifecycleStatus) || !hasApproval)
+    && (!APPROVED_LIFECYCLE.has(record.lifecycleStatus) || hasApproval);
+
+  if (!coherent) {
+    return validationResult(false, 'rejected', [FIXED_REASONS.INVALID_RECORD], null);
+  }
+
+  return validationResult(true, 'valid', [], Object.freeze({ ...record }));
+}
+
+function readCommand(candidate) {
+  const entries = readExactRecord(candidate, EXPECTED_COMMAND_KEYS);
+  if (!entries) return null;
+
+  const command = {
+    socialPostSchemaVersion: entries.get('socialPostSchemaVersion'),
+    type: entries.get('type'),
+    expectedLifecycle: entries.get('expectedLifecycle'),
+    payloadHash: entries.get('payloadHash'),
+    actor: entries.get('actor'),
+    capability: entries.get('capability'),
+    selfApprovalAllowed: entries.get('selfApprovalAllowed'),
+  };
+
+  if (command.socialPostSchemaVersion !== socialPostSchemaVersion
+    || !COMMAND_TYPE_SET.has(command.type)
+    || !LIFECYCLE_SET.has(command.expectedLifecycle)
+    || !isNullableIdentifier(command.payloadHash)
+    || !isNullableIdentifier(command.actor)
+    || !CAPABILITY_SET.has(command.capability)
+    || typeof command.selfApprovalAllowed !== 'boolean') {
+    return null;
+  }
+  return command;
+}
+
+function verdict(fields) {
+  return Object.freeze({
+    accepted: false,
+    outcome: 'rejected',
+    changed: false,
+    lifecycleStatus: null,
+    payloadHash: null,
+    approvedHash: null,
+    approverActor: null,
+    approvalRecorded: false,
+    approvalCleared: false,
+    reason: FIXED_REASONS.INVALID_COMMAND,
+    ...fields,
+  });
+}
+
+function rejectAs(record, reason) {
+  return verdict({
+    lifecycleStatus: record.lifecycleStatus,
+    payloadHash: record.payloadHash,
+    approvedHash: record.approvedHash,
+    approverActor: record.approverActor,
+    reason,
+  });
+}
+
+// Reduce (current record, command) to a frozen verdict. Never throws, never
+// echoes raw input. The verdict's record fields are the exact next durable
+// record the caller should persist, and the whole verdict is audit-safe.
+function classifySocialPostTransition(current, command) {
+  const validation = validateSocialPostRecord(current);
+  if (!validation.accepted) {
+    return verdict({ reason: FIXED_REASONS.INVALID_RECORD });
+  }
+  const record = validation.projection;
+
+  const cmd = readCommand(command);
+  if (!cmd) {
+    return rejectAs(record, FIXED_REASONS.INVALID_COMMAND);
+  }
+
+  const spec = COMMANDS[cmd.type];
+
+  // Idempotent cancellation: cancelling an already-cancelled post that the
+  // caller also believes cancelled is a settled no-op, not a conflict.
+  if (cmd.type === 'cancel'
+    && record.lifecycleStatus === 'cancelled'
+    && cmd.expectedLifecycle === 'cancelled') {
+    return verdict({
+      accepted: true,
+      outcome: 'unchanged',
+      lifecycleStatus: record.lifecycleStatus,
+      payloadHash: record.payloadHash,
+      approvedHash: record.approvedHash,
+      approverActor: record.approverActor,
+      reason: FIXED_REASONS.IDEMPOTENT,
+    });
+  }
+
+  // Optimistic concurrency: the command must be formed against the true current
+  // state. A mismatch is a duplicate or concurrent command.
+  if (cmd.expectedLifecycle !== record.lifecycleStatus) {
+    return rejectAs(record, FIXED_REASONS.STATE_CONFLICT);
+  }
+
+  // Impossible transition.
+  if (!spec.from.has(record.lifecycleStatus)) {
+    return rejectAs(record, FIXED_REASONS.FORBIDDEN);
+  }
+
+  // Scoped verified identity: allowed capability, and actor presence matching
+  // the command kind (human commands bear an actor; system commands do not).
+  const systemCapability = SYSTEM_CAPABILITIES.has(cmd.capability);
+  const actorPresent = cmd.actor !== null;
+  if (!spec.capabilities.has(cmd.capability)
+    || (spec.kind === 'human' && (systemCapability || !actorPresent))
+    || (spec.kind === 'system' && (!systemCapability || actorPresent))) {
+    return rejectAs(record, FIXED_REASONS.CAPABILITY_FORBIDDEN);
+  }
+
+  // Per-command payload-hash coherence.
+  if (cmd.type === 'edit') {
+    // An edit must supply a new, different canonical payload hash.
+    if (!isOpaqueIdentifier(cmd.payloadHash) || cmd.payloadHash === record.payloadHash) {
+      return rejectAs(record, FIXED_REASONS.INVALID_COMMAND);
+    }
+  } else if (cmd.type === 'approve') {
+    // An approval must name the exact current payload; approving anything else
+    // is a stale approval attempt.
+    if (!isOpaqueIdentifier(cmd.payloadHash)) {
+      return rejectAs(record, FIXED_REASONS.INVALID_COMMAND);
+    }
+    if (cmd.payloadHash !== record.payloadHash) {
+      return rejectAs(record, FIXED_REASONS.STALE_APPROVAL);
+    }
+  } else if (cmd.payloadHash !== null) {
+    // Every other command carries no payload hash.
+    return rejectAs(record, FIXED_REASONS.INVALID_COMMAND);
+  }
+
+  // Self-approval is an explicit owner policy, fail-closed. A valid `approved`,
+  // `scheduled`, `publishing`, or `published` record already carries a current
+  // approval bound to its payload (validateSocialPostRecord), so publication is
+  // unreachable without one; no separate advancing-edge gate is needed.
+  if (cmd.type === 'approve'
+    && cmd.actor === record.authorActor
+    && cmd.selfApprovalAllowed !== true) {
+    return rejectAs(record, FIXED_REASONS.SELF_APPROVAL_FORBIDDEN);
+  }
+
+  return applyTransition(record, cmd, spec);
+}
+
+function applyTransition(record, cmd, spec) {
+  let payloadHash = record.payloadHash;
+  let approvedHash = record.approvedHash;
+  let approverActor = record.approverActor;
+  let approvalRecorded = false;
+  let approvalCleared = false;
+
+  if (spec.approvalEffect === 'reset') {
+    // An edit mints a new canonical payload and invalidates any approval.
+    payloadHash = cmd.payloadHash;
+    if (approvedHash !== null) approvalCleared = true;
+    approvedHash = null;
+    approverActor = null;
+  } else if (spec.approvalEffect === 'record') {
+    approvedHash = record.payloadHash;
+    approverActor = cmd.actor;
+    approvalRecorded = true;
+  }
+
+  return verdict({
+    accepted: true,
+    outcome: 'applied',
+    changed: true,
+    lifecycleStatus: spec.to,
+    payloadHash,
+    approvedHash,
+    approverActor,
+    approvalRecorded,
+    approvalCleared,
+    reason: FIXED_REASONS.APPLIED,
+  });
+}
+
+module.exports = Object.freeze({
+  socialPostSchemaVersion,
+  SocialPostLifecycle,
+  SocialPostCommandType,
+  SocialPostCapability,
+  SocialPostSource,
+  validateSocialPostRecord,
+  classifySocialPostTransition,
+});

--- a/functions/socialPostState.test.js
+++ b/functions/socialPostState.test.js
@@ -1,0 +1,692 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  socialPostSchemaVersion,
+  SocialPostLifecycle,
+  SocialPostCommandType,
+  SocialPostCapability,
+  SocialPostSource,
+  validateSocialPostRecord,
+  classifySocialPostTransition,
+} = require('./socialPostState');
+
+// A value that must never be echoed by a rejection. It stands in for the kind
+// of protected content a hostile extra field could try to smuggle in.
+const HOSTILE_CANARY = 'caption=leak; media=https://cdn.example/signed?sig=abc; contact=+12025550123';
+
+const VERDICT_KEYS = [
+  'accepted',
+  'outcome',
+  'changed',
+  'lifecycleStatus',
+  'payloadHash',
+  'approvedHash',
+  'approverActor',
+  'approvalRecorded',
+  'approvalCleared',
+  'reason',
+];
+
+const AUTHOR = 'officer_author';
+const REVIEWER = 'officer_reviewer_1';
+const HASH_V1 = 'hash_v1';
+const HASH_V2 = 'hash_v2';
+
+// A durable record in `draft` with no approval. Every record fixture starts here.
+function record(overrides = {}) {
+  return {
+    socialPostSchemaVersion: 1,
+    lifecycleStatus: 'draft',
+    sourceKind: 'public_event',
+    payloadHash: HASH_V1,
+    approvedHash: null,
+    authorActor: AUTHOR,
+    approverActor: null,
+    ...overrides,
+  };
+}
+
+// A durable record that already carries a current approval bound to its payload.
+function approvedRecord(overrides = {}) {
+  return record({
+    lifecycleStatus: 'approved',
+    approvedHash: HASH_V1,
+    approverActor: REVIEWER,
+    ...overrides,
+  });
+}
+
+// A canonical valid command. Defaults to a `submit` by the author-editor.
+function command(overrides = {}) {
+  return {
+    socialPostSchemaVersion: 1,
+    type: 'submit',
+    expectedLifecycle: 'draft',
+    payloadHash: null,
+    actor: AUTHOR,
+    capability: 'officer_editor',
+    selfApprovalAllowed: false,
+    ...overrides,
+  };
+}
+
+// Build the exact next durable record from a prior record and an applied verdict.
+function nextRecord(prev, verdict) {
+  return {
+    socialPostSchemaVersion: 1,
+    lifecycleStatus: verdict.lifecycleStatus,
+    sourceKind: prev.sourceKind,
+    payloadHash: verdict.payloadHash,
+    approvedHash: verdict.approvedHash,
+    authorActor: prev.authorActor,
+    approverActor: verdict.approverActor,
+  };
+}
+
+function expectValidRecord(candidate) {
+  const result = validateSocialPostRecord(candidate);
+  expect(result.accepted).toBe(true);
+  return result.projection;
+}
+
+function expectInvalidRecord(candidate) {
+  const result = validateSocialPostRecord(candidate);
+  expect(result.accepted).toBe(false);
+  expect(result.status).toBe('rejected');
+  expect(result.reasons).toContain('invalid_record');
+  expect(result.projection).toBeNull();
+}
+
+function expectRejected(current, cmd, reason) {
+  const verdict = classifySocialPostTransition(current, cmd);
+  expect(verdict.accepted).toBe(false);
+  expect(verdict.outcome).toBe('rejected');
+  expect(verdict.changed).toBe(false);
+  if (reason) expect(verdict.reason).toBe(reason);
+  // A rejection never echoes any raw input.
+  expect(JSON.stringify(verdict)).not.toContain(HOSTILE_CANARY);
+  return verdict;
+}
+
+describe('canonical fixtures validate and expose a frozen versioned surface', () => {
+  test('the draft and approved fixtures are coherent records', () => {
+    expectValidRecord(record());
+    expectValidRecord(approvedRecord());
+  });
+
+  test('schema version is 1 and every enum is deeply frozen', () => {
+    expect(socialPostSchemaVersion).toBe(1);
+    for (const e of [SocialPostLifecycle, SocialPostCommandType, SocialPostCapability, SocialPostSource]) {
+      expect(Object.isFrozen(e)).toBe(true);
+    }
+    expect(new Set(Object.values(SocialPostLifecycle))).toEqual(new Set([
+      'draft', 'pending_review', 'approved', 'scheduled', 'publishing',
+      'published', 'failed', 'outcome_unknown', 'cancelled',
+    ]));
+    expect(new Set(Object.values(SocialPostSource))).toEqual(new Set(['public_event']));
+  });
+
+  test('the module export is frozen', () => {
+    expect(Object.isFrozen(require('./socialPostState'))).toBe(true);
+  });
+});
+
+describe('full approval-gated happy path draft -> published', () => {
+  test('a post reaches published only through submit, approve, schedule, begin_publish, confirm', () => {
+    let current = record();
+    const steps = [
+      command({ type: 'submit', expectedLifecycle: 'draft' }),
+      command({
+        type: 'approve', expectedLifecycle: 'pending_review',
+        payloadHash: HASH_V1, actor: REVIEWER, capability: 'officer_reviewer',
+      }),
+      command({
+        type: 'schedule', expectedLifecycle: 'approved',
+        actor: REVIEWER, capability: 'officer_reviewer',
+      }),
+      command({
+        type: 'begin_publish', expectedLifecycle: 'scheduled',
+        actor: null, capability: 'system_publisher',
+      }),
+      command({
+        type: 'provider_confirmed', expectedLifecycle: 'publishing',
+        actor: null, capability: 'system_publisher',
+      }),
+    ];
+    const seen = [];
+    for (const step of steps) {
+      const verdict = classifySocialPostTransition(current, step);
+      expect(verdict.accepted).toBe(true);
+      expect(verdict.outcome).toBe('applied');
+      expect(Object.isFrozen(verdict)).toBe(true);
+      expect(Object.keys(verdict)).toEqual(VERDICT_KEYS);
+      current = nextRecord(current, verdict);
+      // Every intermediate durable record the reducer produces is itself valid.
+      expectValidRecord(current);
+      seen.push(current.lifecycleStatus);
+    }
+    expect(seen).toEqual(['pending_review', 'approved', 'scheduled', 'publishing', 'published']);
+    // The published post carries the human approval bound to exactly its payload.
+    expect(current.approvedHash).toBe(current.payloadHash);
+    expect(current.approverActor).toBe(REVIEWER);
+  });
+
+  test('the approve step records approval; only that step sets approvalRecorded', () => {
+    const pending = record({ lifecycleStatus: 'pending_review' });
+    const verdict = classifySocialPostTransition(pending, command({
+      type: 'approve', expectedLifecycle: 'pending_review',
+      payloadHash: HASH_V1, actor: REVIEWER, capability: 'officer_reviewer',
+    }));
+    expect(verdict.approvalRecorded).toBe(true);
+    expect(verdict.approvalCleared).toBe(false);
+    expect(verdict.approvedHash).toBe(HASH_V1);
+    expect(verdict.approverActor).toBe(REVIEWER);
+  });
+
+  test('provider results and reconciliation resolve a publishing / unknown post', () => {
+    const publishing = approvedRecord({ lifecycleStatus: 'publishing' });
+    for (const [type, to] of [
+      ['provider_confirmed', 'published'],
+      ['provider_failed', 'failed'],
+      ['provider_indeterminate', 'outcome_unknown'],
+    ]) {
+      const verdict = classifySocialPostTransition(publishing, command({
+        type, expectedLifecycle: 'publishing', actor: null, capability: 'system_publisher',
+      }));
+      expect(verdict.outcome).toBe('applied');
+      expect(verdict.lifecycleStatus).toBe(to);
+    }
+    const unknown = approvedRecord({ lifecycleStatus: 'outcome_unknown' });
+    for (const [type, to] of [['reconciled_published', 'published'], ['reconciled_failed', 'failed']]) {
+      const verdict = classifySocialPostTransition(unknown, command({
+        type, expectedLifecycle: 'outcome_unknown', actor: null, capability: 'system_reconciler',
+      }));
+      expect(verdict.lifecycleStatus).toBe(to);
+    }
+    const failed = approvedRecord({ lifecycleStatus: 'failed' });
+    const retry = classifySocialPostTransition(failed, command({
+      type: 'retry', expectedLifecycle: 'failed', actor: null, capability: 'system_publisher',
+    }));
+    expect(retry.lifecycleStatus).toBe('scheduled');
+  });
+});
+
+describe('transition matrix — every lifecycle state against every command', () => {
+  const CAPABILITY_FOR = {
+    submit: 'officer_editor',
+    edit: 'officer_editor',
+    approve: 'officer_reviewer',
+    reject: 'officer_reviewer',
+    schedule: 'officer_reviewer',
+    cancel: 'officer_reviewer',
+    begin_publish: 'system_publisher',
+    provider_confirmed: 'system_publisher',
+    provider_failed: 'system_publisher',
+    provider_indeterminate: 'system_publisher',
+    retry: 'system_publisher',
+    reconciled_published: 'system_reconciler',
+    reconciled_failed: 'system_reconciler',
+  };
+  const SYSTEM_TYPES = new Set([
+    'begin_publish', 'provider_confirmed', 'provider_failed', 'provider_indeterminate',
+    'retry', 'reconciled_published', 'reconciled_failed',
+  ]);
+  // The one target state each command enters, used to check applied transitions.
+  const TARGET = {
+    submit: 'pending_review', edit: 'draft', approve: 'approved', reject: 'draft',
+    schedule: 'scheduled', begin_publish: 'publishing', provider_confirmed: 'published',
+    provider_failed: 'failed', provider_indeterminate: 'outcome_unknown', retry: 'scheduled',
+    reconciled_published: 'published', reconciled_failed: 'failed', cancel: 'cancelled',
+  };
+  const ALLOWED_FROM = {
+    submit: ['draft'],
+    edit: ['draft', 'pending_review', 'approved', 'scheduled'],
+    approve: ['pending_review'],
+    reject: ['pending_review'],
+    schedule: ['approved'],
+    begin_publish: ['scheduled'],
+    provider_confirmed: ['publishing'],
+    provider_failed: ['publishing'],
+    provider_indeterminate: ['publishing'],
+    retry: ['failed'],
+    reconciled_published: ['outcome_unknown'],
+    reconciled_failed: ['outcome_unknown'],
+    cancel: ['draft', 'pending_review', 'approved', 'scheduled', 'failed', 'outcome_unknown'],
+  };
+  const UNAPPROVED = new Set(['draft', 'pending_review']);
+
+  function canonicalRecord(state) {
+    if (UNAPPROVED.has(state) || state === 'cancelled') {
+      return record({ lifecycleStatus: state });
+    }
+    return approvedRecord({ lifecycleStatus: state });
+  }
+
+  function canonicalCommand(type, state) {
+    const system = SYSTEM_TYPES.has(type);
+    let payloadHash = null;
+    if (type === 'edit') payloadHash = HASH_V2;
+    else if (type === 'approve') payloadHash = HASH_V1;
+    return command({
+      type,
+      expectedLifecycle: state,
+      payloadHash,
+      actor: system ? null : (type === 'approve' ? REVIEWER : AUTHOR),
+      capability: CAPABILITY_FOR[type],
+      selfApprovalAllowed: false,
+    });
+  }
+
+  const states = Object.values(SocialPostLifecycle);
+  const types = Object.values(SocialPostCommandType);
+
+  test('applies exactly the allowed edges and forbids every other', () => {
+    let applied = 0;
+    let forbidden = 0;
+    for (const state of states) {
+      for (const type of types) {
+        const verdict = classifySocialPostTransition(canonicalRecord(state), canonicalCommand(type, state));
+        // The one idempotent exception: cancel on an already-cancelled post.
+        if (type === 'cancel' && state === 'cancelled') {
+          expect(verdict.outcome).toBe('unchanged');
+          expect(verdict.reason).toBe('same_state_idempotent');
+          continue;
+        }
+        if (ALLOWED_FROM[type].includes(state)) {
+          expect(verdict.outcome).toBe('applied');
+          expect(verdict.lifecycleStatus).toBe(TARGET[type]);
+          applied += 1;
+        } else {
+          expect(verdict.outcome).toBe('rejected');
+          expect(verdict.reason).toBe('transition_forbidden');
+          forbidden += 1;
+        }
+      }
+    }
+    // 9 states x 13 commands = 117; minus the 1 idempotent cancel.
+    expect(applied + forbidden).toBe(116);
+    expect(applied).toBe(
+      Object.values(ALLOWED_FROM).reduce((n, from) => n + from.length, 0),
+    );
+  });
+});
+
+describe('approval binding and invalidation', () => {
+  test('an edit mints a new payload hash and clears any approval', () => {
+    const verdict = classifySocialPostTransition(approvedRecord(), command({
+      type: 'edit', expectedLifecycle: 'approved', payloadHash: HASH_V2,
+      actor: AUTHOR, capability: 'officer_editor',
+    }));
+    expect(verdict.outcome).toBe('applied');
+    expect(verdict.lifecycleStatus).toBe('draft');
+    expect(verdict.payloadHash).toBe(HASH_V2);
+    expect(verdict.approvedHash).toBeNull();
+    expect(verdict.approverActor).toBeNull();
+    expect(verdict.approvalCleared).toBe(true);
+  });
+
+  test('after an edit, the post cannot be scheduled or published until re-approved', () => {
+    const edited = nextRecord(approvedRecord(), classifySocialPostTransition(approvedRecord(), command({
+      type: 'edit', expectedLifecycle: 'approved', payloadHash: HASH_V2,
+      actor: AUTHOR, capability: 'officer_editor',
+    })));
+    expect(edited.lifecycleStatus).toBe('draft');
+    expect(edited.approvedHash).toBeNull();
+    // Scheduling requires the `approved` state, which the edited draft is not in.
+    expectRejected(edited, command({
+      type: 'schedule', expectedLifecycle: 'draft', actor: REVIEWER, capability: 'officer_reviewer',
+    }), 'transition_forbidden');
+    // A re-approval must name the NEW payload hash.
+    const reapprove = classifySocialPostTransition(
+      record({ lifecycleStatus: 'pending_review', payloadHash: HASH_V2 }),
+      command({
+        type: 'approve', expectedLifecycle: 'pending_review', payloadHash: HASH_V2,
+        actor: REVIEWER, capability: 'officer_reviewer',
+      }),
+    );
+    expect(reapprove.approvedHash).toBe(HASH_V2);
+  });
+
+  test('an edit must supply a new, different payload hash', () => {
+    expectRejected(approvedRecord(), command({
+      type: 'edit', expectedLifecycle: 'approved', payloadHash: HASH_V1, // unchanged
+      actor: AUTHOR, capability: 'officer_editor',
+    }), 'invalid_command');
+    expectRejected(approvedRecord(), command({
+      type: 'edit', expectedLifecycle: 'approved', payloadHash: null,
+      actor: AUTHOR, capability: 'officer_editor',
+    }), 'invalid_command');
+  });
+
+  test('approving a hash that is not the current payload is a stale approval', () => {
+    expectRejected(record({ lifecycleStatus: 'pending_review' }), command({
+      type: 'approve', expectedLifecycle: 'pending_review', payloadHash: 'hash_v0',
+      actor: REVIEWER, capability: 'officer_reviewer',
+    }), 'stale_approval');
+  });
+});
+
+describe('self-approval is an explicit owner policy', () => {
+  const pending = () => record({ lifecycleStatus: 'pending_review' });
+  const selfApprove = (selfApprovalAllowed) => command({
+    type: 'approve', expectedLifecycle: 'pending_review', payloadHash: HASH_V1,
+    actor: AUTHOR, capability: 'officer_reviewer', selfApprovalAllowed,
+  });
+
+  test('the author approving their own post is forbidden by default', () => {
+    expectRejected(pending(), selfApprove(false), 'self_approval_forbidden');
+  });
+
+  test('self-approval succeeds only when the owner policy explicitly allows it', () => {
+    const verdict = classifySocialPostTransition(pending(), selfApprove(true));
+    expect(verdict.outcome).toBe('applied');
+    expect(verdict.approverActor).toBe(AUTHOR);
+  });
+
+  test('a different reviewer is never affected by the self-approval policy', () => {
+    const verdict = classifySocialPostTransition(pending(), command({
+      type: 'approve', expectedLifecycle: 'pending_review', payloadHash: HASH_V1,
+      actor: REVIEWER, capability: 'officer_reviewer', selfApprovalAllowed: false,
+    }));
+    expect(verdict.outcome).toBe('applied');
+  });
+});
+
+describe('no publish without a current approval (record invariant)', () => {
+  const POST_APPROVAL = ['approved', 'scheduled', 'publishing', 'published', 'failed', 'outcome_unknown'];
+
+  test.each(POST_APPROVAL)('a %s record with no approval is invalid', (lifecycleStatus) => {
+    expectInvalidRecord(record({ lifecycleStatus, approvedHash: null, approverActor: null }));
+  });
+
+  test.each(POST_APPROVAL)('a %s record whose approval does not match its payload is invalid', (lifecycleStatus) => {
+    // A stale stored approval (approvedHash != payloadHash) is unrepresentable.
+    expectInvalidRecord(approvedRecord({ lifecycleStatus, payloadHash: HASH_V2, approvedHash: HASH_V1 }));
+  });
+
+  test('a pre-approval state that carries an approval is invalid', () => {
+    expectInvalidRecord(record({ lifecycleStatus: 'draft', approvedHash: HASH_V1, approverActor: REVIEWER }));
+    expectInvalidRecord(record({ lifecycleStatus: 'pending_review', approvedHash: HASH_V1, approverActor: REVIEWER }));
+  });
+
+  test('approval hash and approver actor must travel together', () => {
+    expectInvalidRecord(approvedRecord({ approverActor: null }));
+    expectInvalidRecord(record({ lifecycleStatus: 'approved', approvedHash: null, approverActor: REVIEWER }));
+  });
+
+  test('every scheduled/publishing/published record that validates carries a matching approval', () => {
+    for (const lifecycleStatus of ['scheduled', 'publishing', 'published']) {
+      const projection = expectValidRecord(approvedRecord({ lifecycleStatus }));
+      expect(projection.approvedHash).toBe(projection.payloadHash);
+      expect(projection.approverActor).not.toBeNull();
+    }
+  });
+});
+
+describe('scoped verified identity (capabilities)', () => {
+  test('a human command presenting a system capability is forbidden', () => {
+    expectRejected(record(), command({
+      type: 'submit', expectedLifecycle: 'draft', actor: AUTHOR, capability: 'system_publisher',
+    }), 'capability_forbidden');
+  });
+
+  test('a system command presenting an actor (client identity) is forbidden', () => {
+    expectRejected(approvedRecord({ lifecycleStatus: 'scheduled' }), command({
+      type: 'begin_publish', expectedLifecycle: 'scheduled', actor: AUTHOR, capability: 'system_publisher',
+    }), 'capability_forbidden');
+  });
+
+  test('an officer capability outside the command scope is forbidden', () => {
+    // Only editors may submit; a reviewer capability cannot.
+    expectRejected(record(), command({
+      type: 'submit', expectedLifecycle: 'draft', actor: AUTHOR, capability: 'officer_reviewer',
+    }), 'capability_forbidden');
+    // Only the system publisher may begin publishing; an admin cannot.
+    expectRejected(approvedRecord({ lifecycleStatus: 'scheduled' }), command({
+      type: 'begin_publish', expectedLifecycle: 'scheduled', actor: null, capability: 'officer_admin',
+    }), 'capability_forbidden');
+  });
+
+  test('the officer_admin capability may act on both editor and reviewer edges', () => {
+    expect(classifySocialPostTransition(record(), command({
+      type: 'submit', expectedLifecycle: 'draft', actor: AUTHOR, capability: 'officer_admin',
+    })).outcome).toBe('applied');
+    expect(classifySocialPostTransition(record({ lifecycleStatus: 'pending_review' }), command({
+      type: 'approve', expectedLifecycle: 'pending_review', payloadHash: HASH_V1,
+      actor: REVIEWER, capability: 'officer_admin',
+    })).outcome).toBe('applied');
+  });
+
+  test('reconciliation requires the reconciler capability, not the publisher', () => {
+    expectRejected(approvedRecord({ lifecycleStatus: 'outcome_unknown' }), command({
+      type: 'reconciled_published', expectedLifecycle: 'outcome_unknown',
+      actor: null, capability: 'system_publisher',
+    }), 'capability_forbidden');
+  });
+});
+
+describe('optimistic concurrency and cancellation races', () => {
+  test('a command formed against a stale lifecycle is a conflict', () => {
+    // The caller believes the post is still a draft, but it has advanced.
+    expectRejected(record({ lifecycleStatus: 'pending_review' }), command({
+      type: 'submit', expectedLifecycle: 'draft', actor: AUTHOR, capability: 'officer_editor',
+    }), 'state_conflict');
+  });
+
+  test('a duplicate approve after the post advanced is a conflict, not a re-approval', () => {
+    expectRejected(approvedRecord(), command({
+      type: 'approve', expectedLifecycle: 'pending_review', payloadHash: HASH_V1,
+      actor: REVIEWER, capability: 'officer_reviewer',
+    }), 'state_conflict');
+  });
+
+  test('cancelling an in-flight publishing post is forbidden', () => {
+    expectRejected(approvedRecord({ lifecycleStatus: 'publishing' }), command({
+      type: 'cancel', expectedLifecycle: 'publishing', actor: REVIEWER, capability: 'officer_reviewer',
+    }), 'transition_forbidden');
+  });
+
+  test('cancelling an already-cancelled post is an idempotent no-op', () => {
+    const verdict = classifySocialPostTransition(record({ lifecycleStatus: 'cancelled' }), command({
+      type: 'cancel', expectedLifecycle: 'cancelled', actor: REVIEWER, capability: 'officer_reviewer',
+    }));
+    expect(verdict.accepted).toBe(true);
+    expect(verdict.outcome).toBe('unchanged');
+    expect(verdict.changed).toBe(false);
+    expect(verdict.reason).toBe('same_state_idempotent');
+    expect(verdict.lifecycleStatus).toBe('cancelled');
+  });
+
+  test('a cancel racing against a state it did not expect is a conflict', () => {
+    expectRejected(record({ lifecycleStatus: 'cancelled' }), command({
+      type: 'cancel', expectedLifecycle: 'scheduled', actor: REVIEWER, capability: 'officer_reviewer',
+    }), 'state_conflict');
+  });
+
+  test('cancel is allowed from every non-terminal, non-publishing state', () => {
+    for (const state of ['draft', 'pending_review', 'approved', 'scheduled', 'failed', 'outcome_unknown']) {
+      const current = ['draft', 'pending_review'].includes(state)
+        ? record({ lifecycleStatus: state })
+        : approvedRecord({ lifecycleStatus: state });
+      const verdict = classifySocialPostTransition(current, command({
+        type: 'cancel', expectedLifecycle: state, actor: REVIEWER, capability: 'officer_reviewer',
+      }));
+      expect(verdict.outcome).toBe('applied');
+      expect(verdict.lifecycleStatus).toBe('cancelled');
+    }
+  });
+});
+
+describe('only a public-event source may become a post', () => {
+  test('a record whose source is not a public event is rejected', () => {
+    for (const sourceKind of ['membership', 'discount', 'whatsapp', 'strava', 'internal']) {
+      expectInvalidRecord(record({ sourceKind }));
+    }
+  });
+
+  test('the only accepted source is the public event', () => {
+    expect(Object.values(SocialPostSource)).toEqual(['public_event']);
+  });
+});
+
+describe('durable record validation — malformed and hostile input', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', HOSTILE_CANARY],
+    ['a number', 7],
+    ['an array', [HOSTILE_CANARY]],
+  ])('rejects a non-object record (%s)', (_label, value) => {
+    expectInvalidRecord(value);
+  });
+
+  test('rejects an extra or missing key', () => {
+    expectInvalidRecord(record({ leaked: HOSTILE_CANARY }));
+    const short = record();
+    delete short.approverActor;
+    expectInvalidRecord(short);
+  });
+
+  test('rejects the wrong schema version and unknown enum values', () => {
+    expectInvalidRecord(record({ socialPostSchemaVersion: 2 }));
+    expectInvalidRecord(record({ lifecycleStatus: 'deleted' }));
+  });
+
+  test('rejects a Proxy without tripping its traps', () => {
+    const proxy = new Proxy(record(), { get() { throw new Error('trap must not run'); } });
+    expectInvalidRecord(proxy);
+  });
+
+  test('rejects an accessor-backed field without invoking the getter', () => {
+    let invoked = false;
+    const hostile = record();
+    delete hostile.payloadHash;
+    Object.defineProperty(hostile, 'payloadHash', {
+      enumerable: true, configurable: true,
+      get() { invoked = true; return HOSTILE_CANARY; },
+    });
+    expectInvalidRecord(hostile);
+    expect(invoked).toBe(false);
+  });
+
+  test('rejects a non-enumerable own field and inherited fields', () => {
+    const hostile = record();
+    const value = hostile.authorActor;
+    delete hostile.authorActor;
+    Object.defineProperty(hostile, 'authorActor', {
+      value, enumerable: false, writable: true, configurable: true,
+    });
+    expectInvalidRecord(hostile);
+    expectInvalidRecord(Object.create(record()));
+    expectInvalidRecord(Object.assign(Object.create(null), record()));
+  });
+});
+
+describe('command validation — malformed and hostile input', () => {
+  const validCurrent = () => record();
+
+  test('an unparseable command is rejected without echo', () => {
+    for (const bad of [null, undefined, 7, 'x', [HOSTILE_CANARY]]) {
+      expectRejected(validCurrent(), bad, 'invalid_command');
+    }
+  });
+
+  test('rejects an extra command key, wrong version, or unknown type', () => {
+    expectRejected(validCurrent(), command({ leaked: HOSTILE_CANARY }), 'invalid_command');
+    expectRejected(validCurrent(), command({ socialPostSchemaVersion: 2 }), 'invalid_command');
+    expectRejected(validCurrent(), command({ type: 'nuke' }), 'invalid_command');
+  });
+
+  test('rejects a non-boolean selfApprovalAllowed and an unknown capability', () => {
+    expectRejected(validCurrent(), command({ selfApprovalAllowed: 'yes' }), 'invalid_command');
+    expectRejected(validCurrent(), command({ capability: 'root' }), 'invalid_command');
+  });
+
+  test('a non-edit, non-approve command carrying a payload hash is rejected', () => {
+    expectRejected(validCurrent(), command({
+      type: 'submit', expectedLifecycle: 'draft', payloadHash: HASH_V1,
+      actor: AUTHOR, capability: 'officer_editor',
+    }), 'invalid_command');
+  });
+
+  test('a rejection reflects the current record and never echoes the command', () => {
+    const verdict = expectRejected(validCurrent(), command({ leaked: HOSTILE_CANARY }), 'invalid_command');
+    expect(verdict.lifecycleStatus).toBe('draft');
+    expect(Object.isFrozen(verdict)).toBe(true);
+  });
+
+  test('an invalid current record short-circuits to invalid_record', () => {
+    const verdict = classifySocialPostTransition({ bogus: HOSTILE_CANARY }, command());
+    expect(verdict.reason).toBe('invalid_record');
+    expect(verdict.lifecycleStatus).toBeNull();
+    expect(JSON.stringify(verdict)).not.toContain(HOSTILE_CANARY);
+  });
+});
+
+describe('source boundary — pure, unused, provider-neutral', () => {
+  const modulePath = path.join(__dirname, 'socialPostState.js');
+  const source = fs.readFileSync(modulePath, 'utf8');
+
+  // The code-behavior batteries below assert on executable code, not prose. The
+  // module's header legitimately names its issue tracker (an Instagram epic) and
+  // documents the very fields it deliberately excludes ("never a name, email,
+  // address..."). Those words are allowed in comments but must never appear in
+  // the CODE — which is exactly what stripping comments first lets us enforce.
+  function codeOnly(text) {
+    return text
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')      // block comments
+      .replace(/(^|[^:])\/\/[^\n]*/gm, '$1');  // line comments, never a URL's //
+  }
+  const code = codeOnly(source);
+
+  test('comment stripping preserves code and removes prose', () => {
+    expect(code).toContain('classifySocialPostTransition');
+    expect(code).toContain('module.exports');
+    expect(code).toContain('immutableEnum');
+    const sample = codeOnly("keep(); // drop instagram\n/* drop address */ more();");
+    expect(sample).toContain('keep()');
+    expect(sample).toContain('more()');
+    expect(sample).not.toMatch(/instagram/i);
+    expect(sample).not.toMatch(/address/i);
+  });
+
+  test('is not imported by the functions runtime entry point', () => {
+    const index = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+    expect(index).not.toContain('socialPostState');
+  });
+
+  test('requires only node:util', () => {
+    const requires = [...code.matchAll(/require\(([^)]*)\)/g)].map((m) => m[1].trim());
+    expect(requires).toEqual(["'node:util'"]);
+  });
+
+  test('reads no clock, randomness, environment, network, or provider surface', () => {
+    for (const forbidden of [
+      /process\.env/, /Date\.now/, /new Date/, /Math\.random/, /console\./,
+      /fetch\(/, /https?:/, /firebase/i, /firestore/i, /stripe/i,
+    ]) {
+      expect(code).not.toMatch(forbidden);
+    }
+  });
+
+  test('the executable surface names no concrete social provider', () => {
+    expect(code).not.toMatch(/instagram/i);
+    expect(code).not.toMatch(/facebook/i);
+  });
+
+  test('the executable surface carries no PII or credential vocabulary', () => {
+    for (const forbidden of [
+      /phone/i, /address/i, /\bdob\b/i, /\bssn\b/i, /secret/i,
+      /\btoken\b/i, /password/i, /bearer/i, /api[_-]?key/i,
+    ]) {
+      expect(code).not.toMatch(forbidden);
+    }
+  });
+
+  test('hard-codes the approval-gated posture and the single public-event source', () => {
+    expect(source).toContain("immutableEnum(['public_event'])");
+    expect(source).toContain('self_approval_forbidden');
+    expect(source).toContain('stale_approval');
+  });
+});


### PR DESCRIPTION
Closes #401. Parent: #92.

The first **conservative, safe-by-default** slice of INSTAGRAM-002 (#92): one pure, unused, provider-neutral CommonJS contract for the approval-gated lifecycle of a social post, plus the durable record it validates — in the non-throwing frozen-verdict idiom of `commerceOutboxState` (SYSTEM_DESIGN §8.5a). It follows the merged source-only precedents PAY-003B1 (#365), PAY-003C1 (#379), PAY-003B2 (#398), and EVENTS-001A (#400): a scoped child that encodes the model and its negative tests without wiring runtime behavior, leaving #92's full-implementation gate intact.

## What this adds
- `functions/socialPostState.js` — requires only `node:util`.
  - `classifySocialPostTransition(current, command)` — reduces a durable record and an exact revision-1 command over closed lifecycle / command / capability vocabularies and returns a frozen `applied` / `unchanged` / `rejected` verdict with a fixed reason code. Never throws, never echoes raw input.
  - `validateSocialPostRecord(candidate)` — validates the durable record `{ socialPostSchemaVersion, lifecycleStatus, sourceKind, payloadHash, approvedHash, authorActor, approverActor }` and its approval/lifecycle coherence; returns a frozen canonical projection or a fixed rejection reason.
- `functions/socialPostState.test.js` — 65 colocated jest tests (happy path, full 9×13 transition matrix, approval binding/invalidation, self-approval owner policy, publish-requires-approval record invariant, scoped identity/capabilities, optimistic-concurrency & cancellation races, source allowlist, hostile record/command inputs, and a source-boundary battery).
- `SYSTEM_DESIGN.md` §8.7 — the "SOURCE ONLY, UNUSED" section.

## #92 acceptance criteria covered (as pure model + negative tests)
- Impossible transitions, stale approvals, duplicate/concurrent commands, stale payload hashes, and cancellation races are negative-tested.
- **No post publishes without a recorded human approval** bound to its exact current payload hash — enforced as a record invariant.
- Approval is bound to the canonical payload hash; **any edit mints a new hash and clears the approval**.
- Self-approval is an explicit, fail-closed owner policy (`selfApprovalAllowed`, defaults closed).
- Scoped verified identity: officer capabilities drive human edges, system capabilities drive machine edges; a client can present neither.
- Only an intentionally public event source (`sourceKind: 'public_event'`) may become a post; membership, discount, WhatsApp, and Strava sources have no representation.
- Optimistic concurrency: a command names the lifecycle it believes current; a mismatch is `state_conflict`.
- Schema is additive by construction (a `socialPostSchemaVersion` constant); no migration runs.

## Deliberately out of scope (safe-by-default)
The module holds **only opaque hashes, closed enums, and opaque capability-scoped actor tokens** — never a caption, media reference, alt text, URL, timezone, disclosure flag, or request body. The canonical `payloadHash` **binds** content by equality without holding it. Those content fields, the append-oriented audit store, Firestore schema/Rules, endpoints, and the Instagram adapter remain with #92, #93, and their gating owner decisions.

## Safety
Source only and unused: imported by no runtime or Functions index; reads no clock, randomness, environment, network, Firestore, or provider; stores and logs nothing; changes no live behavior. Verified: 65/65 jest green (secrets unset), ESLint (project-pinned 8.56.0) clean, and no `require('./socialPostState')` anywhere in `functions/`. Source change, tests, merge, and Firebase deployment remain separate states — this PR proves none of the external or live states.

No production secrets or customer data are touched. No co-author trailer per repo convention.