### PR TITLE
WEB-UX-003: make mobile navigation state deterministic

### DIFF
--- a/docs/officers/UPDATE_PUBLIC_CONTENT.md
+++ b/docs/officers/UPDATE_PUBLIC_CONTENT.md
@@ -49,6 +49,37 @@ Do not publish photos of minors, private events, name badges, addresses, license
 4. Check spelling, title, photo, order, and old-officer removal.
 5. Ask AI to confirm no account permissions changed. Website display and GitHub/Firebase access are separate.
 
+## Phone navigation preview check — NOT LIVE YET
+
+**Purpose:** confirm that the small-screen menu is predictable before a website release.
+
+**Approver:** communications lead or platform owner.
+
+**Before you start:** have the reviewed preview link. Stay signed out and use no private information.
+
+1. Open the preview at a phone-sized width.
+2. Select the MPRC logo while the menu is closed.
+3. Confirm Home opens and the menu stays closed.
+4. Open the menu with its button.
+5. Select one public page and confirm the menu closes.
+6. Reopen the menu and select Sign in.
+7. Confirm the Sign in page opens and the menu closes.
+8. Use Tab and Enter to repeat the open, close, and public-page check.
+9. Open the preview at a normal computer width.
+10. Confirm the navigation links remain visible and work normally.
+
+**Expected result:** only the menu button opens the menu; the logo or any destination closes it after opening the correct page.
+
+**Stop conditions:** stop if a destination is wrong, the logo opens the menu, the menu stays open after a choice, keyboard use fails, or computer navigation changes.
+
+**Success proof:** record the preview link, check date, phone and computer widths, tested destination, keyboard result, and pass or fail. Keep accounts and private information out of screenshots.
+
+**Undo:** ask the platform maintainer for one revert pull request. Do not publish a second fix at the same time.
+
+**Escalation:** platform owner first; accessibility reviewer second.
+
+This check describes #490 source and preview behavior only. It is **NOT LIVE YET** until an approved exact website release is published and the same checks pass on `runmprc.com`.
+
 ## Success check
 
 - The exact change appears on `runmprc.com`.

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -7,11 +7,14 @@ import './navbar.css';
 import Logo from '../assets/images/logo.svg';
 import { useAuth } from '../services/hooks/useAuth';
 
