### PR TITLE
MEMBERS-DUES-001G: remove unapproved membership Offer metadata

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -1155,6 +1155,43 @@ Backup-officer source-review steps:
 
 No system-topology map changes are required because this unused contract changes no data movement, permissions, account ownership, or deployment topology.
 
+## Membership Offer metadata containment — SOURCE ONLY, NOT LIVE
+
+**Status: NOT AVAILABLE YET**
+
+**Purpose:** prevent the Join route's membership structured data from giving search engines or browsers a machine-readable membership price, currency, or annual term before the club approves the versioned membership plan under #114. The visible Join-page dues sentence is unchanged. The separate static `$0` Offer for the free Saturday run is not a membership Offer and remains unchanged.
+
+**Terms:** structured data is page information embedded for search engines. `WebPage` labels the page, `SportsOrganization` labels the club, and `Offer` labels machine-readable price or term information. The separate static `Event` labels the free Saturday run.
+
+**Approver:** membership lead plus treasurer and communications/platform owner.
+
+**Prerequisites:** issue [#486](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/486) and its exact reviewed pull request must be merged for source review. A protected website publication and an exact revision check on `runmprc.com` are required before describing this containment as live. Any future membership `Offer` metadata requires the owner-approved term, price, household meaning, effective date, and change process under #114; visible copy alone is not that approval.
+
+**Steps:**
+
+1. Ask the platform owner for the exact #486 issue, pull request, and merge commit.
+2. Confirm the reviewed Join route test selects the real `/joinus` WebPage schema by its URL.
+3. Confirm that schema's SportsOrganization `mainEntity` has no membership `offers`, `Offer`, `price`, `priceCurrency`, or individual annual-fee description.
+4. Confirm the reviewed shared Join-schema helper has the same membership omissions.
+5. Confirm both tests retain the club organization and Saturday-run event metadata.
+6. Confirm the visible Join page still says `Affordable membership fees: $25/individual or $30/household per calendar year`.
+7. Keep the separate static `$0` Saturday-run Event Offer distinct from the removed membership Offer.
+8. Record source change, tests, merge, website publication, exact `runmprc.com` revision, Firebase deployment, outside-provider configuration, membership or payment data changes, and live behavior as separate results.
+
+**Expected result:** the reviewed Join WebPage/SportsOrganization source keeps useful club and Saturday-run metadata but publishes no machine-readable membership Offer. The separate static Event schema may still describe the Saturday run as free. No officer edits source files, changes provider settings, or changes member or payment records for this task.
+
+**Stop conditions:** the route-owned Join WebPage/SportsOrganization schema retains a membership `Offer`, `offers`, machine-readable membership price, currency, annual-fee description, or unapproved term; the separate free-run Event Offer is confused with membership dues; visible dues copy changes; club or Saturday-run metadata disappears; #114 approval is assumed from existing copy; a provider, Firebase, payment, account, membership record, or production-data action is requested; or source, tests, merge, preview, or a green workflow is presented as proof of live `runmprc.com` behavior.
+
+**Success proof — source completion:** exact #486 issue, pull request, reviewed merge commit, and focused and full frontend results. These prove only the reviewed source outcome.
+
+**Success proof — live containment (separate; not authorized by #486):** a later protected website publication record and dated exact-revision check of the public `/joinus` route-owned WebPage/SportsOrganization structured data. The check identifies the separate static `$0` Saturday-run Event Offer without treating it as membership pricing. Record Firebase, Stripe or another provider, member or payment data, migration, and live membership behavior as not changed unless each has separate private evidence and approval.
+
+**Undo:** before publication, use one reviewed revert or safe roll-forward of the two Offer-removal hunks, focused tests, and this named section. After publication, use the protected website rollback path and verify the exact public revision. Do not restore Offer metadata until #114 records the required owner decisions and a separate reviewed issue implements them.
+
+**Escalation:** membership lead plus treasurer and communications/platform owner. Use the private incident route if machine-readable dues disclose an unintended term or any real member, payment, account, or provider data appears.
+
+No system-topology map changes are required because this source-only removal changes no data movement, permissions, account ownership, or deployment topology.
+
 ## My Account membership truth — SOURCE ONLY, NOT LIVE
 
 **Status: NOT AVAILABLE YET**

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -42,6 +42,7 @@ import {
   listAllProducts,
   lookupOrder,
 } from './services/shop/shopService';
+import { createJoinUsPageSchema } from './services/seo/structuredData';
 import App from './App';
 
 jest.mock('./services/ServiceLocatorProvider', () => function TestServiceLocatorProvider({
@@ -179,6 +180,62 @@ test('renders the MPRC home route without contacting Firebase', () => {
   } finally {
     consoleWarn.mockRestore();
   }
+});
+
+test('keeps the real Join route structured data free of an unapproved membership Offer', async () => {
+  window.history.pushState({}, '', '/joinus');
+  render(<App />);
+
+  const joinSchema = await waitFor(() => {
+    const schemas = Array.from(
+      document.head.querySelectorAll('script[type="application/ld+json"]'),
+      (script) => JSON.parse(script.textContent),
+    );
+    const schema = schemas.find((candidate) => candidate.url === 'https://runmprc.com/joinus');
+
+    expect(schema).toBeDefined();
+    return schema;
+  });
+
+  expect(joinSchema.mainEntity).toMatchObject({
+    '@type': 'SportsOrganization',
+    event: {
+      '@type': 'SportsEvent',
+      name: 'Saturday Morning Run',
+    },
+  });
+  expect(joinSchema.mainEntity).not.toHaveProperty('offers');
+  expect(JSON.stringify(joinSchema)).not.toMatch(
+    /"@type":"Offer"|"price":|"priceCurrency":|Annual membership fee for individuals \(2026\)/,
+  );
+  expect(screen.getByText(
+    'Affordable membership fees: $25/individual or $30/household per calendar year',
+  )).toBeInTheDocument();
+});
+
+test('keeps the shared Join schema helper price-neutral while retaining organization and run data', () => {
+  const schema = createJoinUsPageSchema({
+    pageTitle: 'Synthetic Join Page',
+    pageDescription: 'Synthetic public running-club description',
+    pageUrl: 'https://example.test/join',
+  });
+
+  expect(schema).toMatchObject({
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Synthetic Join Page',
+    mainEntity: {
+      '@type': 'SportsOrganization',
+      event: {
+        '@type': 'SportsEvent',
+        name: 'Saturday Morning Run',
+      },
+    },
+  });
+  expect(schema.mainEntity).not.toHaveProperty('offers');
+  expect(JSON.stringify(schema)).not.toMatch(
+    /"@type":"Offer"|"price":|"priceCurrency":|Annual membership fee for individuals \(2026\)/,
+  );
 });
 
 test('normalizes embedded double slashes before resolving a route', () => {

--- a/src/pages/joinUs/JoinUs.jsx
+++ b/src/pages/joinUs/JoinUs.jsx
@@ -197,12 +197,6 @@ function JoinUs() {
           name: 'Mid-Peninsula Running Club',
         },
       },
-      offers: {
-        '@type': 'Offer',
-        price: '25',
-        priceCurrency: 'USD',
-        description: 'Annual membership fee for individuals (2026)',
-      },
     },
   };
 

--- a/src/services/seo/structuredData.ts
+++ b/src/services/seo/structuredData.ts
@@ -121,12 +121,6 @@ export function createJoinUsPageSchema(options: StructuredDataOptions) {
     mainEntity: {
       ...createSportsOrganizationSchema(),
       event: createSaturdayRunEventSchema(),
-      offers: {
-        '@type': 'Offer',
-        price: '25',
-        priceCurrency: 'USD',
-        description: 'Annual membership fee for individuals (2026)',
-      },
     },
   };
 }


### PR DESCRIPTION
## Outcome

Removes the hardcoded individual membership `Offer` from both Join-page structured-data producers. The route-owned membership schema remains price- and term-neutral until #114 has an owner-approved, versioned server plan.

The club/Saturday-run structured data and visible `$25 individual / $30 household` dues sentence are unchanged. The separate static `$0` Saturday-run Event Offer is also unchanged and is not membership pricing.

## Scope and safety

- Removes only the two `mainEntity.offers` blocks.
- Tests the actual `/joinus` route object selected by URL and the shared helper.
- Retains the Organization and Saturday-run event projections.
- Adds source-only officer containment, stop, proof, undo, and escalation guidance.
- No PII, secrets, authorization, data flow, Firebase, Stripe/provider, account, membership record, payment, migration, analytics, or deployment behavior changes.

## Verification

- RED before fix: 2/2 focused tests failed on the exact hardcoded `Offer` in both producers.
- GREEN after fix: focused 2/2.
- Full frontend: 764/764.
- Workflow/release/artifact/dependency safety: 75/75.
- SPA navigation: 11/11.
- Frontend lint baseline: 111 files; 113 reviewed legacy errors; 6 reviewed legacy warnings.
- Node 20 diagnostic production build: passed.
- Two independent exact-diff reviews: GO after correcting the static free-run Event distinction.
- `git diff --check`: passed.

Officer impact: Officers do not edit structured metadata or approve pricing through this containment. They receive a plain-language way to distinguish source completion from later live proof.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — new “Membership Offer metadata containment — SOURCE ONLY, NOT LIVE” section.

Deployment evidence: Source and local tests only at PR creation. Website publication, exact `runmprc.com` verification, Firebase deployment, outside-provider configuration, production-data action, migration, and live behavior were not performed and are not authorized by this issue.

Closes #486
