### PR TITLE
Release: prepare WEB-002A Netlify gate re-pause

### DIFF
--- a/config/netlify-production-release.json
+++ b/config/netlify-production-release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "active": true,
+  "active": false,
   "releaseId": "WEB-002A-2026-07-30",
   "issueNumber": 473,
   "previewBranch": "codex/issue-473-netlify-release",

--- a/tests/release-workflow.test.js
+++ b/tests/release-workflow.test.js
@@ -206,10 +206,10 @@ test('Netlify production is an exact-artifact release while previews remain avai
   });
 });
 
-test('Netlify manifest pins the reviewed merged website source and is armed', () => {
+test('Netlify manifest pins the reviewed merged website source and is paused', () => {
   const loaded = loadManifest(NETLIFY_MANIFEST_PATH);
   assert.equal(loaded.ok, true);
-  assert.equal(loaded.manifest.active, true);
+  assert.equal(loaded.manifest.active, false);
   assert.equal(loaded.manifest.releaseId, 'WEB-002A-2026-07-30');
   assert.equal(loaded.manifest.issueNumber, 473);
   assert.equal(


### PR DESCRIPTION
Prepared follow-up for #473. Do not merge before PR #474 publishes and passes every signed-out production check.

This draft temporarily targets the exact #473 control branch so the diff is only the manifest-disable change. After PR #474 merges and live verification succeeds, retarget this branch to main and merge it to disable the temporary release authority. The pinned release provenance remains unchanged; only active changes from true to false and the focused test records the paused state.

Officer impact: No website content or account behavior changes. This follow-up removes temporary Netlify release authority after the one exact artifact is verified.

Officer documentation: Existing #473 retirement steps in docs/officers/PUBLISH_AND_CHECK.md and OPERATIONS_RUNBOOK.md. No additional officer guide changes in this two-file preparation.

Deployment evidence: Focused release-policy tests pass 13/13 locally. Hosted CI is required. After merge, verify a later Netlify production attempt skips and does not replace the verified website. No Firebase deployment, provider action, or data change is authorized.