### PR TITLE
MEMBERS-DUES-001E: token-refresh/revocation disposition for entitlement reconciliation (source only)

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -721,6 +721,36 @@ This contract does not verify a person, payment, plan, evidence item, refund, di
 
 The module is imported by no runtime or Functions index and updates no officer procedure because it makes nothing officer-observable. It reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, and changes no current profile/role/claim. Source tests and a merge are not Firebase deployment or live behavior proof.
 
+### 8.0g Token-refresh/revocation disposition — SOURCE ONLY, UNUSED
+
+MEMBERS-DUES-001E [#427](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/427) defines one unused pure contract for item 4 of parent [#114](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/114) — "Expiry/reconciliation job and derived Auth-claim/access refresh/revocation without deleting membership history", whose acceptance criterion requires expiry, refund/chargeback/dispute, suspension, and offboarding to "force safe token refresh/revocation". It is the step the §8.0c claim contract (`membershipClaimReconciliation.js`, MEMBERS-IDENTITY-001E, [#373](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/373)) explicitly DEFERS: §8.0c derives the desired member-claim VALUE (`aligned` / `grant_member` / `revoke_member`) and states that "the actual custom-claim write, token refresh, and revocation remain gated" on later Functions/Admin work. This contract consumes that disposition and derives the distinct next decision — given whether the subject holds an outstanding session and which claims-version that session's token carries, whether to force-revoke outstanding sessions, force a token refresh, or do nothing.
+
+```mermaid
+flowchart LR
+    V["§8.0c disposition + session state + authoritative/observed claims-version"] --> G{"Well-formed evidence?"}
+    G -- "No" --> X["One fixed error, input never echoed"]
+    G -- "Yes" --> R{"reconciliationDisposition?"}
+    R -- "revoke_member" --> FR["force_revoke (unconditional, fail-closed)"]
+    R -- "grant_member" --> GS{"Active session?"}
+    GS -- "Yes" --> RF["force_refresh"]
+    GS -- "No" --> N1["noop — next sign-in mints the claim"]
+    R -- "aligned" --> AS{"Active session?"}
+    AS -- "No" --> N2["noop"]
+    AS -- "Yes" --> VV{"Stamped version equals authoritative?"}
+    VV -- "Yes" --> N3["noop"]
+    VV -- "No" --> RF2["force_refresh — stale claims-version"]
+```
+
+Text alternative: a revoked member authorization always forces session revocation, regardless of the observed session or version evidence, because `revokeRefreshTokens` is idempotent and sets a revocation watermark that invalidates even a session the evidence did not observe. A newly granted claim propagates only on refresh, so an active session is force-refreshed while a subject with no outstanding session is left for the next sign-in to mint the claim. An aligned claim whose value already matches needs nothing unless an active session carries a claims-version that differs from the authoritative cursor, in which case a refresh is forced so version-gated consumers converge. A malformed shape, an unknown enum, a non-integer or negative version, an extra or missing field, an accessor, an inherited field, or a proxy fails through one fixed error that never echoes the input.
+
+The marquee property is fail-closed access removal, proven across the seam: `force_revoke` is emitted if and only if the reconciliation disposition is `revoke_member` — no other path can produce it, and a de-entitlement never resolves to a refresh or a noop. Driving the entire shipped §8.0c input space through the composed pipeline confirms that every path §8.0c resolves to `revoke_member` (a lapsed, suspended, unverified, or decision-pending subject still holding the claim) forces revocation of an active session, so item 4's "expiry/refund/suspension → force safe token revocation" holds for every disposition the claim contract can take. As in §8.0c, the officer (`admin`) role is administered separately and is never touched (`officerRoleAffected: false`), so a lapsed officer's member session is revoked while their admin role is left intact, and the verdict itself confers no membership, price, or role (`grantsAuthority: false`).
+
+The CommonJS module accepts an exact five-field revision-1 evidence object — the §8.0c disposition, the session state, and the authoritative and observed claims-version cursors — and derives one of three frozen non-identifying dispositions with a closed reason. The two version fields are validated as non-negative safe integers even on the `revoke_member` branch that ignores them, so validation is shape-complete rather than decision-driven, mirroring how §8.0c validates `observedOfficerClaim` even though it never affects the outcome. The evidence carries authorization and version state alone — never a token value, provider ID, phone, profile field, roster, address, or secret; "token" names the SESSION being reconciled, not a stored credential.
+
+This contract invents no revocation SLA, grace period, expiry date, timing, or clock: it reads no clock and compares only caller-supplied version cursors, honoring the #114 owner-decision constraint that such values are recorded as versioned server configuration rather than invented. It writes no token, mints and revokes nothing, and derives the reconciliation verdict only; the actual refresh-token revocation and forced re-mint remain gated on the AUTH-001/AUTH-003 Functions/Admin authorization work. The entitlement derivation (§8.0a), the claim-value reconciliation (§8.0c), the officer-role grant path ([#115](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/115)), and the immutable receipt ledger (§8.0f) are separate contracts.
+
+The module is imported by no runtime or Functions index and updates no officer procedure because it makes nothing officer-observable. It requires only `node:util`, reads no clock or environment, calls no Firebase/Stripe/provider service, stores nothing, logs nothing, and changes no current profile/role/claim. Source tests and a merge are not Firebase deployment or live behavior proof.
+
 ### 8.1 Paid race registration
 
 PAY-001B1 [#219](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/219) adds only the browser projection and first two server validation steps below. The website sends the active field set and omits volunteer tier. The callable preserves the opaque event ID, accepts an exact bounded envelope before Firestore, matches answers against the admitted selected server fields, and encodes callback values. It does not add the target request ID, snapshot, transaction, reservation, idempotent Session saga, safe confirmation capability, deployment, or live proof.

--- a/functions/tokenReconciliation.js
+++ b/functions/tokenReconciliation.js
@@ -1,0 +1,249 @@
+'use strict';
+
+// MEMBERS-DUES-001E — pure token-refresh/revocation disposition (pure contract).
+//
+// SOURCE ONLY, UNUSED: this module is imported by nothing (not by
+// functions/index.js, no route, no Firestore Rules, no callable, no webhook, no
+// scheduled worker, no Admin SDK call). It has zero runtime behavior. It is the
+// access-revocation decision core for item 4 of parent #114 (MEMBERS-DUES-001) —
+// "Expiry/reconciliation job and derived Auth-claim/access refresh/revocation
+// without deleting membership history", whose acceptance criterion requires that
+// expiry, refund/chargeback/dispute, suspension, and offboarding "force safe token
+// refresh/revocation". See SYSTEM_DESIGN.md §8.0g.
+//
+// It is the piece the shipped-source claim contract membershipClaimReconciliation.js
+// (MEMBERS-IDENTITY-001E, §8.0c, #373) explicitly DEFERS: that reducer derives the
+// desired member-claim VALUE (aligned / grant_member / revoke_member) and states in
+// its own text that "the actual custom-claim write, token refresh, and revocation
+// remain gated on the AUTH-001/AUTH-003 Functions/Admin authorization work." This
+// module CONSUMES that reconciliation disposition and derives the next, distinct
+// decision: given the desired claim change plus whether the subject holds an
+// outstanding session and which claims-version that session's token carries, whether
+// to FORCE-REVOKE outstanding sessions, FORCE a token REFRESH, or do NOTHING.
+//
+// The marquee property is fail-closed access removal: a revoked member authorization
+// (reconciliationDisposition === 'revoke_member') ALWAYS maps to force_revoke —
+// unconditionally, regardless of the observed session/version evidence — and NO other
+// disposition can produce force_revoke. So a de-entitled subject's outstanding
+// sessions are always invalidated NOW (revokeRefreshTokens is idempotent and sets a
+// revocation watermark, so even a session this evidence did not observe is killed),
+// and a member is never spuriously kicked. A newly granted claim propagates only on
+// refresh, so an active session is force-refreshed to pick it up; a claim that is
+// already the correct VALUE but stamped at a stale claims-version is force-refreshed
+// so version-gated consumers converge; anything already coherent is a noop.
+//
+// Why throwing (the idiom of its §8.0c sibling): the evidence is assembled from
+// trusted authoritative sources — the §8.0c disposition, an Admin-side session query,
+// and the authoritative claims-version cursor. A malformed shape, an unknown enum, a
+// non-integer version, an extra/missing/accessor/inherited field, or a proxy is a
+// caller ASSEMBLY BUG, not a business outcome, so it fails through one fixed error
+// that never echoes the input — exactly as membershipClaimReconciliation.js does. A
+// stale token version or an absent session is a NORMAL state and resolves to a frozen
+// verdict, never a throw.
+//
+// It invents no revocation SLA, grace period, expiry date, timing, or clock: it reads
+// no clock and compares only caller-supplied version cursors, honoring the #114
+// owner-decision constraint ("Do not invent ... grace period ... Record approved
+// values as versioned server configuration"). Membership governs ONLY the member
+// authorization claim; the separately-administered officer (admin) role is never
+// touched (officerRoleAffected: false), and this verdict itself confers no membership,
+// price, or role (grantsAuthority: false). It writes no token, mints/revokes nothing,
+// calls no Firebase/Admin/Stripe/provider service, stores nothing, and logs nothing.
+// The actual refresh-token revocation and forced re-mint remain gated on the
+// AUTH-001/AUTH-003 Functions/Admin authorization work. Source tests and a merge are
+// not Firebase deployment or live-behavior proof.
+
+const { types: { isProxy } } = require('node:util');
+
+const tokenReconciliationSchemaVersion = 1;
+const TOKEN_RECONCILIATION_ERROR_MESSAGE =
+  'Token reconciliation input is invalid.';
+
+const EXPECTED_FIELDS = Object.freeze([
+  'tokenReconciliationSchemaVersion',
+  'reconciliationDisposition',
+  'sessionState',
+  'authoritativeClaimsVersion',
+  'observedTokenClaimsVersion',
+]);
+
+const TOKEN_RECONCILIATION_ENUMS = Object.freeze({
+  // The desired member-claim VALUE derived by membershipClaimReconciliation.js
+  // (MEMBERS-IDENTITY-001E, §8.0c, #373). This module consumes that verdict.
+  reconciliationDisposition: Object.freeze(['aligned', 'grant_member', 'revoke_member']),
+  // Whether the subject currently holds an outstanding refresh-token session.
+  sessionState: Object.freeze(['active_session', 'no_session']),
+  // Output-only token dispositions.
+  action: Object.freeze(['force_revoke', 'force_refresh', 'noop']),
+});
+
+// Only the input enums are validated against the incoming evidence.
+const ENUM_SETS = Object.freeze({
+  reconciliationDisposition: new Set(TOKEN_RECONCILIATION_ENUMS.reconciliationDisposition),
+  sessionState: new Set(TOKEN_RECONCILIATION_ENUMS.sessionState),
+});
+
+// The two claims-version fields are non-negative safe integers. A version cursor is
+// an authoritative monotone counter, never a float, boxed Number, bigint, NaN,
+// Infinity, or negative. Number.isSafeInteger already rejects every non-number,
+// non-integer, and out-of-safe-range value; the >= 0 guard rejects negatives.
+const INTEGER_FIELDS = Object.freeze([
+  'authoritativeClaimsVersion',
+  'observedTokenClaimsVersion',
+]);
+
+class TokenReconciliationError extends Error {
+  constructor() {
+    super(TOKEN_RECONCILIATION_ERROR_MESSAGE);
+    Object.defineProperty(this, 'name', {
+      value: 'TokenReconciliationError',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'message', {
+      value: TOKEN_RECONCILIATION_ERROR_MESSAGE,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(this, 'code', {
+      value: 'invalid_token_reconciliation',
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Error.captureStackTrace?.(this, TokenReconciliationError);
+    Object.freeze(this);
+  }
+}
+
+function fail() {
+  throw new TokenReconciliationError();
+}
+
+function isClaimsVersion(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function readDataObject(value) {
+  if (value === null || typeof value !== 'object' || isProxy(value)) fail();
+
+  let prototype;
+  let keys;
+  try {
+    prototype = Object.getPrototypeOf(value);
+    keys = Reflect.ownKeys(value);
+  } catch {
+    fail();
+  }
+  if (prototype !== Object.prototype) fail();
+
+  const data = Object.create(null);
+  for (const key of keys) {
+    if (typeof key !== 'string' || Object.prototype.hasOwnProperty.call(data, key)) fail();
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch {
+      fail();
+    }
+    if (!descriptor
+      || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined) {
+      fail();
+    }
+    data[key] = descriptor.value;
+  }
+  return { data, keys };
+}
+
+function readExactObject(value, expectedFields) {
+  const { data, keys } = readDataObject(value);
+  if (keys.length !== expectedFields.length) fail();
+  const keySet = new Set(keys);
+  if (expectedFields.some((field) => !keySet.has(field))) fail();
+  return data;
+}
+
+function readExactEvidence(input) {
+  const evidence = readExactObject(input, EXPECTED_FIELDS);
+  if (evidence.tokenReconciliationSchemaVersion !== tokenReconciliationSchemaVersion) fail();
+  for (const [field, allowedValues] of Object.entries(ENUM_SETS)) {
+    if (!allowedValues.has(evidence[field])) fail();
+  }
+  for (const field of INTEGER_FIELDS) {
+    if (!isClaimsVersion(evidence[field])) fail();
+  }
+  return evidence;
+}
+
+function frozenAction(action, reason) {
+  return Object.freeze({
+    tokenReconciliationSchemaVersion,
+    action,
+    reason,
+    // A token verdict never itself confers membership, price, or role...
+    grantsAuthority: false,
+    // ...and membership never grants or revokes the separately-administered
+    // officer (admin) role.
+    officerRoleAffected: false,
+  });
+}
+
+const RESULTS = Object.freeze({
+  // Fail-closed access removal: unconditional, ignoring session/version evidence.
+  forceRevoke: frozenAction('force_revoke', 'deentitled_revoke_sessions'),
+  // A newly granted claim propagates only on refresh.
+  grantRefresh: frozenAction('force_refresh', 'entitled_refresh_active_session'),
+  grantNoSession: frozenAction('noop', 'entitled_pending_next_signin'),
+  // The claim VALUE is correct; only a stale claims-version needs a refresh.
+  alignedStale: frozenAction('force_refresh', 'aligned_stale_claims_version'),
+  alignedCurrent: frozenAction('noop', 'aligned_current_claims_version'),
+  alignedNoSession: frozenAction('noop', 'aligned_no_session'),
+});
+
+function classifyTokenReconciliation(input) {
+  const evidence = readExactEvidence(input);
+
+  // Fail-closed: a revoked member authorization claim forces outstanding sessions
+  // to be revoked NOW, regardless of the observed session/version evidence.
+  // revokeRefreshTokens is idempotent and sets a revocation watermark, so even a
+  // session this evidence did not observe is invalidated. This is the ONLY branch
+  // that yields force_revoke, so force_revoke <=> revoke_member.
+  if (evidence.reconciliationDisposition === 'revoke_member') {
+    return RESULTS.forceRevoke;
+  }
+
+  // A newly granted member claim propagates only on token refresh. An active
+  // session is force-refreshed to pick it up; with no outstanding session the next
+  // sign-in mints the claim on the normal path, so nothing is forced.
+  if (evidence.reconciliationDisposition === 'grant_member') {
+    return evidence.sessionState === 'active_session'
+      ? RESULTS.grantRefresh
+      : RESULTS.grantNoSession;
+  }
+
+  // aligned: the claim VALUE already matches. With no outstanding session there is
+  // nothing to act on. With an active session whose stamped claims-version diverges
+  // from the authoritative cursor, force a refresh so version-gated consumers
+  // converge; an already-current session needs nothing.
+  if (evidence.sessionState === 'no_session') {
+    return RESULTS.alignedNoSession;
+  }
+  return evidence.observedTokenClaimsVersion !== evidence.authoritativeClaimsVersion
+    ? RESULTS.alignedStale
+    : RESULTS.alignedCurrent;
+}
+
+Object.freeze(TokenReconciliationError.prototype);
+Object.freeze(TokenReconciliationError);
+
+module.exports = Object.freeze({
+  tokenReconciliationSchemaVersion,
+  TOKEN_RECONCILIATION_ENUMS,
+  TokenReconciliationError,
+  classifyTokenReconciliation,
+});

--- a/functions/tokenReconciliation.test.js
+++ b/functions/tokenReconciliation.test.js
@@ -30,8 +30,13 @@ const RESULT_KEYS = [
 const DISPOSITIONS = TOKEN_RECONCILIATION_ENUMS.reconciliationDisposition;
 const SESSIONS = TOKEN_RECONCILIATION_ENUMS.sessionState;
 // (authoritativeClaimsVersion, observedTokenClaimsVersion) pairs covering equal,
-// stale-behind, ahead-anomalous, and zero cursors.
-const VERSION_PAIRS = [[7, 7], [7, 6], [6, 7], [0, 0], [0, 1], [1, 0]];
+// stale-behind, ahead-anomalous, zero, negative-zero (must compare equal to 0), and
+// equal/off-by-one at the safe-integer ceiling.
+const MAXV = Number.MAX_SAFE_INTEGER;
+const VERSION_PAIRS = [
+  [7, 7], [7, 6], [6, 7], [0, 0], [0, 1], [1, 0],
+  [0, -0], [-0, 0], [MAXV, MAXV], [MAXV, MAXV - 1],
+];
 
 function evidence(overrides = {}) {
   return {
@@ -65,6 +70,37 @@ function expectedResult(e) {
   return e.observedTokenClaimsVersion !== e.authoritativeClaimsVersion
     ? { action: 'force_refresh', reason: 'aligned_stale_claims_version' }
     : { action: 'noop', reason: 'aligned_current_claims_version' };
+}
+
+// A SECOND, independently-derived oracle built by boolean composition rather than
+// the nested-disposition cascade used by the implementation AND by expectedResult.
+// Agreement between all three is real cross-validation, not a restatement of one
+// shape -- it closes the "the test just mirrors the code" gap for this
+// authorization-critical decision.
+function independentExpected(e) {
+  const mustRevoke = e.reconciliationDisposition === 'revoke_member';
+  const versionsDiffer = e.observedTokenClaimsVersion !== e.authoritativeClaimsVersion;
+  const claimNeedsPropagation =
+    e.reconciliationDisposition === 'grant_member'
+    || (e.reconciliationDisposition === 'aligned' && versionsDiffer);
+  const activeSession = e.sessionState === 'active_session';
+
+  if (mustRevoke) return { action: 'force_revoke', reason: 'deentitled_revoke_sessions' };
+  if (claimNeedsPropagation && activeSession) {
+    return {
+      action: 'force_refresh',
+      reason: e.reconciliationDisposition === 'grant_member'
+        ? 'entitled_refresh_active_session'
+        : 'aligned_stale_claims_version',
+    };
+  }
+  let reason;
+  if (e.reconciliationDisposition === 'grant_member') {
+    reason = 'entitled_pending_next_signin';
+  } else {
+    reason = activeSession ? 'aligned_current_claims_version' : 'aligned_no_session';
+  }
+  return { action: 'noop', reason };
 }
 
 function classifyError(input) {
@@ -110,8 +146,13 @@ describe('token-reconciliation decision matrix', () => {
           expect(TOKEN_RECONCILIATION_ENUMS.action).toContain(result.action);
 
           const expected = expectedResult(e);
+          const independent = independentExpected(e);
+          // The two independently-structured oracles must agree with each other...
+          expect(independent).toEqual(expected);
+          // ...and the module must match them both.
           expect(result.action).toBe(expected.action);
           expect(result.reason).toBe(expected.reason);
+          expect({ action: result.action, reason: result.reason }).toEqual(independent);
 
           if (result.action === 'force_revoke') forceRevokeInputs.push(e);
           count += 1;
@@ -119,7 +160,7 @@ describe('token-reconciliation decision matrix', () => {
       }
     }
     expect(count).toBe(DISPOSITIONS.length * SESSIONS.length * VERSION_PAIRS.length);
-    expect(count).toBe(36);
+    expect(count).toBe(60);
 
     // Crown jewel: force_revoke happens for EXACTLY the revoke_member inputs, and
     // for ALL of them (both directions of the iff).

--- a/functions/tokenReconciliation.test.js
+++ b/functions/tokenReconciliation.test.js
@@ -1,0 +1,630 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  tokenReconciliationSchemaVersion,
+  TOKEN_RECONCILIATION_ENUMS,
+  TokenReconciliationError,
+  classifyTokenReconciliation,
+} = require('./tokenReconciliation');
+
+// The REAL upstream claim-value contract (MEMBERS-IDENTITY-001E, §8.0c). The
+// cross-seam section drives its output into this reducer to prove the composed
+// entitlement -> claim-value -> token-action chain closes item 4's expiry->revoke
+// loop. Nothing is mocked.
+const { classifyClaimReconciliation } = require('./membershipClaimReconciliation');
+
+// A PII/secret-shaped value that must never survive into a result or a thrown error.
+const HOSTILE_CANARY = 'private-member@example.test/+12025550170?token=do-not-copy';
+
+const RESULT_KEYS = [
+  'tokenReconciliationSchemaVersion',
+  'action',
+  'reason',
+  'grantsAuthority',
+  'officerRoleAffected',
+];
+
+const DISPOSITIONS = TOKEN_RECONCILIATION_ENUMS.reconciliationDisposition;
+const SESSIONS = TOKEN_RECONCILIATION_ENUMS.sessionState;
+// (authoritativeClaimsVersion, observedTokenClaimsVersion) pairs covering equal,
+// stale-behind, ahead-anomalous, and zero cursors.
+const VERSION_PAIRS = [[7, 7], [7, 6], [6, 7], [0, 0], [0, 1], [1, 0]];
+
+function evidence(overrides = {}) {
+  return {
+    tokenReconciliationSchemaVersion: 1,
+    reconciliationDisposition: 'aligned',
+    sessionState: 'active_session',
+    authoritativeClaimsVersion: 7,
+    observedTokenClaimsVersion: 7,
+    ...overrides,
+  };
+}
+
+// An independent restatement of the specified semantics (from the issue's decision
+// table), used as the oracle for the exhaustive matrix. It does not call into the
+// module. It proves, by construction, that force_revoke depends ONLY on
+// reconciliationDisposition === 'revoke_member' (never on session/version), that a
+// granted claim refreshes only an active session, and that an aligned claim
+// refreshes only a stale-version active session.
+function expectedResult(e) {
+  if (e.reconciliationDisposition === 'revoke_member') {
+    return { action: 'force_revoke', reason: 'deentitled_revoke_sessions' };
+  }
+  if (e.reconciliationDisposition === 'grant_member') {
+    return e.sessionState === 'active_session'
+      ? { action: 'force_refresh', reason: 'entitled_refresh_active_session' }
+      : { action: 'noop', reason: 'entitled_pending_next_signin' };
+  }
+  if (e.sessionState === 'no_session') {
+    return { action: 'noop', reason: 'aligned_no_session' };
+  }
+  return e.observedTokenClaimsVersion !== e.authoritativeClaimsVersion
+    ? { action: 'force_refresh', reason: 'aligned_stale_claims_version' }
+    : { action: 'noop', reason: 'aligned_current_claims_version' };
+}
+
+function classifyError(input) {
+  try {
+    classifyTokenReconciliation(input);
+  } catch (err) {
+    return err;
+  }
+  return null;
+}
+
+function expectRejected(input) {
+  const err = classifyError(input);
+  expect(err).toBeInstanceOf(TokenReconciliationError);
+  expect(err.message).toBe('Token reconciliation input is invalid.');
+  expect(err.code).toBe('invalid_token_reconciliation');
+  // The fixed error must never echo any part of the offending input.
+  expect(JSON.stringify(err)).not.toContain(HOSTILE_CANARY);
+  expect(String(err)).not.toContain(HOSTILE_CANARY);
+  return err;
+}
+
+describe('token-reconciliation decision matrix', () => {
+  test('every disposition/session/version combination is classified consistently', () => {
+    let count = 0;
+    const forceRevokeInputs = [];
+    for (const reconciliationDisposition of DISPOSITIONS) {
+      for (const sessionState of SESSIONS) {
+        for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+          const e = evidence({
+            reconciliationDisposition,
+            sessionState,
+            authoritativeClaimsVersion,
+            observedTokenClaimsVersion,
+          });
+          const result = classifyTokenReconciliation(e);
+
+          expect(Object.isFrozen(result)).toBe(true);
+          expect(Object.keys(result)).toEqual(RESULT_KEYS);
+          expect(result.tokenReconciliationSchemaVersion).toBe(1);
+          expect(result.grantsAuthority).toBe(false);
+          expect(result.officerRoleAffected).toBe(false);
+          expect(TOKEN_RECONCILIATION_ENUMS.action).toContain(result.action);
+
+          const expected = expectedResult(e);
+          expect(result.action).toBe(expected.action);
+          expect(result.reason).toBe(expected.reason);
+
+          if (result.action === 'force_revoke') forceRevokeInputs.push(e);
+          count += 1;
+        }
+      }
+    }
+    expect(count).toBe(DISPOSITIONS.length * SESSIONS.length * VERSION_PAIRS.length);
+    expect(count).toBe(36);
+
+    // Crown jewel: force_revoke happens for EXACTLY the revoke_member inputs, and
+    // for ALL of them (both directions of the iff).
+    expect(forceRevokeInputs).toHaveLength(SESSIONS.length * VERSION_PAIRS.length);
+    for (const e of forceRevokeInputs) {
+      expect(e.reconciliationDisposition).toBe('revoke_member');
+    }
+  });
+
+  test('force_revoke <=> revoke_member across the whole matrix (no spurious revoke, no missed revoke)', () => {
+    for (const reconciliationDisposition of DISPOSITIONS) {
+      for (const sessionState of SESSIONS) {
+        for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+          const result = classifyTokenReconciliation(evidence({
+            reconciliationDisposition,
+            sessionState,
+            authoritativeClaimsVersion,
+            observedTokenClaimsVersion,
+          }));
+          expect(result.action === 'force_revoke')
+            .toBe(reconciliationDisposition === 'revoke_member');
+        }
+      }
+    }
+  });
+});
+
+describe('explicit dispositions', () => {
+  const cases = [
+    ['revoke_member forces session revocation (active)', {
+      reconciliationDisposition: 'revoke_member', sessionState: 'active_session',
+    }, 'force_revoke', 'deentitled_revoke_sessions'],
+    ['revoke_member forces revocation even with no observed session (fail-closed)', {
+      reconciliationDisposition: 'revoke_member', sessionState: 'no_session',
+    }, 'force_revoke', 'deentitled_revoke_sessions'],
+    ['grant_member forces a refresh on an active session', {
+      reconciliationDisposition: 'grant_member', sessionState: 'active_session',
+    }, 'force_refresh', 'entitled_refresh_active_session'],
+    ['grant_member with no session defers to the next sign-in', {
+      reconciliationDisposition: 'grant_member', sessionState: 'no_session',
+    }, 'noop', 'entitled_pending_next_signin'],
+    ['aligned with a stale-behind claims-version forces a refresh', {
+      reconciliationDisposition: 'aligned', sessionState: 'active_session',
+      authoritativeClaimsVersion: 9, observedTokenClaimsVersion: 8,
+    }, 'force_refresh', 'aligned_stale_claims_version'],
+    ['aligned with an ahead-anomalous claims-version still forces a refresh', {
+      reconciliationDisposition: 'aligned', sessionState: 'active_session',
+      authoritativeClaimsVersion: 8, observedTokenClaimsVersion: 9,
+    }, 'force_refresh', 'aligned_stale_claims_version'],
+    ['aligned with a current claims-version is a noop', {
+      reconciliationDisposition: 'aligned', sessionState: 'active_session',
+      authoritativeClaimsVersion: 9, observedTokenClaimsVersion: 9,
+    }, 'noop', 'aligned_current_claims_version'],
+    ['aligned with no session is a noop', {
+      reconciliationDisposition: 'aligned', sessionState: 'no_session',
+    }, 'noop', 'aligned_no_session'],
+  ];
+
+  test.each(cases)('%s', (_name, overrides, action, reason) => {
+    const result = classifyTokenReconciliation(evidence(overrides));
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(result.action).toBe(action);
+    expect(result.reason).toBe(reason);
+    expect(result.grantsAuthority).toBe(false);
+    expect(result.officerRoleAffected).toBe(false);
+  });
+
+  test('a token verdict never grants authority or affects the officer role', () => {
+    for (const overrides of cases.map((entry) => entry[1])) {
+      const result = classifyTokenReconciliation(evidence(overrides));
+      expect(result.grantsAuthority).toBe(false);
+      expect(result.officerRoleAffected).toBe(false);
+    }
+  });
+});
+
+describe('fail-closed access-revocation invariants', () => {
+  test('revoke_member forces revocation regardless of session state or version cursors', () => {
+    for (const sessionState of SESSIONS) {
+      for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+        const result = classifyTokenReconciliation(evidence({
+          reconciliationDisposition: 'revoke_member',
+          sessionState,
+          authoritativeClaimsVersion,
+          observedTokenClaimsVersion,
+        }));
+        expect(result.action).toBe('force_revoke');
+        expect(result.reason).toBe('deentitled_revoke_sessions');
+      }
+    }
+  });
+
+  test('a still-entitled member (aligned or grant) is never spuriously revoked', () => {
+    for (const reconciliationDisposition of ['aligned', 'grant_member']) {
+      for (const sessionState of SESSIONS) {
+        for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+          const result = classifyTokenReconciliation(evidence({
+            reconciliationDisposition,
+            sessionState,
+            authoritativeClaimsVersion,
+            observedTokenClaimsVersion,
+          }));
+          expect(result.action).not.toBe('force_revoke');
+        }
+      }
+    }
+  });
+
+  test('revoke_member ignores session/version: all such inputs share one frozen verdict', () => {
+    const a = classifyTokenReconciliation(evidence({ reconciliationDisposition: 'revoke_member' }));
+    const b = classifyTokenReconciliation(evidence({
+      reconciliationDisposition: 'revoke_member',
+      sessionState: 'no_session',
+      authoritativeClaimsVersion: 3,
+      observedTokenClaimsVersion: 999,
+    }));
+    // Same precomputed frozen result object, proving the branch reads neither field.
+    expect(a).toBe(b);
+    expect(Object.isFrozen(a)).toBe(true);
+  });
+});
+
+describe('claims-version staleness semantics', () => {
+  test('grant_member on an active session refreshes regardless of the version pair', () => {
+    for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+      const result = classifyTokenReconciliation(evidence({
+        reconciliationDisposition: 'grant_member',
+        sessionState: 'active_session',
+        authoritativeClaimsVersion,
+        observedTokenClaimsVersion,
+      }));
+      expect(result.action).toBe('force_refresh');
+      expect(result.reason).toBe('entitled_refresh_active_session');
+    }
+  });
+
+  test('aligned refreshes exactly when the active session version differs', () => {
+    for (const [authoritativeClaimsVersion, observedTokenClaimsVersion] of VERSION_PAIRS) {
+      const result = classifyTokenReconciliation(evidence({
+        reconciliationDisposition: 'aligned',
+        sessionState: 'active_session',
+        authoritativeClaimsVersion,
+        observedTokenClaimsVersion,
+      }));
+      const differ = authoritativeClaimsVersion !== observedTokenClaimsVersion;
+      expect(result.action).toBe(differ ? 'force_refresh' : 'noop');
+    }
+  });
+
+  test('a large but safe version cursor is accepted', () => {
+    const result = classifyTokenReconciliation(evidence({
+      reconciliationDisposition: 'aligned',
+      sessionState: 'active_session',
+      authoritativeClaimsVersion: Number.MAX_SAFE_INTEGER,
+      observedTokenClaimsVersion: Number.MAX_SAFE_INTEGER - 1,
+    }));
+    expect(result.action).toBe('force_refresh');
+  });
+});
+
+describe('malformed and hostile input is rejected without echo', () => {
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'aligned'],
+    ['a number', 42],
+    ['an array', []],
+    ['a boolean', true],
+  ])('throws on %s', (_name, input) => {
+    expectRejected(input);
+  });
+
+  test('rejects a wrong schema version', () => {
+    expectRejected(evidence({ tokenReconciliationSchemaVersion: 2 }));
+    expectRejected(evidence({ tokenReconciliationSchemaVersion: '1' }));
+  });
+
+  test.each([
+    ['reconciliationDisposition', 'suspend_member'],
+    ['reconciliationDisposition', 'revoke'],
+    ['sessionState', 'expired_session'],
+  ])('rejects an unknown %s value', (field, value) => {
+    expectRejected(evidence({ [field]: value }));
+  });
+
+  test('rejects a boolean where a string enum is required', () => {
+    expectRejected(evidence({ reconciliationDisposition: true }));
+    expectRejected(evidence({ sessionState: false }));
+  });
+
+  test.each([
+    ['a float', 1.5],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+    ['a negative integer', -1],
+    ['a numeric string', '7'],
+    ['a boolean', true],
+    ['a bigint', 7n],
+    ['a boxed Number', new Number(7)],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object', {}],
+    ['just over MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 2],
+  ])('rejects authoritativeClaimsVersion = %s', (_name, value) => {
+    expectRejected(evidence({ authoritativeClaimsVersion: value }));
+  });
+
+  test.each([
+    ['a float', 2.5],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['a negative integer', -3],
+    ['a numeric string', '4'],
+    ['a bigint', 4n],
+    ['a boxed Number', new Number(4)],
+  ])('rejects observedTokenClaimsVersion = %s', (_name, value) => {
+    expectRejected(evidence({ observedTokenClaimsVersion: value }));
+  });
+
+  test('validates the version shape even when the branch ignores it (revoke_member)', () => {
+    // revoke_member never reads the version cursors, but the exact-shape contract
+    // still rejects a malformed one: validation is shape-complete, not decision-driven.
+    expectRejected(evidence({ reconciliationDisposition: 'revoke_member', authoritativeClaimsVersion: -1 }));
+    expectRejected(evidence({ reconciliationDisposition: 'revoke_member', observedTokenClaimsVersion: 1.5 }));
+    // ...and a well-formed revoke_member is still classified.
+    expect(classifyTokenReconciliation(evidence({
+      reconciliationDisposition: 'revoke_member',
+    })).action).toBe('force_revoke');
+  });
+
+  test('rejects a missing field', () => {
+    const missing = evidence();
+    delete missing.observedTokenClaimsVersion;
+    expectRejected(missing);
+  });
+
+  test('rejects an extra field and never reads its value', () => {
+    expectRejected({ ...evidence(), injected: HOSTILE_CANARY });
+  });
+
+  test('rejects a proxy operand', () => {
+    expectRejected(new Proxy(evidence(), {}));
+  });
+
+  test('rejects an accessor field without invoking the getter', () => {
+    let invoked = 0;
+    const accessor = evidence();
+    delete accessor.observedTokenClaimsVersion;
+    Object.defineProperty(accessor, 'observedTokenClaimsVersion', {
+      enumerable: true,
+      configurable: true,
+      get() { invoked += 1; return HOSTILE_CANARY; },
+    });
+    expectRejected(accessor);
+    // Proof the reader used getOwnPropertyDescriptor and never touched the getter.
+    expect(invoked).toBe(0);
+  });
+
+  test('rejects a non-enumerable field', () => {
+    const hidden = evidence();
+    delete hidden.observedTokenClaimsVersion;
+    Object.defineProperty(hidden, 'observedTokenClaimsVersion', {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: 7,
+    });
+    expectRejected(hidden);
+  });
+
+  test('rejects an operand whose fields are inherited', () => {
+    expectRejected(Object.create(evidence()));
+  });
+
+  test('rejects an operand carrying an own symbol key', () => {
+    const withSymbol = evidence();
+    withSymbol[Symbol('extra')] = HOSTILE_CANARY;
+    expectRejected(withSymbol);
+  });
+});
+
+describe('determinism and immutability', () => {
+  test('identical evidence yields a deeply-equal frozen result every time', () => {
+    const e = evidence({ reconciliationDisposition: 'grant_member', sessionState: 'active_session' });
+    const first = classifyTokenReconciliation(e);
+    const second = classifyTokenReconciliation({ ...e });
+    expect(first).toEqual(second);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+
+  test('result is independent of own-key insertion order', () => {
+    const forward = classifyTokenReconciliation({
+      tokenReconciliationSchemaVersion: 1,
+      reconciliationDisposition: 'aligned',
+      sessionState: 'active_session',
+      authoritativeClaimsVersion: 5,
+      observedTokenClaimsVersion: 4,
+    });
+    const shuffled = classifyTokenReconciliation({
+      observedTokenClaimsVersion: 4,
+      sessionState: 'active_session',
+      authoritativeClaimsVersion: 5,
+      reconciliationDisposition: 'aligned',
+      tokenReconciliationSchemaVersion: 1,
+    });
+    expect(shuffled).toEqual(forward);
+    expect(shuffled.action).toBe('force_refresh');
+  });
+
+  test('the returned result cannot be mutated', () => {
+    const result = classifyTokenReconciliation(evidence({ reconciliationDisposition: 'revoke_member' }));
+    expect(() => { result.action = 'noop'; }).toThrow();
+    expect(result.action).toBe('force_revoke');
+  });
+});
+
+describe('cross-seam composition with the real §8.0c claim contract', () => {
+  // Build §8.0c (membershipClaimReconciliation) evidence.
+  function claimEvidence(overrides = {}) {
+    return {
+      claimReconciliationSchemaVersion: 1,
+      entitlementDisposition: 'current_member',
+      emailVerification: 'verified',
+      observedMemberClaim: 'present',
+      observedOfficerClaim: 'none',
+      ...overrides,
+    };
+  }
+
+  // The full item-4 pipeline: entitlement/claim reconciliation -> token disposition.
+  function pipeline(claimOverrides, sessionState, authoritativeClaimsVersion, observedTokenClaimsVersion) {
+    const claim = classifyClaimReconciliation(claimEvidence(claimOverrides));
+    return {
+      claim,
+      token: classifyTokenReconciliation({
+        tokenReconciliationSchemaVersion: 1,
+        reconciliationDisposition: claim.disposition,
+        sessionState,
+        authoritativeClaimsVersion,
+        observedTokenClaimsVersion,
+      }),
+    };
+  }
+
+  test('a lapsed member holding the claim: §8.0c revoke_member -> §8.0g force_revoke', () => {
+    const { claim, token } = pipeline(
+      { entitlementDisposition: 'not_entitled', observedMemberClaim: 'present' },
+      'active_session', 5, 5,
+    );
+    expect(claim.disposition).toBe('revoke_member');
+    expect(token.action).toBe('force_revoke');
+    expect(token.reason).toBe('deentitled_revoke_sessions');
+  });
+
+  test('an unverified member holding the claim: revoke_member -> force_revoke (fail-closed)', () => {
+    const { claim, token } = pipeline(
+      { emailVerification: 'unverified', observedMemberClaim: 'present' },
+      'active_session', 2, 2,
+    );
+    expect(claim.disposition).toBe('revoke_member');
+    expect(token.action).toBe('force_revoke');
+  });
+
+  test('a lapsed OFFICER: member session force-revoked while the admin role is untouched', () => {
+    const { claim, token } = pipeline(
+      { entitlementDisposition: 'not_entitled', observedMemberClaim: 'present', observedOfficerClaim: 'admin' },
+      'active_session', 1, 1,
+    );
+    expect(claim.disposition).toBe('revoke_member');
+    expect(claim.officerRoleAffected).toBe(false);
+    expect(token.action).toBe('force_revoke');
+    expect(token.officerRoleAffected).toBe(false);
+  });
+
+  test('a newly entitled member lacking the claim: grant_member -> force_refresh (active) / noop (no session)', () => {
+    const active = pipeline({ observedMemberClaim: 'absent' }, 'active_session', 3, 3);
+    expect(active.claim.disposition).toBe('grant_member');
+    expect(active.token.action).toBe('force_refresh');
+    expect(active.token.reason).toBe('entitled_refresh_active_session');
+
+    const dormant = pipeline({ observedMemberClaim: 'absent' }, 'no_session', 3, 3);
+    expect(dormant.claim.disposition).toBe('grant_member');
+    expect(dormant.token.action).toBe('noop');
+    expect(dormant.token.reason).toBe('entitled_pending_next_signin');
+  });
+
+  test('an aligned entitled member: stale active session refreshes, current session is a noop', () => {
+    const stale = pipeline({ observedMemberClaim: 'present' }, 'active_session', 8, 7);
+    expect(stale.claim.disposition).toBe('aligned');
+    expect(stale.token.action).toBe('force_refresh');
+    expect(stale.token.reason).toBe('aligned_stale_claims_version');
+
+    const current = pipeline({ observedMemberClaim: 'present' }, 'active_session', 8, 8);
+    expect(current.claim.disposition).toBe('aligned');
+    expect(current.token.action).toBe('noop');
+    expect(current.token.reason).toBe('aligned_current_claims_version');
+  });
+
+  test('loop-closure: every §8.0c de-entitlement forces revocation of an active session', () => {
+    // Drive the entire §8.0c input space through the pipeline. Whenever §8.0c
+    // decides revoke_member, the token action for an active session MUST be
+    // force_revoke -- proving item 4 ("expiry/refund/suspension -> force safe token
+    // revocation") holds across every path the shipped claim contract can take.
+    const ENTITLEMENTS = ['current_member', 'not_entitled', 'decision_pending'];
+    const EMAILS = ['verified', 'unverified'];
+    const MEMBER_CLAIMS = ['present', 'absent'];
+    const OFFICER_CLAIMS = ['admin', 'none'];
+    let revokeCount = 0;
+    for (const entitlementDisposition of ENTITLEMENTS) {
+      for (const emailVerification of EMAILS) {
+        for (const observedMemberClaim of MEMBER_CLAIMS) {
+          for (const observedOfficerClaim of OFFICER_CLAIMS) {
+            const { claim, token } = pipeline(
+              { entitlementDisposition, emailVerification, observedMemberClaim, observedOfficerClaim },
+              'active_session', 4, 4,
+            );
+            if (claim.disposition === 'revoke_member') {
+              revokeCount += 1;
+              expect(token.action).toBe('force_revoke');
+            } else {
+              expect(token.action).not.toBe('force_revoke');
+            }
+          }
+        }
+      }
+    }
+    // Sanity: the space really does contain de-entitlement paths.
+    expect(revokeCount).toBeGreaterThan(0);
+  });
+});
+
+describe('frozen versioned surface', () => {
+  test('exposes a stable version and frozen enums', () => {
+    expect(tokenReconciliationSchemaVersion).toBe(1);
+    expect(Object.isFrozen(TOKEN_RECONCILIATION_ENUMS)).toBe(true);
+    for (const values of Object.values(TOKEN_RECONCILIATION_ENUMS)) {
+      expect(Object.isFrozen(values)).toBe(true);
+    }
+  });
+
+  test('publishes the closed decision vocabularies', () => {
+    expect(TOKEN_RECONCILIATION_ENUMS.reconciliationDisposition).toEqual([
+      'aligned', 'grant_member', 'revoke_member',
+    ]);
+    expect(TOKEN_RECONCILIATION_ENUMS.sessionState).toEqual(['active_session', 'no_session']);
+    expect([...TOKEN_RECONCILIATION_ENUMS.action].sort()).toEqual([
+      'force_refresh', 'force_revoke', 'noop',
+    ]);
+  });
+
+  test('the error type is frozen and carries no input', () => {
+    const err = new TokenReconciliationError();
+    expect(Object.isFrozen(err)).toBe(true);
+    expect(Object.keys(err)).toEqual([]);
+    expect(JSON.stringify(err)).toBe('{}');
+  });
+});
+
+describe('source boundary', () => {
+  const rawSource = fs.readFileSync(path.join(__dirname, 'tokenReconciliation.js'), 'utf8');
+  // Strip comments so legitimate domain narration (this module is ABOUT refresh-token
+  // revocation) is not mistaken for a modeled credential field. The secret/PII
+  // battery runs against executable CODE only.
+  const codeOnly = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/gm, '$1');
+
+  test('is imported by no runtime entrypoint', () => {
+    const index = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+    expect(index).not.toContain('tokenReconciliation');
+  });
+
+  test('requires only node:util', () => {
+    const requires = [...codeOnly.matchAll(/require\(([^)]+)\)/g)].map((match) => match[1]);
+    expect(requires).toEqual(["'node:util'"]);
+  });
+
+  test('the code reads no clock, randomness, network, environment, console, or URL', () => {
+    for (const forbidden of [
+      'process.env', 'Date.now', 'new Date', 'Math.random',
+      'console.', 'fetch(', 'https:', 'http:', 'firebase', 'stripe', 'URL',
+    ]) {
+      expect(codeOnly).not.toContain(forbidden);
+    }
+  });
+
+  test('the code models no credential VALUE, personal-data, or provider-id field', () => {
+    // The data fields are integer version cursors and closed enums -- never a stored
+    // token/secret/PII value. "token" here names the SESSION being reconciled.
+    expect(codeOnly).not.toMatch(/accessToken|refreshToken|clientSecret|api[_]?key|bearer|passwordHash/i);
+    expect(codeOnly).not.toMatch(/phoneNumber|emailAddress|streetAddress|dateOfBirth|emergencyContact/i);
+    expect(codeOnly).not.toMatch(/providerId|providerAccountRef|athleteId|whatsappNumber/i);
+  });
+
+  test('the header names the issue code and the SOURCE ONLY, UNUSED status', () => {
+    expect(rawSource).toContain('MEMBERS-DUES-001E');
+    expect(rawSource).toContain('SOURCE ONLY, UNUSED');
+    expect(rawSource).toContain('§8.0g');
+  });
+
+  test('hard-codes the no-authority and officer-untouched invariants', () => {
+    expect(codeOnly).toContain('grantsAuthority: false');
+    expect(codeOnly).not.toContain('grantsAuthority: true');
+    expect(codeOnly).toContain('officerRoleAffected: false');
+    expect(codeOnly).not.toContain('officerRoleAffected: true');
+  });
+});


### PR DESCRIPTION
Closes #427. Child of #114 (MEMBERS-DUES-001) **tracker item 4** — "Expiry/reconciliation job and derived Auth-claim/access refresh/revocation without deleting membership history"; acceptance criterion "force safe token refresh/revocation". Parent #114 stays OPEN.

## What this adds (SOURCE ONLY, UNUSED)

The pure `node:util`-only contract the shipped §8.0c claim reducer (`membershipClaimReconciliation.js`, MEMBERS-IDENTITY-001E #373) **explicitly defers**: §8.0c derives the desired member-claim VALUE (`aligned`/`grant_member`/`revoke_member`) and states *"the actual custom-claim write, token refresh, and revocation remain gated."* This module consumes that disposition and derives the next, distinct decision — whether outstanding sessions must be force-revoked, a refresh forced, or nothing done.

- `functions/tokenReconciliation.js` — throwing-projector reducer `classifyTokenReconciliation(evidence)` mirroring its §8.0c sibling (same `readExact` machinery, same `grantsAuthority:false`/`officerRoleAffected:false` invariants).
  - **Input** (exact rev-1, 5 fields): `tokenReconciliationSchemaVersion:1`, `reconciliationDisposition` ∈ {`aligned`,`grant_member`,`revoke_member`}, `sessionState` ∈ {`active_session`,`no_session`}, `authoritativeClaimsVersion`/`observedTokenClaimsVersion` (non-negative safe integers).
  - **Output** (frozen): `{ action: force_revoke|force_refresh|noop, reason, grantsAuthority:false, officerRoleAffected:false }`.
  - **Decision (fail-closed):** `revoke_member` → `force_revoke` *unconditionally* (idempotent downstream; sets the revocation watermark so even an unobserved session dies). `grant_member` → active⇒`force_refresh`, no_session⇒noop. `aligned` → active & versions differ⇒`force_refresh` (stale claims-version), else noop.
- `functions/tokenReconciliation.test.js` — 74 negative-heavy tests: full 36-combo matrix vs an independent oracle; malformed/hostile rejection (proxy, accessor with a getter-never-invoked probe, inherited, own-symbol, non-integer/negative/bigint/boxed-Number/`>MAX_SAFE_INTEGER` versions, shape-complete validation even on the branch that ignores versions); determinism/immutability; and a **cross-seam section that drives the REAL `classifyClaimReconciliation` output** through the pipeline over its entire input space.
- `SYSTEM_DESIGN.md` §8.0g — the contract, flowchart, text alternative, and boundary.

## Crown-jewel invariant

`force_revoke` ⟺ `reconciliationDisposition === 'revoke_member'` — de-entitlement ALWAYS kills sessions, no other path yields `force_revoke`, and a revoke never resolves to refresh/noop. The cross-seam test proves that **every** path the shipped §8.0c contract resolves to `revoke_member` (lapsed/suspended/unverified/decision-pending) forces revocation of an active session, closing item 4's "expiry/refund/suspension → force safe token revocation" loop. A lapsed officer's member session is revoked while the separately-administered `admin` role is untouched.

## Safety / scope

Imported by no runtime, route, Rules, callable, webhook, worker, or Admin call → zero runtime behavior. Invents no revocation SLA, grace period, expiry date, or clock — reads no clock, compares only caller-supplied version cursors (per the #114 owner-decision constraint). Writes no token, mints/revokes nothing, calls no Firebase/Stripe/provider service, stores/logs nothing. The data fields are integer version cursors and closed enums — never a token value or secret ("token" names the session being reconciled). Local: 74/74 jest green, ESLint clean. Source tests + merge are **not** Firebase deployment or live-behavior proof.
