### PR TITLE
fix: bind Admin Products results to current database

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -2320,48 +2320,58 @@ Until that issue closes, request event/product changes through [Request a change
 
 **Status: NOT AVAILABLE YET**
 
-**Purpose:** give an officer one plain instruction when the Admin Products list cannot load, without showing a Firebase, database, provider, account, endpoint, token-shaped, or technical detail and without falsely saying that the catalog is empty.
+**Purpose:** give an officer one plain instruction when the Admin Products list cannot load, without showing a Firebase, database, provider, account, endpoint, token-shaped, or technical detail, without falsely saying that the catalog is empty, and without showing a result left over from an earlier database or readiness state.
 
 **Approver:** shop lead plus platform/security and privacy owners. Add the treasurer before any future live commerce-admin review.
 
-**Prerequisites:** issue [#277](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/277) must be merged for source review. Use only a mocked admin identity, mocked database reference, made-up product, and mocked rejected list lookup. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply: this slice does not approve the screen, role, permissions, backup, preview, rollback, product editing, publication, checkout, or production use. It does not deploy Firebase, change database permissions or product records, contact Stripe or another provider, use production data, or prove live behavior.
+**Prerequisites:** issues [#277](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/277) and [#498](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/498) must be merged for source review. Use only a mocked admin identity, mocked database references, made-up products, mocked readiness changes, and mocked fulfilled or rejected list lookups. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply: these slices do not approve the screen, role, permissions, backup, preview, rollback, product editing, publication, checkout, or production use. They do not deploy Firebase, change database permissions or product records, contact Stripe or another provider, use production data, or prove live behavior.
 
 ```mermaid
 flowchart LR
-    A["Made-up Admin Products route"] --> B["Mocked product-list lookup"]
+    A["Made-up Admin Products route"] --> B["Current mocked database lookup"]
     B -- "Fulfilled empty" --> C["Existing No products yet state"]
     B -- "Fulfilled with products" --> D["Existing product table"]
     B -- "Rejected" --> E["Fixed alert; no empty state or table"]
+    F["Database or readiness changes"] --> G["Immediate loading state; old results hidden"]
+    G --> B
+    H["Older result or result received after leaving"] -. "Ignored" .-> I["No page change; current result stays or page stays closed"]
 ```
 
-In words: only a successful mocked lookup may show the existing empty catalog or product table. A mocked rejection shows one fixed alert while keeping the Products heading and navigation; it does not turn an unknown result into an empty catalog.
+In words: only a successful lookup for the current mocked database may show the existing empty catalog or product table. A mocked rejection shows one fixed alert while keeping the Products heading and navigation; it does not turn an unknown result into an empty catalog. A database or readiness change hides the earlier result immediately, and an older result or a result received after leaving the page cannot settle the page.
 
 Officer review steps after the source merge:
 
 1. Keep the Admin product-list failure sentence and the complete Admin Products screen marked **NOT AVAILABLE YET**.
-2. Ask the platform owner for the exact #277 issue, reviewed pull request, merged commit, and synthetic frontend test result.
-3. Confirm the tests use only a made-up admin identity, mocked database reference, made-up product, and mocked lookup. Do not use a real officer account or product record.
+2. Ask the platform owner for the exact #277 and #498 issues, reviewed pull requests, merged commits, and synthetic frontend test results.
+3. Confirm the tests use only a made-up admin identity, mocked database references, made-up products, mocked readiness changes, and mocked lookups. Do not use a real officer account or product record.
 4. Confirm a mocked rejection shows exactly `We could not load products right now. Please try again later.`
 5. Confirm assistive technology receives the complete sentence immediately as one alert.
 6. Confirm no made-up rejection-only email, database, Firebase, provider, account, endpoint, token-shaped, or technical detail appears on the page, in analytics, or in five browser console methods.
 7. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
 8. Confirm the rejected lookup ends loading and shows neither **No products yet** nor a product table.
 9. Confirm the **Products** heading and existing **Orders** and **New product** links remain available without following either link.
-10. Confirm the mocked lookup receives the same mocked database reference exactly once.
+10. Confirm each current mocked lookup receives its matching mocked database reference exactly once.
 11. Confirm a successful mocked empty list still shows **No products yet**, and a successful made-up product still shows its existing title, price, status, and edit link.
-12. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, product-record, production-data, admin-screen approval, and live-behavior evidence as separate results.
+12. Confirm giving the page the same ready mocked database again does not start another lookup when only its surrounding test setup object is replaced.
+13. Confirm a not-ready page with a mocked database and a ready page without a mocked database both stay in loading and start no lookup.
+14. Confirm a changed database hides the earlier empty result, product table, or failure immediately.
+15. Confirm loss of readiness hides the earlier empty result, product table, or failure immediately.
+16. Confirm readiness recovery starts one new lookup for the current database and never briefly shows the earlier result, including when the exact same database returns.
+17. Confirm an older success or hostile rejection cannot replace a newer result.
+18. Confirm a success or hostile rejection received after leaving the page causes no page change and is not inspected.
+19. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, product-record, production-data, admin-screen approval, and live-behavior evidence as separate results.
 
-**Expected result:** the reviewed source discards the complete rejected value without binding or inspecting it and shows one fixed accessible retry-later sentence. A failure is not treated as an empty or populated catalog. The Products heading and navigation remain, while genuine successful empty and populated results keep their existing displays. This does not authorize an officer to open or use the Admin Products screen live.
+**Expected result:** the reviewed source discards the complete rejected value without binding or inspecting it and shows one fixed accessible retry-later sentence. A failure is not treated as an empty or populated catalog. Only the current ready database may supply the displayed result; database and readiness changes hide older results immediately, and an older result or a result received after leaving the page causes no change. Replacing only the surrounding test setup object does not repeat a lookup for the same ready database. The Products heading and navigation remain, while genuine successful empty and populated results keep their existing displays. This does not authorize an officer to open or use the Admin Products screen live.
 
-**Stop conditions:** any real officer, member, product, price, inventory, order, checkout, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; the false empty state or a product table after rejection; an attempted product/admin write; a Firebase, Rules, provider, or permission change; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or Admin screen is live.
+**Stop conditions:** any real officer, member, product, price, inventory, order, checkout, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; the false empty state or a product table after rejection; an earlier catalog result visible after the database or readiness changes; an obsolete result settling the page; an attempted product/admin write; a Firebase, Rules, provider, or permission change; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or Admin screen is live.
 
-**Success proof:** for source completion, record the exact #277 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic actual-route tests, relevant full checks, and independent privacy, accessibility, and officer-continuity reviews. The safe review path stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, database-permission changes, provider configuration, product-record changes, production-data actions, and live behavior as **not performed** for this frontend-only slice unless separate evidence proves otherwise.
+**Success proof:** for source completion, record the exact #277 and #498 issues, reviewed pull requests, merged commits, intended old-source failures, green synthetic actual-route tests, relevant full checks, and independent privacy, accessibility, lifecycle, and officer-continuity reviews. The safe review path stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, database-permission changes, provider configuration, product-record changes, production-data actions, and live behavior as **not performed** for these frontend-only slices unless separate evidence proves otherwise.
 
 **Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After any later approved publication, use the same protected website release path and verify the replacement revision. Do not undo by changing or deleting a product, order, payment, officer account, permission, database record, source document, or provider setting.
 
 **Escalation:** shop lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, Firebase, provider, account, product, order, payment, endpoint, token-shaped, or technical detail appeared. Add the treasurer if a commerce or payment state might be involved. Do not copy private details into an issue, message, screenshot, email, or AI tool.
 
-No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display and current mocked lookup lifecycle.
 
 ### Admin Product editor load failure privacy — SOURCE ONLY, NOT LIVE
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -3853,6 +3853,309 @@ describe('Admin Products list-load failure boundary', () => {
   });
 });
 
+describe('WEB-PRIVACY-001X Admin Products current-context lifecycle', () => {
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+  }
+
+  function syntheticListedProduct({
+    id = 'synthetic-listed-product',
+    slug = id,
+    title = 'Synthetic Listed Product',
+    priceCents = 2500,
+    status = 'active',
+  } = {}) {
+    return {
+      id,
+      slug,
+      title,
+      description: 'A made-up product used only for this test.',
+      imageUrl: '',
+      priceCents,
+      status,
+      sizes: [],
+      colors: [],
+    };
+  }
+
+  function configureAdminProductsContext({
+    database = firestore,
+    ready = true,
+    servicesAvailable = true,
+  } = {}) {
+    useServiceLocator.mockReturnValue({
+      services: servicesAvailable ? { firebaseResources: { firestore: database } } : null,
+      isReady: ready,
+    });
+  }
+
+  function expectProductResultsHidden() {
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create one' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+  }
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    configureAdminProductsContext();
+    listAllProducts.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('starts no lookup and exposes no catalog result before services are ready', async () => {
+    configureAdminProductsContext({ ready: false });
+
+    renderAdminProducts();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Products' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectProductResultsHidden();
+    expect(listAllProducts).not.toHaveBeenCalled();
+  });
+
+  test('starts no lookup and exposes no catalog result without a database', async () => {
+    configureAdminProductsContext({ database: null });
+
+    renderAdminProducts();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Products' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectProductResultsHidden();
+    expect(listAllProducts).not.toHaveBeenCalled();
+  });
+
+  test('does not reload when only the services wrapper changes', async () => {
+    listAllProducts.mockResolvedValueOnce([syntheticListedProduct()]);
+    const view = renderAdminProducts();
+    expect(await screen.findByText('Synthetic Listed Product')).toBeInTheDocument();
+
+    configureAdminProductsContext();
+    view.rerender(<App />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByText('Synthetic Listed Product')).toBeInTheDocument();
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
+    expect(listAllProducts).toHaveBeenCalledWith(firestore);
+  });
+
+  test('hides earlier products while a changed-database lookup is pending and rejected', async () => {
+    listAllProducts.mockResolvedValueOnce([syntheticListedProduct({
+      title: 'Earlier Synthetic Product',
+    })]);
+    const view = renderAdminProducts();
+    expect(await screen.findByText('Earlier Synthetic Product')).toBeInTheDocument();
+
+    const currentLookup = deferred();
+    listAllProducts.mockReturnValueOnce(currentLookup.promise);
+    const currentFirestore = { name: 'synthetic-current-products-firestore' };
+    configureAdminProductsContext({ database: currentFirestore });
+    view.rerender(<App />);
+
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Synthetic Product')).not.toBeInTheDocument();
+    expectProductResultsHidden();
+
+    await act(async () => { currentLookup.reject(new Error('synthetic current failure')); });
+    expect((await screen.findByRole('alert')).textContent).toBe(ADMIN_PRODUCTS_LOAD_FAILURE);
+    expect(screen.queryByText('Earlier Synthetic Product')).not.toBeInTheDocument();
+    expectProductResultsHidden();
+    expect(listAllProducts).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllProducts).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('hides earlier products when readiness is lost and reloads the same database after recovery', async () => {
+    listAllProducts.mockResolvedValueOnce([syntheticListedProduct({
+      title: 'Earlier Ready Product',
+    })]);
+    const view = renderAdminProducts();
+    expect(await screen.findByText('Earlier Ready Product')).toBeInTheDocument();
+
+    configureAdminProductsContext({ ready: false });
+    view.rerender(<App />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Ready Product')).not.toBeInTheDocument();
+    expectProductResultsHidden();
+    expect(listAllProducts).toHaveBeenCalledTimes(1);
+
+    const recoveredLookup = deferred();
+    listAllProducts.mockReturnValueOnce(recoveredLookup.promise);
+    const staleAdditions = [];
+    const observer = new MutationObserver((records) => {
+      records.forEach((record) => record.addedNodes.forEach((node) => {
+        if (node.textContent?.includes('Earlier Ready Product')) staleAdditions.push(node);
+      }));
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    configureAdminProductsContext();
+    view.rerender(<App />);
+
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(2));
+    await act(async () => { await Promise.resolve(); });
+    observer.disconnect();
+    expect(staleAdditions).toHaveLength(0);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Ready Product')).not.toBeInTheDocument();
+    expectProductResultsHidden();
+
+    await act(async () => {
+      recoveredLookup.resolve([syntheticListedProduct({
+        id: 'synthetic-recovered-product',
+        title: 'Recovered Current Product',
+      })]);
+    });
+    expect(await screen.findByText('Recovered Current Product')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Ready Product')).not.toBeInTheDocument();
+    expect(listAllProducts).toHaveBeenCalledTimes(2);
+    expect(listAllProducts).toHaveBeenNthCalledWith(2, firestore);
+  });
+
+  test('keeps a newer empty result when an older lookup later resolves', async () => {
+    const olderLookup = deferred();
+    listAllProducts.mockReturnValueOnce(olderLookup.promise);
+    const view = renderAdminProducts();
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-newer-empty-products-firestore' };
+    listAllProducts.mockResolvedValueOnce([]);
+    configureAdminProductsContext({ database: currentFirestore });
+    view.rerender(<App />);
+    expect(await screen.findByRole('link', { name: 'Create one' })).toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.resolve([syntheticListedProduct({ title: 'Obsolete Synthetic Product' })]);
+    });
+
+    expect(screen.getByRole('link', { name: 'Create one' })).toBeInTheDocument();
+    expect(screen.queryByText('Obsolete Synthetic Product')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('keeps a newer product when an older hostile rejection later arrives', async () => {
+    const olderLookup = deferred();
+    listAllProducts.mockReturnValueOnce(olderLookup.promise);
+    const view = renderAdminProducts();
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-newer-product-firestore' };
+    listAllProducts.mockResolvedValueOnce([syntheticListedProduct({
+      id: 'synthetic-current-product',
+      title: 'Current Synthetic Product',
+    })]);
+    configureAdminProductsContext({ database: currentFirestore });
+    view.rerender(<App />);
+    expect(await screen.findByText('Current Synthetic Product')).toBeInTheDocument();
+
+    const messageGetter = jest.fn(() => 'obsolete-products-private-canary');
+    await act(async () => {
+      olderLookup.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Current Synthetic Product')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-products-private-canary');
+  });
+
+  test('treats ready to not-ready to ready as distinct generations for the same database', async () => {
+    const olderLookup = deferred();
+    listAllProducts.mockReturnValueOnce(olderLookup.promise);
+    const view = renderAdminProducts();
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(1));
+
+    configureAdminProductsContext({ ready: false });
+    view.rerender(<App />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectProductResultsHidden();
+
+    listAllProducts.mockResolvedValueOnce([syntheticListedProduct({
+      id: 'synthetic-current-a-product',
+      title: 'Current A Product',
+    })]);
+    configureAdminProductsContext();
+    view.rerender(<App />);
+    expect(await screen.findByText('Current A Product')).toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.resolve([syntheticListedProduct({
+        id: 'synthetic-obsolete-a-product',
+        title: 'Obsolete A Product',
+      })]);
+    });
+
+    expect(screen.getByText('Current A Product')).toBeInTheDocument();
+    expect(screen.queryByText('Obsolete A Product')).not.toBeInTheDocument();
+    expect(listAllProducts).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not inspect a hostile rejection after the page unmounts', async () => {
+    const lookup = deferred();
+    listAllProducts.mockReturnValueOnce(lookup.promise);
+    const view = renderAdminProducts();
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const messageGetter = jest.fn(() => 'unmounted-products-private-canary');
+    await act(async () => {
+      lookup.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('does not inspect or display a successful result after the page unmounts', async () => {
+    const lookup = deferred();
+    listAllProducts.mockReturnValueOnce(lookup.promise);
+    const view = renderAdminProducts();
+    await waitFor(() => expect(listAllProducts).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const titleGetter = jest.fn(() => 'Unmounted Synthetic Product');
+    const product = Object.defineProperty(syntheticListedProduct(), 'title', {
+      configurable: true,
+      get: titleGetter,
+    });
+    await act(async () => {
+      lookup.resolve([product]);
+      await Promise.resolve();
+    });
+
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('Unmounted Synthetic Product');
+    expect(track).not.toHaveBeenCalled();
+  });
+});
+
 describe('Admin Product editor load-failure boundary', () => {
   beforeEach(() => {
     useAuth.mockReturnValue({

--- a/src/pages/admin/shop/AdminProducts.tsx
+++ b/src/pages/admin/shop/AdminProducts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../../components/SEO';
 import AdminGuard from '../AdminGuard';
@@ -7,6 +7,24 @@ import { Product } from '../../../types/shop';
 import { listAllProducts, formatPrice } from '../../../services/shop/shopService';
 
 const LOAD_FAILURE = 'We could not load products right now. Please try again later.';
+const firestoreIdentities = new WeakMap<object, number>();
+let nextFirestoreIdentity = 1;
+
+function getFirestoreIdentity(value: object | null): number {
+  if (value === null) return 0;
+  const existing = firestoreIdentities.get(value);
+  if (existing !== undefined) return existing;
+  const identity = nextFirestoreIdentity;
+  nextFirestoreIdentity += 1;
+  firestoreIdentities.set(value, identity);
+  return identity;
+}
+
+interface ProductsLoadOutcome {
+  firestore: unknown;
+  status: 'loading' | 'resolved' | 'unavailable';
+  products: Product[];
+}
 
 function StatusPill({ status }: { status: string }) {
   const m: Record<string, string> = {
@@ -18,18 +36,48 @@ function StatusPill({ status }: { status: string }) {
   return <span className={`text-xs px-2 py-0.5 rounded ${m[status] || 'bg-gray-100'}`}>{status}</span>;
 }
 
-function Inner() {
-  const { services, isReady } = useServiceLocator();
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+type ProductsFirestore = Parameters<typeof listAllProducts>[0];
+
+function ProductsAttempt({ firestore }: { firestore: ProductsFirestore | null }) {
+  const currentFirestoreRef = useRef(firestore);
+  currentFirestoreRef.current = firestore;
+  const requestSequence = useRef(0);
+  const [loadOutcome, setLoadOutcome] = useState<ProductsLoadOutcome | null>(null);
+
+  const currentOutcome = loadOutcome?.firestore === firestore ? loadOutcome : null;
+  const currentStatus = currentOutcome?.status ?? 'loading';
+  const products = currentOutcome?.status === 'resolved' ? currentOutcome.products : [];
+  const loading = currentStatus === 'loading';
+  const error = currentStatus === 'unavailable' ? LOAD_FAILURE : null;
 
   useEffect(() => {
-    if (!isReady || !services) return;
-    listAllProducts(services.firebaseResources.firestore)
-      .then((ps) => { setProducts(ps); setLoading(false); })
-      .catch(() => { setError(LOAD_FAILURE); setLoading(false); });
-  }, [services, isReady]);
+    if (!firestore) {
+      requestSequence.current += 1;
+      return () => undefined;
+    }
+
+    const requestFirestore = firestore;
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
+    const outcomeKey = { firestore: requestFirestore };
+    setLoadOutcome({ ...outcomeKey, status: 'loading', products: [] });
+
+    async function load() {
+      try {
+        const all = await listAllProducts(requestFirestore);
+        if (requestId !== requestSequence.current
+          || currentFirestoreRef.current !== requestFirestore) return;
+        setLoadOutcome({ ...outcomeKey, status: 'resolved', products: all });
+      } catch {
+        if (requestId !== requestSequence.current
+          || currentFirestoreRef.current !== requestFirestore) return;
+        setLoadOutcome({ ...outcomeKey, status: 'unavailable', products: [] });
+      }
+    }
+
+    load();
+    return () => { requestSequence.current += 1; };
+  }, [firestore]);
 
   return (
     <>
@@ -104,6 +152,20 @@ function Inner() {
         )}
       </div>
     </>
+  );
+}
+
+function Inner() {
+  const { services, isReady } = useServiceLocator();
+  const firestore = isReady && services
+    ? services.firebaseResources.firestore
+    : null;
+
+  return (
+    <ProductsAttempt
+      key={getFirestoreIdentity(firestore)}
+      firestore={firestore}
+    />
   );
 }
 


### PR DESCRIPTION
## Outcome

The source-only Admin Products list now shows catalog results only for its current ready Firestore context. A database/readiness transition starts a fresh keyed attempt, hides all prior result-derived UI in the first commit, and makes obsolete or post-leave outcomes inert.

Closes #498.

## Safety invariant and behavior

- No lookup starts without both readiness and an effective Firestore object.
- The exact Firestore identity is the lookup and display boundary.
- A same-ready-database services-container rerender does not repeat the lookup.
- A changed database, lost readiness, A→B→A, or A→not-ready→A transition remounts a fresh attempt before result UI can render.
- Only the current generation may show the preserved #277 empty, populated, or fixed unavailable state.
- Rejections remain unbound and uninspected; no raw value is logged, measured, stored, or rendered.
- AdminGuard, request shape, product projection, price/status rendering, and generic navigation remain unchanged.

Migration impact: none. No schema, record, provider, permission, or production-state change.

## Proof

- Trustworthy pre-runtime RED on base `94fe8ffe89a93df1e1276f6562871a15d96dc63b`: 6 failed / 2 passed / 331 skipped.
- Corrective mutation: replacing the Firestore-identity key with constant `0` made the strengthened readiness-recovery observer fail by detecting the transient old table; the secure key was restored.
- Focused #277 + #498 actual-route tests: 14/14 passed.
- Full frontend: 14 suites, 794/794 passed.
- Frontend lint: 110 files / 113 reviewed legacy errors / 6 reviewed legacy warnings; baseline unchanged.
- Repository workflow/release/artifact/dependency safety: 77/77 passed.
- SPA navigation: 11/11 passed.
- Functions lint: passed; no Functions file changed.
- Direct production build: compiled successfully without sitemap generation.
- Three independent reviews: lifecycle/test GO; privacy/ownership GO; officer-continuity GO. A first review STOP found the readiness-recovery flash, which was fixed and mutation-proven before these approvals.

Local environment limits: Java is unavailable, so local Rules/commerce emulator checks could not run. The local shell has unsupported Node 22 rather than required Node 20; after a clean Functions install, 64 Functions suites passed and one Node-sensitive projection suite (12 cases) failed. Hosted Node 20 CI is required and remains the authority for all five jobs.

## Scope

Changed only:

- `src/pages/admin/shop/AdminProducts.tsx`
- the separately named `WEB-PRIVACY-001X` test block in `src/App.test.jsx`
- the additive #498 lifecycle language in the existing #277 section of `docs/officers/EVENTS_SHOP_MEMBERS.md`

No service, Rules, Functions, Auth/AdminGuard, package, lockfile, workflow, root design/security document, Firebase/provider configuration, product record, payment, or production-data change.

Officer impact: A future separately approved publication would stop the Admin Products page from showing a catalog result from an obsolete or unavailable database context. The complete Admin screen remains **NOT AVAILABLE YET**, and officers must not use it live.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md`.

Deployment evidence: Source changed and local tests/build passed. Code merge, preview, website publication, exact `runmprc.com` revision, Firebase/Rules deployment, provider configuration, product-record action, production-data action, Admin-screen approval, and live behavior are separate and currently unproven/not performed.
