### PR TITLE
WEB-001A — Publish exact-delta production header hotfix

### DIFF
--- a/docs/officers/UPDATE_PUBLIC_CONTENT.md
+++ b/docs/officers/UPDATE_PUBLIC_CONTENT.md
@@ -35,8 +35,9 @@ Helpful request:
 2. Confirm the correct name and role of each person shown.
 3. Use a clear JPG or PNG; a square photo works best for officers.
 4. Remove private location or device information when possible.
-5. Tell AI where the photo should appear and provide a short description for screen readers.
+5. Tell AI where the photo should appear. Provide a short description for screen readers unless the photo is only decorative.
 6. Review the crop on phone and computer views.
+7. Confirm the page title and first line of content begin below the blue navigation bar.
 
 Do not publish photos of minors, private events, name badges, addresses, license plates, or private screens without specific approval.
 
@@ -52,7 +53,8 @@ Do not publish photos of minors, private events, name badges, addresses, license
 
 - The exact change appears on `runmprc.com`.
 - Every new link opens correctly without requiring editor access.
-- Photos have correct names and descriptions.
+- Photos have correct names and descriptions, or are correctly marked decorative.
+- Each intended page shows its header photo, and no page text is hidden behind the navigation bar.
 - No unrelated page changed.
 - The delivery report separates “merged” from “verified live.”
 

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.jpg' {
+  const source: string;
+  export default source;
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,11 +6,11 @@ function Header({ title, image, children }) {
     <header className="header">
       <div className="header__container">
         <div className="header__container-lg">
-          <img src={image} alt="Mid-Peninsula Running Club" />
+          <img src={image} alt="" aria-hidden="true" />
         </div>
         <div className="header__content">
-          <h2>{title}</h2>
-          <p>{children}</p>
+          <h1>{title}</h1>
+          {children && <p>{children}</p>}
         </div>
       </div>
     </header>
@@ -20,7 +20,7 @@ function Header({ title, image, children }) {
 Header.propTypes = {
   title: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 export default Header;

--- a/src/components/navbar.css
+++ b/src/components/navbar.css
@@ -1,5 +1,5 @@
 nav {
-  height: 5.5rem;
+  height: var(--site-nav-height);
   width: 100vw; /*100% of the window/browser*/
   background: var(--color-primary);
   display: grid;

--- a/src/headerClearance.test.jsx
+++ b/src/headerClearance.test.jsx
@@ -1,0 +1,172 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import Header from './components/Header';
+import Events from './pages/events/Events';
+import Shop from './pages/shop/Shop';
+import Account from './pages/account/Account';
+import { useServiceLocator } from './services/ServiceLocatorContext';
+import { useAuth } from './services/hooks/useAuth';
+
+jest.mock('./services/ServiceLocatorContext', () => ({
+  useServiceLocator: jest.fn(),
+}));
+
+jest.mock('./services/hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('./pages/account/StravaSection', () => function StravaSection() {
+  return <div data-testid="strava-section" />;
+});
+
+const readStylesheet = (...parts) => readFileSync(join(__dirname, ...parts), 'utf8');
+
+const getRule = (stylesheet, selector) => {
+  const stylesheetWithoutComments = stylesheet.replace(/\/\*[\s\S]*?\*\//g, '');
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = stylesheetWithoutComments.match(
+    new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`),
+  );
+
+  return match?.[1] ?? '';
+};
+
+const defaultAuthState = {
+  user: null,
+  isLoading: false,
+  isAuthenticated: false,
+  isMember: false,
+  isAdmin: false,
+};
+
+const renderPage = (page) => render(
+  <HelmetProvider>
+    <MemoryRouter
+      future={{
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      }}
+    >
+      {page}
+    </MemoryRouter>
+  </HelmetProvider>,
+);
+
+const expectDecorativeHero = (container, title) => {
+  expect(screen.getByRole('heading', { level: 1, name: title })).toBeInTheDocument();
+  expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  const image = container.querySelector('.header img');
+  expect(image).toHaveAttribute('alt', '');
+  expect(image).toHaveAttribute('aria-hidden', 'true');
+};
+
+beforeEach(() => {
+  useServiceLocator.mockReturnValue({ services: null, isReady: false });
+  useAuth.mockReturnValue(defaultAuthState);
+});
+
+describe('persistent navigation clearance', () => {
+  const globalStyles = readStylesheet('index.css');
+  const navbarStyles = readStylesheet('components', 'navbar.css');
+  const homeStyles = readStylesheet('pages', 'home', 'home.css');
+
+  test('uses one shared height for the fixed navigation and main content offset', () => {
+    expect(getRule(globalStyles, ':root')).toMatch(
+      /--site-nav-height:\s*5\.5rem\s*;/,
+    );
+
+    const navigationRule = getRule(navbarStyles, 'nav');
+    expect(navigationRule).toMatch(/height:\s*var\(--site-nav-height\)\s*;/);
+    expect(navigationRule).toMatch(/position:\s*fixed\s*;/);
+    expect(navigationRule).toMatch(/top:\s*0\s*;/);
+
+    const mainRule = getRule(globalStyles, '#main-content');
+    expect(mainRule).toMatch(
+      /padding-top:\s*var\(--site-nav-height\)\s*;/,
+    );
+  });
+
+  test('does not add legacy hero offsets on top of the shared clearance', () => {
+    expect(getRule(globalStyles, '.header')).toMatch(/margin-top:\s*0\s*;/);
+    expect(getRule(homeStyles, '.main__header')).toMatch(/margin-top:\s*0\s*;/);
+  });
+});
+
+describe('shared page hero semantics', () => {
+  test('uses one page heading and omits an empty description', () => {
+    const { container } = render(<Header title="Example page" image="/hero.jpg" />);
+
+    expectDecorativeHero(container, 'Example page');
+    expect(container.querySelector('.header__content p')).not.toBeInTheDocument();
+  });
+
+  test('renders Events with a semantic hero before its section heading', () => {
+    const { container } = renderPage(<Events />);
+
+    expectDecorativeHero(container, 'Events');
+    expect(screen.getByText(
+      'Runs, races, and social gatherings with the MPRC community.',
+    )).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'Upcoming Events',
+    })).toBeInTheDocument();
+  });
+
+  test('renders Shop with a semantic hero before its section heading', () => {
+    const { container } = renderPage(<Shop />);
+
+    expectDecorativeHero(container, 'MPRC Shop');
+    expect(screen.getByText(
+      'Club merchandise and gear for the MPRC community.',
+    )).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'Available merchandise',
+    })).toBeInTheDocument();
+  });
+
+  test('keeps the My Account hero mounted across authentication and profile loading', () => {
+    useAuth.mockReturnValue({
+      ...defaultAuthState,
+      isLoading: true,
+    });
+    const view = renderPage(<Account />);
+    const originalHeader = view.container.querySelector('.header');
+
+    expectDecorativeHero(view.container, 'My Account');
+    expect(screen.getByRole('status')).toHaveTextContent('Loading...');
+
+    useAuth.mockReturnValue({
+      ...defaultAuthState,
+      user: {
+        uid: 'synthetic-user',
+        email: 'member@example.test',
+        role: 'unverified',
+      },
+      isAuthenticated: true,
+    });
+    view.rerender(
+      <HelmetProvider>
+        <MemoryRouter
+          future={{
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+          }}
+        >
+          <Account />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    expect(view.container.querySelector('.header')).toBe(originalHeader);
+    expect(screen.getByText('Loading profile...')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,7 @@
 
   --container-width-lg: 80%;
   --container-width-md: 90%;
+  --site-nav-height: 5.5rem;
 
   --transition: all 500ms ease; /* make sure all transition have a constant effect*/
 }
@@ -62,6 +63,10 @@ body {
   line-height: 1.7;
   overflow-x: hidden;
   background: var(--color-gray-600) url(./images/bg_texture.png);
+}
+
+#main-content {
+  padding-top: var(--site-nav-height);
 }
 
 .container {
@@ -246,7 +251,7 @@ section {
 }
 
 .header {
-  margin-top: 5rem;
+  margin-top: 0;
   height: 20rem;
   overflow: hidden;
   border-bottom: 2px solid var(--color-gray-400);
@@ -278,7 +283,8 @@ section {
   color: var(--color-gray-100);
 }
 
-.header__content h2 {
+.header__content h1 {
+  font-size: 2rem;
   margin-bottom: 1rem;
 }
 

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Link, Navigate, useLocation } from 'react-router-dom';
 import { Timestamp } from 'firebase/firestore';
 import SEO from '../../components/SEO';
+import Header from '../../components/Header';
+import HeaderImage from '../../images/joinus/header_bg_1.jpg';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { useAuth } from '../../services/hooks/useAuth';
 import { Member } from '../../types/member';
@@ -26,6 +28,18 @@ function tsToDate(ts: Timestamp | null | undefined) {
   if (!ts) return '';
   const d = typeof ts.toDate === 'function' ? ts.toDate() : new Date(ts as any);
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export function AccountPageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SEO title="My Account" noindex />
+      <Header title="My Account" image={HeaderImage}>
+        Manage your MPRC profile, registrations, and connected services.
+      </Header>
+      {children}
+    </>
+  );
 }
 
 function ResendVerificationButton() {
@@ -183,11 +197,10 @@ function AccountContent({ user }: { user: NonNullable<ReturnType<typeof useAuth>
   const past = regsData?.registrations.filter((r) => !upcoming.includes(r)) || [];
 
   return (
-    <>
-      <SEO title="My Account" noindex />
+    <div className="account-content">
       <div className="container mx-auto p-4 max-w-3xl">
         <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold">My Account</h1>
+          <h2 className="text-2xl font-bold">Account details</h2>
           <button
             type="button"
             onClick={handleSignOut}
@@ -338,15 +351,21 @@ function AccountContent({ user }: { user: NonNullable<ReturnType<typeof useAuth>
 
         <StravaSection uid={user.uid} />
       </div>
-    </>
+    </div>
   );
 }
 
-function Account() {
+export function Account() {
   const { user, isLoading, isAuthenticated } = useAuth();
   const location = useLocation();
 
-  if (isLoading) return <div className="container mx-auto p-6">Loading...</div>;
+  if (isLoading) {
+    return (
+      <AccountPageShell>
+        <div role="status" className="container mx-auto p-6">Loading...</div>
+      </AccountPageShell>
+    );
+  }
   if (!isAuthenticated || !user) {
     return (
       <Navigate
@@ -356,7 +375,11 @@ function Account() {
       />
     );
   }
-  return <AccountContent user={user} />;
+  return (
+    <AccountPageShell>
+      <AccountContent user={user} />
+    </AccountPageShell>
+  );
 }
 
 export default Account;

--- a/src/pages/events/Events.tsx
+++ b/src/pages/events/Events.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import SEO from '../../components/SEO';
+import Header from '../../components/Header';
+import HeaderImage from '../../images/activities/header_bg_1.jpg';
 import {
   listPublicEvents,
   listMemberEvents,
@@ -113,6 +115,9 @@ function Events() {
         canonicalUrl={SEO_CONFIG.url}
         structuredData={structuredData}
       />
+      <Header title="Events" image={HeaderImage}>
+        Runs, races, and social gatherings with the MPRC community.
+      </Header>
       <div className="container mx-auto p-4 max-w-3xl">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-2xl font-bold">Upcoming Events</h2>
@@ -121,7 +126,13 @@ function Events() {
           </Link>
         </div>
         {loading && <p className="text-gray-500">Loading events...</p>}
-        {error && <p className="text-red-500">Error: {error}</p>}
+        {error && (
+          <p className="text-red-500">
+            Error:
+            {' '}
+            {error}
+          </p>
+        )}
         {!loading && !error && events.length === 0 && (
           <p className="text-gray-500">No events scheduled at this time.</p>
         )}

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -2,7 +2,7 @@
   width: 100vw;
   height: calc(100vh - 3.49rem);
   display: grid;
-  margin-top: 3rem;
+  margin-top: 0;
 }
 
 .main__header-container {

--- a/src/pages/shop/Shop.tsx
+++ b/src/pages/shop/Shop.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../components/SEO';
+import Header from '../../components/Header';
+import HeaderImage from '../../images/home/mprc_home.jpg';
 import { useServiceLocator } from '../../services/ServiceLocatorContext';
 import { Product } from '../../types/shop';
 import { listActiveProducts, formatPrice } from '../../services/shop/shopService';
@@ -26,8 +28,11 @@ function Shop() {
         url="https://runmprc.com/shop"
         canonicalUrl="https://runmprc.com/shop"
       />
+      <Header title="MPRC Shop" image={HeaderImage}>
+        Club merchandise and gear for the MPRC community.
+      </Header>
       <div className="container mx-auto p-4 max-w-5xl">
-        <h1 className="text-2xl font-bold mb-4">MPRC Shop</h1>
+        <h2 className="text-2xl font-bold mb-4">Available merchandise</h2>
         {loading && <p className="text-gray-500">Loading...</p>}
         {error && <p className="text-red-500">{error}</p>}
         {!loading && !error && products.length === 0 && (


### PR DESCRIPTION
## Outcome

Restores readable, image-backed page headers for Events, Shop, and My Account, and applies one shared navigation-clearance rule so every route begins below the fixed navigation bar.

This is a release-only pull request against `codex/production-baseline-e86a0f7`, which is the exact live production source commit `e86a0f702cff6495f50630c5de3337290db8b8cb`. It must never be merged into `main`; current `main` contains substantial unrelated work that is not part of this production hotfix.

Tracks #457.

## Scope and invariants

- Adds the shared header to Events, Shop, and My Account.
- Uses one `--site-nav-height` value for both the fixed navigation and main-content clearance.
- Gives each page exactly one H1 and retains appropriate H2 section headings.
- Marks atmospheric header images as decorative and omits empty descriptions.
- Keeps the My Account header mounted through authentication and profile loading.
- Preserves the existing signed-out redirect and live-baseline account behavior.
- Does not change Firebase, Functions, Firestore Rules, commerce, provider configuration, secrets, or production data.

Failure condition: stop if the preview contains commits beyond the exact live base plus this patch, if public build-variable parity cannot be confirmed privately, or if any reviewed page overlaps the navigation or overflows horizontally.

Rollback: republish the current production Netlify deploy `6a54a3c93db9d300082e1f5f`.

## Verification

- Node.js 20 frontend suite: 5 suites, 53/53 tests passed.
- SPA navigation suite: 10/10 tests passed.
- Focused ESLint: 0 errors; only two pre-existing Account label warnings.
- Diagnostic production build: passed (`main.9ab083e3.js`, `main.9b75243f.css`).
- Local mobile Shop render at 390 × 844: nav bottom 88px, hero top 88px, one H1, expected H2, decorative club image loaded, no horizontal overflow.
- Independent code review: approved after correcting the Shop image and strengthening heading/description assertions.
- `git diff --check`: passed.

## Continuity

Officer impact: Public pages receive readable page titles and header images; content no longer begins underneath the fixed navigation bar.

Officer documentation: `docs/officers/UPDATE_PUBLIC_CONTENT.md`

Deployment evidence: Local production build and browser verification passed. The live site, Firebase, and outside providers are unchanged pending exact-artifact preview verification and Netlify publication.
