### PR TITLE
WEB-002A: re-pause bounded containment release

### DIFF
--- a/config/netlify-production-release.json
+++ b/config/netlify-production-release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "active": true,
+  "active": false,
   "releaseId": "WEB-002A-CONTAINMENT-2026-08-01",
   "issueNumber": 473,
   "previewBranch": "codex/issue-473-permissions-containment-release",

--- a/tests/release-workflow.test.js
+++ b/tests/release-workflow.test.js
@@ -206,10 +206,10 @@ test('Netlify production is an exact-artifact release while previews remain avai
   });
 });
 
-test('Netlify manifest pins the bounded permissions-containment artifact', () => {
+test('Netlify manifest retains the bounded containment provenance and is paused', () => {
   const loaded = loadManifest(NETLIFY_MANIFEST_PATH);
   assert.equal(loaded.ok, true);
-  assert.equal(loaded.manifest.active, true);
+  assert.equal(loaded.manifest.active, false);
   assert.equal(loaded.manifest.releaseId, 'WEB-002A-CONTAINMENT-2026-08-01');
   assert.equal(loaded.manifest.issueNumber, 473);
   assert.equal(


### PR DESCRIPTION
## Outcome

Make the temporary #473 Netlify release manifest inactive after the bounded replacement was verified live.

This is the exact two-file fail-closed control prepared before release. It changes no website source or artifact. Once merged, ordinary `main` changes must stop at the inactive-manifest gate instead of reusing the temporary authority.

## Exact scope

- `config/netlify-production-release.json`: `active: true` → `false`; all reviewed provenance remains unchanged.
- `tests/release-workflow.test.js`: rename the focused expectation and require `active: false`.

## Verified release prerequisite

- Release merge: `9ad6837756cdd409d296009fde5082eeeae5c059`
- Published Netlify deploy: `6a6dc9ea588b0c0008036312`
- Source/tree: `39ab8649df411262c8109a3c81a57bc38f1e168b` / `d76b496cdc5e79015bc048cb961758abbe88b9ce`
- Artifact: 60 files; SHA-256 `07b10c7d5ff176a1ad893d7549b07042312df35f4a4126e8765824ca94eaefb8`
- Exact-main CI `30695723173`: all five jobs passed
- Both temporary release-source refs are absent; rollback source `ed1b0833f25822cee80c99ded8753722b5608a3f` remains

## Post-merge stop condition

Do not call #473 complete until exact-main CI passes and Netlify readback proves this merge did not replace production deploy `6a6dc9ea588b0c0008036312` or change the public marker. Publish the final incident/current-truth documentation only after that proof.

Officer impact: no officer action. This removes temporary publication authority; the already-published bounded Shop and Events/Calendar frontend containment should remain unchanged.

Officer documentation: None — final current-state documentation must wait for post-merge provider evidence.

Deployment evidence: Before merge, `runmprc.com` and the Netlify API identify deploy `6a6dc9ea588b0c0008036312` with the exact marker above. After merge, verify Netlify separately; no Firebase, Rules, Functions, outside-provider configuration, account, payment, or production-data action is authorized.