+const PRIMARY_NAVIGATION_ID = 'primary-navigation';
+
 function Navbar() {
   const [isNavShowing, setIsNavShowing] = useState(false);
   const { isAuthenticated } = useAuth();
 
   const handleNavToggle = () => setIsNavShowing((prevValue) => !prevValue);
+  const handleNavClose = () => setIsNavShowing(false);
 
   const baseAnimationDelay = 100;
   const staggeredAnimationDelayIncrement = 50;
@@ -25,10 +28,11 @@ function Navbar() {
   return (
     <nav>
       <div className="container nav__container">
-        <Link to="/" className="logo" onClick={handleNavToggle}>
+        <Link to="/" className="logo" onClick={handleNavClose}>
           <img src={Logo} alt="MPRC Logo" />
         </Link>
         <ul
+          id={PRIMARY_NAVIGATION_ID}
           className={`nav__links ${isNavShowing ? 'show__nav' : 'hide__nav'}`}
         >
           {/* Destructure the links array of object from the links to get each item */}
@@ -37,7 +41,7 @@ function Navbar() {
               <NavLink
                 to={path}
                 className={({ isActive }) => (isActive ? 'active-nav' : '')}
-                onClick={handleNavToggle}
+                onClick={handleNavClose}
               >
                 {name}
               </NavLink>
@@ -47,7 +51,7 @@ function Navbar() {
             <NavLink
               to={isAuthenticated ? '/account' : '/login'}
               className={({ isActive }) => (isActive ? 'active-nav' : '')}
-              onClick={handleNavToggle}
+              onClick={handleNavClose}
             >
               {isAuthenticated ? 'My Account' : 'Sign in'}
             </NavLink>
@@ -59,6 +63,8 @@ function Navbar() {
           onClick={handleNavToggle}
           className="nav__toggle-btn"
           aria-label={isNavShowing ? 'Close navigation menu' : 'Open navigation menu'}
+          aria-controls={PRIMARY_NAVIGATION_ID}
+          aria-expanded={isNavShowing}
         >
           {isNavShowing ? <MdOutlineClose /> : <FaBars />}
         </button>

--- a/src/headerClearance.test.js
+++ b/src/headerClearance.test.js
@@ -3,8 +3,14 @@
 import React from 'react';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Header from './components/Header';
+import Navbar from './components/Navbar';
+
+jest.mock('./services/hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+}));
 
 const readStylesheet = (...parts) => readFileSync(join(__dirname, ...parts), 'utf8');
 
@@ -97,6 +103,62 @@ describe('persistent navigation clearance', () => {
   test('does not add legacy hero offsets on top of the shared clearance', () => {
     expect(getRule(globalStyles, '.header')).toMatch(/margin-top:\s*0\s*;/);
     expect(getRule(homeStyles, '.main__header')).toMatch(/margin-top:\s*0\s*;/);
+  });
+});
+
+describe('mobile navigation disclosure semantics', () => {
+  const renderNavbar = () => render(React.createElement(
+    MemoryRouter,
+    {
+      initialEntries: ['/synthetic-start'],
+      future: { v7_startTransition: true, v7_relativeSplatPath: true },
+    },
+    React.createElement(Navbar),
+  ));
+
+  const expectMenuState = (toggle, list, isOpen) => {
+    expect(list).toHaveClass(isOpen ? 'show__nav' : 'hide__nav');
+    expect(list).not.toHaveClass(isOpen ? 'hide__nav' : 'show__nav');
+    expect(toggle).toHaveAttribute('aria-expanded', String(isOpen));
+    expect(toggle).toHaveAccessibleName(
+      isOpen ? 'Close navigation menu' : 'Open navigation menu',
+    );
+  };
+
+  test('binds the toggle disclosure state to one stable navigation list', () => {
+    renderNavbar();
+
+    const toggle = screen.getByRole('button', { name: 'Open navigation menu' });
+    const list = screen.getByRole('list');
+    expect(list.id).toBe('primary-navigation');
+    expect(document.querySelectorAll(`#${list.id}`)).toHaveLength(1);
+    expect(toggle).toHaveAttribute('aria-controls', list.id);
+    expectMenuState(toggle, list, false);
+
+    fireEvent.click(toggle);
+    expectMenuState(toggle, list, true);
+
+    fireEvent.click(toggle);
+    expectMenuState(toggle, list, false);
+  });
+
+  test.each([
+    ['MPRC logo', () => screen.getByRole('link', { name: 'MPRC Logo' })],
+    ['ordinary destination', () => screen.getByRole('link', { name: 'Join Us' })],
+    ['authentication destination', () => screen.getByRole('link', { name: 'Sign in' })],
+  ])('selecting the %s always leaves the menu closed', (_label, getTarget) => {
+    renderNavbar();
+
+    const toggle = screen.getByRole('button', { name: 'Open navigation menu' });
+    const list = screen.getByRole('list');
+
+    fireEvent.click(getTarget());
+    expectMenuState(toggle, list, false);
+
+    fireEvent.click(toggle);
+    expectMenuState(toggle, list, true);
+    fireEvent.click(getTarget());
+    expectMenuState(toggle, list, false);
   });
 });
 


### PR DESCRIPTION
## Outcome

Phone navigation now opens only from its menu button, closes after the logo or any destination is chosen, and exposes its state to assistive technology.

## Scope

- Issue: Closes #490.
- What changed: split toggle and close intent in `Navbar`; linked the toggle to one stable list with `aria-expanded` and `aria-controls`; added focused regression coverage; added a plain-language phone/desktop preview check.
- What did not change: CSS, destinations, Auth policy, routes, data, dependencies, workflows, Firebase, providers, production data, or release controls.

## Officer handoff

- Officer impact: Members using phones get predictable navigation, including an explicit open/closed state for assistive technology.
- Officer documentation: `docs/officers/UPDATE_PUBLIC_CONTENT.md`
- Approving role: communications lead or platform owner.
- Preview or redacted screenshot: Local synthetic signed-out preview checked at 390x844 and 1280x900 with no private data; hosted PR preview pending.
- Screenshot checked at: 2026-08-01.
- Plain-language undo plan: ask the platform maintainer for one revert pull request; do not publish a competing fix.
- Deployment evidence: exact head `ccc470a7fec428e05df34133212cea7cf0c006a5` is source-only. Local tests/build/browser checks passed. Nothing is merged or published yet.

## Proof by surface

- Source changed: exactly the three claimed files on `ccc470a7fec428e05df34133212cea7cf0c006a5`.
- Tests passed: RED on old code failed the four missing/disagreeing behaviors; GREEN focused 12/12; full frontend 768/768; SPA 11/11; workflow/release/artifact/dependency safety 76/76; lint baseline 111 files / 113 reviewed legacy errors / 6 reviewed legacy warnings; Node 20 diagnostic build compiled successfully.
- Browser preview: at 390x844, the list was hidden initially, toggle state tracked visibility, and logo, Join Us, and Sign in navigation left the list closed; at 1280x900, the button stayed hidden and links stayed visible. The guide retains a required manual Tab/Enter check before publication.
- Independent review: behavior/accessibility GO and scope/officer-documentation GO; no blocking findings.
- Code merged: not yet.
- Website published: not yet.
- Netlify intended commit verified: not yet.
- `runmprc.com` verified: not yet.
- Firebase deployed: not relevant; no Firebase files changed and no deployment was attempted.
- Outside provider configured: not relevant.
- Outside provider verified: not relevant.
- Production behavior verified: not yet.

## Safety review

- [x] No secrets, recovery codes, private member data, or payment data are included.
- [x] Planned behavior is marked `NOT AVAILABLE YET`.
- [x] Skipped checks or deployments are reported as incomplete, not green/live.
- [x] No diagram changed because page hierarchy, destinations, data flow, permissions, and deployment topology are unchanged.
- [x] A backup officer can follow the affected guide without a terminal.