### PR TITLE
Rollback: prepare exact prior WEB-002A artifact

### DIFF
--- a/config/netlify-production-release.json
+++ b/config/netlify-production-release.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "active": true,
-  "releaseId": "WEB-002A-2026-07-30",
+  "releaseId": "WEB-002A-ROLLBACK-2026-08-01",
   "issueNumber": 473,
-  "previewBranch": "codex/issue-473-netlify-release",
+  "previewBranch": "codex/issue-473-netlify-rollback",
   "expectedProductionParent": "52fd426662c3d814044aa55eb6104ea1464a5bc6",
   "sourceRepository": "https://github.com/Run-MPRC/Run-MPRC.github.io.git",
-  "sourceRef": "refs/heads/codex/netlify-source-473-shop-events-auth",
-  "sourceCommit": "094af1096ed8721597561cd59bf695d4c4a9d210",
-  "sourceTree": "d12fd7660beaaddac5e952fe950dc6ad6bbdf68f",
-  "previousSourceCommit": "ed1b0833f25822cee80c99ded8753722b5608a3f",
+  "sourceRef": "refs/heads/codex/netlify-source-473-rollback",
+  "sourceCommit": "ed1b0833f25822cee80c99ded8753722b5608a3f",
+  "sourceTree": "878c6628d961f4484cb49208aef53f1e9f2e3b47",
+  "previousSourceCommit": "094af1096ed8721597561cd59bf695d4c4a9d210",
   "rollbackDeployId": "6a61c544171ea80008307623",
-  "expectedSiteFileCount": 59,
-  "expectedSiteFilesSha256": "72f16455fb67b0f00408ed867b69543c94395fb28aaa11cb2d490383de1aed01"
+  "expectedSiteFileCount": 60,
+  "expectedSiteFilesSha256": "7570955c2a00926e5813aef135f1799172cfd046072ac89fb4e492bed0797092"
 }

--- a/tests/release-workflow.test.js
+++ b/tests/release-workflow.test.js
@@ -206,11 +206,11 @@ test('Netlify production is an exact-artifact release while previews remain avai
   });
 });
 
-test('Netlify manifest pins the reviewed merged website source and is armed', () => {
+test('Netlify manifest pins the exact prior website artifact for rollback', () => {
   const loaded = loadManifest(NETLIFY_MANIFEST_PATH);
   assert.equal(loaded.ok, true);
   assert.equal(loaded.manifest.active, true);
-  assert.equal(loaded.manifest.releaseId, 'WEB-002A-2026-07-30');
+  assert.equal(loaded.manifest.releaseId, 'WEB-002A-ROLLBACK-2026-08-01');
   assert.equal(loaded.manifest.issueNumber, 473);
   assert.equal(
     loaded.manifest.expectedProductionParent,
@@ -218,15 +218,15 @@ test('Netlify manifest pins the reviewed merged website source and is armed', ()
   );
   assert.equal(
     loaded.manifest.sourceCommit,
-    '094af1096ed8721597561cd59bf695d4c4a9d210',
+    'ed1b0833f25822cee80c99ded8753722b5608a3f',
   );
   assert.equal(
     loaded.manifest.sourceTree,
-    'd12fd7660beaaddac5e952fe950dc6ad6bbdf68f',
+    '878c6628d961f4484cb49208aef53f1e9f2e3b47',
   );
   assert.equal(
     loaded.manifest.previousSourceCommit,
-    'ed1b0833f25822cee80c99ded8753722b5608a3f',
+    '094af1096ed8721597561cd59bf695d4c4a9d210',
   );
   assert.equal(
     loaded.manifest.rollbackDeployId,
@@ -234,16 +234,16 @@ test('Netlify manifest pins the reviewed merged website source and is armed', ()
   );
   assert.equal(
     loaded.manifest.sourceRef,
-    'refs/heads/codex/netlify-source-473-shop-events-auth',
+    'refs/heads/codex/netlify-source-473-rollback',
   );
   assert.equal(
     loaded.manifest.previewBranch,
-    'codex/issue-473-netlify-release',
+    'codex/issue-473-netlify-rollback',
   );
-  assert.equal(loaded.manifest.expectedSiteFileCount, 59);
+  assert.equal(loaded.manifest.expectedSiteFileCount, 60);
   assert.equal(
     loaded.manifest.expectedSiteFilesSha256,
-    '72f16455fb67b0f00408ed867b69543c94395fb28aaa11cb2d490383de1aed01',
+    '7570955c2a00926e5813aef135f1799172cfd046072ac89fb4e492bed0797092',
   );
 });
 


### PR DESCRIPTION
Preparation-only rollback projection for #473. Do not merge while production is healthy.

This draft temporarily targets the exact #473 control branch so its diff and preview are only the rollback projection. After PR #474 merges, refresh the expected production parent, preserve the reviewed source fields, retarget to main, and require a new exact preview before any incident merge.

Pinned prior artifact source: ed1b0833f25822cee80c99ded8753722b5608a3f
Pinned tree: 878c6628d961f4484cb49208aef53f1e9f2e3b47
Dedicated source ref: refs/heads/codex/netlify-source-473-rollback
Artifact: 60 files; SHA-256 7570955c2a00926e5813aef135f1799172cfd046072ac89fb4e492bed0797092
Current exact projection parent: 52fd426662c3d814044aa55eb6104ea1464a5bc6
Fallback Netlify deploy: 6a61c544171ea80008307623

Officer impact: None while production is healthy. In a separately approved incident, this projection can restore the prior public website after its parent and preview are refreshed and reverified.

Officer documentation: Existing #473 procedure hunks in docs/officers/PUBLISH_AND_CHECK.md and OPERATIONS_RUNBOOK.md. No additional officer procedure changes in this two-file projection.

Deployment evidence: Focused release-policy tests pass 13/13 locally. Hosted CI and the exact pinned rollback preview are required on this draft. No production publication, Firebase deployment, provider action, or data change is authorized.