### PR TITLE
WEB-002A: repause Netlify after exact rollback

### DIFF
--- a/config/netlify-production-release.json
+++ b/config/netlify-production-release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "active": true,
+  "active": false,
   "releaseId": "WEB-002A-ROLLBACK-2026-08-01",
   "issueNumber": 473,
   "previewBranch": "codex/issue-473-netlify-rollback",

--- a/tests/release-workflow.test.js
+++ b/tests/release-workflow.test.js
@@ -206,10 +206,10 @@ test('Netlify production is an exact-artifact release while previews remain avai
   });
 });
 
-test('Netlify manifest pins the exact prior website artifact for rollback', () => {
+test('Netlify manifest retains the exact rollback provenance and is paused', () => {
   const loaded = loadManifest(NETLIFY_MANIFEST_PATH);
   assert.equal(loaded.ok, true);
-  assert.equal(loaded.manifest.active, true);
+  assert.equal(loaded.manifest.active, false);
   assert.equal(loaded.manifest.releaseId, 'WEB-002A-ROLLBACK-2026-08-01');
   assert.equal(loaded.manifest.issueNumber, 473);
   assert.equal(


### PR DESCRIPTION
Refs #473

Turns the temporary Netlify release manifest off after incident rollback PR #476 restored the exact prior production artifact.

Officer impact: Removes temporary Git-triggered production publication authority. It changes no website page, Firebase surface, provider configuration, account, payment, or production record.

Officer documentation: None in this minimal fail-closed change; the corrected WEB-002A release-control follow-up must record the incident, rollback, and next bounded candidate separately.

Deployment evidence: Production marker at the time of preparation identifies rollback merge `1099ee8e6fdb81141fd9460de175b6d854cbcfdd`, source `ed1b0833f25822cee80c99ded8753722b5608a3f`, tree `878c6628d961f4484cb49208aef53f1e9f2e3b47`, 60 files, and digest `7570955c2a00926e5813aef135f1799172cfd046072ac89fb4e492bed0797092`. Focused release tests pass 13/13. This PR should produce a skipped production attempt and leave that rollback artifact live.
