### PR TITLE
AUTH-006C: make email auth submissions one-attempt

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -202,6 +202,56 @@ Password reset is a separate recovery path. [#155](https://github.com/Run-MPRC/R
 
 The incoming verification link is another separate step. [#194](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/194) tracks a deliberate-click `/auth/action` source route that removes the private code from the address and never grants membership. It is **NOT LIVE** and must not become Firebase's global handler while reset-password and email-recovery modes are unsupported. After every provider and website prerequisite is proven, use only [Verification link page — SOURCE ONLY, NOT LIVE](./EMERGENCY_AND_RECOVERY.md#verification-link-page--source-only-not-live). Officers never open, copy, or request the member's link or code.
 
+## Email/password submission one-attempt guard — SOURCE ONLY, NOT LIVE
+
+**Purpose:** make one quick series of clicks on the existing **Sign in** or **Create account** action start only one request, while allowing a later deliberate submission after the page shows its existing general failure message.
+
+**Approver:** membership lead plus identity/platform and privacy owners.
+
+**Prerequisites:** issue [#500](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/500), its reviewed pull request, exact merge commit, and synthetic tests must be complete. Use only a made-up email, password, account result, and rejected value. Parent [#109](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/109) remains incomplete and externally blocked for Google sign-in. This source slice does not enable Google, link accounts, change Firebase or a provider, create a production account, deploy the website, or prove live behavior.
+
+```mermaid
+flowchart TD
+    A["Member chooses existing Sign in or Create account"] --> B{"Is one email request already under way?"}
+    B -- "Yes" --> C["Ignore the repeat"]
+    B -- "No" --> D["Start one request and disable competing actions"]
+    D --> E{"Did that one request finish successfully?"}
+    E -- "Yes" --> F["Keep the existing sign-in destination or account-created result"]
+    E -- "No" --> G["Show the existing general failure message"]
+    G --> H["A later deliberate submission may start one new request"]
+    H --> B
+```
+
+In words: the first valid email sign-in or account-creation submission starts one request and disables the other account actions. Extra submissions during that request do nothing. A success keeps the existing result. A failure reveals no provider detail and allows the member to try again deliberately after the action is available. Sequential retries remain possible; each later submission is guarded as its own attempt.
+
+Officer review steps after the source merge:
+
+1. Keep this guard and the Google sign-in work marked **NOT AVAILABLE YET**.
+2. Ask the platform owner for the exact #500 issue, reviewed pull request, merge commit, and synthetic test result.
+3. Confirm the tests use only a made-up email, password, account result, and rejected value.
+4. Confirm two sign-in submissions made together call the existing sign-in request once with the same made-up email and password.
+5. Confirm two Create-account submissions made together call the existing registration request once with the same made-up email and password.
+6. Confirm the email, password, submit, mode-change, and password-reset actions are unavailable while the request is under way.
+7. Confirm a successful sign-in keeps the existing checked return address or Account fallback.
+8. Confirm a successful account creation keeps the existing accepted-or-unavailable verification-email result.
+9. Confirm a failed sign-in or account creation shows only its existing general message and no rejected provider detail.
+10. Confirm the action becomes available after that failure and each later deliberate submission starts at most one new request. Sequential retries remain possible.
+11. Confirm the separate password-reset request, countdown, result, and retry behavior are unchanged.
+12. Confirm no Google control, popup, redirect, account linking, membership decision, provider setting, Firebase rule, Function, or production account was added or changed.
+13. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase/Auth deployment, provider configuration, account/data action, and live behavior as separate results.
+
+**Expected result:** one quick series of submissions starts one existing email/password request. All competing account actions stay unavailable until that request settles. The existing successful sign-in or account-created result remains unchanged. The existing general failure message reveals no rejected value. A later deliberate submission starts at most one new request, and sequential retries remain possible. This browser guard does not cancel a request already started, persist through a reload, remount, another tab, device, or script, control an already-started result received after navigation or a service-context change, provide server idempotency, add Google sign-in, prove membership, or establish live availability.
+
+**Stop conditions:** any real email, password, account, member, provider response, credential, or production data; a production Auth test; more than one provider call from one quick series of submissions; a raw provider detail on the page, in analytics, or in the console; account actions that remain active during the request; a failure that cannot be retried once; any Google, Firebase, Rule, Function, provider-setting, membership, discount, payment, account-data, or deployment change; or a claim that source, tests, merge, preview, or green CI proves the guard or Google sign-in is live.
+
+**Success proof:** for source completion, record the exact #500 issue, reviewed pull request and merge commit, the two intended old-source duplicate-call failures, four green focused tests, the unchanged Login tests, relevant full checks, and independent lifecycle, privacy, and officer-continuity reviews. Live availability requires a separately approved website publication and dated exact-revision verification using an approved isolated made-up account. Record website publication, `runmprc.com`, Firebase/Auth deployment, Google/provider configuration, account/data action, and live behavior as **not performed** unless separate evidence proves otherwise.
+
+**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After a future approved publication, use the same protected website release path and verify the replacement revision. Do not undo by deleting or recreating an account, changing Firebase or provider settings, or changing membership data.
+
+**Escalation:** membership lead plus identity/platform owner. Add the privacy/security owner if a provider detail or private account value appears. Use the private incident path and never paste an email, password, code, provider response, screenshot, or account record into an issue, message, email, or AI tool.
+
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, provider configuration, and deployment topology are unchanged. The state-flow diagram above records only the one-attempt browser behavior.
+
 ## Checkout adjustment guard — SOURCE ONLY, NOT LIVE
 
 **Purpose:** prevent an unknown discount, tax, or shipping charge from being treated as a valid payment.

--- a/src/pages/login/LoginForm.jsx
+++ b/src/pages/login/LoginForm.jsx
@@ -25,6 +25,7 @@ function LoginForm() {
   const emailInputRef = useRef(null);
   const registrationStatusRef = useRef(null);
   const resetStatusRef = useRef(null);
+  const authSubmitInFlightRef = useRef(false);
   const resetInFlightRef = useRef(false);
   const resetRetryAtRef = useRef(0);
   const mountedRef = useRef(true);
@@ -95,6 +96,7 @@ function LoginForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (authSubmitInFlightRef.current) return;
     setError('');
     setRegistrationOutcome(null);
 
@@ -103,6 +105,7 @@ function LoginForm() {
       return;
     }
 
+    authSubmitInFlightRef.current = true;
     setIsLoading(true);
 
     try {
@@ -119,6 +122,7 @@ function LoginForm() {
         ? 'We could not create the account. Please try again.'
         : 'Failed to authenticate. Please check your credentials and try again.');
     } finally {
+      authSubmitInFlightRef.current = false;
       setIsLoading(false);
     }
   };

--- a/src/pages/login/LoginForm.test.jsx
+++ b/src/pages/login/LoginForm.test.jsx
@@ -608,6 +608,202 @@ describe('LoginForm return navigation', () => {
   });
 });
 
+describe('AUTH-006C email/password one-attempt submissions', () => {
+  const signIn = jest.fn();
+  const register = jest.fn();
+  const sendPasswordReset = jest.fn();
+
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+  }
+
+  function prepareCredentials({ initialEntry = '/login', registering = false } = {}) {
+    renderLogin(initialEntry);
+    if (registering) {
+      fireEvent.click(screen.getByRole('button', { name: 'New here? Register' }));
+    }
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'synthetic-member@example.test' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'synthetic-password' },
+    });
+    return screen.getByRole('button', {
+      name: registering ? 'Create account' : 'Sign in',
+    }).closest('form');
+  }
+
+  function submitRapidly(form) {
+    act(() => {
+      fireEvent.submit(form);
+      fireEvent.submit(form);
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    signIn.mockReset();
+    register.mockReset();
+    sendPasswordReset.mockReset();
+    signIn.mockResolvedValue({ user: { email: 'synthetic-member@example.test' } });
+    register.mockResolvedValue({
+      user: { email: 'synthetic-member@example.test' },
+      verificationEmailRequest: 'accepted',
+    });
+    sendPasswordReset.mockResolvedValue(undefined);
+    useServiceLocator.mockReturnValue({
+      isReady: true,
+      services: {
+        identityService: { signIn, register, sendPasswordReset },
+      },
+    });
+    useAuth.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: false,
+      isAdmin: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('admits one sign-in request from two same-act submissions', async () => {
+    const attempt = deferred();
+    signIn.mockReturnValue(attempt.promise);
+    const form = prepareCredentials({
+      initialEntry: {
+        pathname: '/login',
+        state: { from: '/discounts?kind=race#active' },
+      },
+    });
+
+    submitRapidly(form);
+
+    expect(screen.getByRole('button', { name: 'Working...' })).toBeDisabled();
+    expect(screen.getByLabelText('Email address')).toBeDisabled();
+    expect(screen.getByLabelText('Password')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'New here? Register' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Forgot password?' })).toBeDisabled();
+    await act(async () => {
+      attempt.resolve({ user: { email: 'synthetic-member@example.test' } });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('Discounts destination')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/discounts?kind=race#active');
+    expect(signIn).toHaveBeenCalledTimes(1);
+    expect(signIn).toHaveBeenCalledWith(
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(register).not.toHaveBeenCalled();
+    expect(sendPasswordReset).not.toHaveBeenCalled();
+  });
+
+  test('admits one registration request from two same-act submissions', async () => {
+    const attempt = deferred();
+    register.mockReturnValue(attempt.promise);
+    const form = prepareCredentials({ registering: true });
+
+    submitRapidly(form);
+
+    expect(screen.getByRole('button', { name: 'Working...' })).toBeDisabled();
+    expect(screen.getByLabelText('Email address')).toBeDisabled();
+    expect(screen.getByLabelText('Password')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Have an account? Sign in' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Forgot password?' })).not.toBeInTheDocument();
+    await act(async () => {
+      attempt.resolve({
+        user: { email: 'synthetic-member@example.test' },
+        verificationEmailRequest: 'accepted',
+      });
+      await Promise.resolve();
+    });
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('Account created.');
+    expect(status).toHaveTextContent('accepted the verification email request');
+    expect(status).toHaveFocus();
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(signIn).not.toHaveBeenCalled();
+    expect(sendPasswordReset).not.toHaveBeenCalled();
+  });
+
+  test('lets a later deliberate sign-in submission start one new request', async () => {
+    signIn
+      .mockRejectedValueOnce(new Error('synthetic sign-in provider detail'))
+      .mockResolvedValueOnce({ user: { email: 'synthetic-member@example.test' } });
+    const form = prepareCredentials();
+
+    fireEvent.submit(form);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to authenticate. Please check your credentials and try again.',
+    );
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled();
+    expect(document.body).not.toHaveTextContent('synthetic sign-in provider detail');
+    fireEvent.submit(form);
+
+    expect(await screen.findByText('Account destination')).toBeInTheDocument();
+    expect(signIn).toHaveBeenCalledTimes(2);
+    expect(signIn).toHaveBeenNthCalledWith(
+      1,
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(signIn).toHaveBeenNthCalledWith(
+      2,
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  test('lets a later deliberate registration submission start one new request', async () => {
+    register
+      .mockRejectedValueOnce(new Error('synthetic registration provider detail'))
+      .mockResolvedValueOnce({
+        user: { email: 'synthetic-member@example.test' },
+        verificationEmailRequest: 'accepted',
+      });
+    const form = prepareCredentials({ registering: true });
+
+    fireEvent.submit(form);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'We could not create the account. Please try again.',
+    );
+    expect(screen.getByRole('button', { name: 'Create account' })).toBeEnabled();
+    expect(document.body).not.toHaveTextContent('synthetic registration provider detail');
+    fireEvent.submit(form);
+
+    expect(await screen.findByText('Account created.')).toBeInTheDocument();
+    expect(register).toHaveBeenCalledTimes(2);
+    expect(register).toHaveBeenNthCalledWith(
+      1,
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(register).toHaveBeenNthCalledWith(
+      2,
+      'synthetic-member@example.test',
+      'synthetic-password',
+    );
+    expect(signIn).not.toHaveBeenCalled();
+  });
+});
+
 describe('LoginForm account-email spam guidance (AUTH-MAIL-002 C6)', () => {
   const ENV_KEY = 'REACT_APP_ACCOUNT_EMAIL_SENDER';
   const originalSender = process.env[ENV_KEY];


### PR DESCRIPTION
## Outcome

A rapid repeat of the existing email/password **Sign in** or **Create account** form now stays inert while the admitted request is pending. After any settled failure, each later deliberate submission may start one new guarded request; sequential retries remain possible.

Closes #500.

## Scope and invariant

- Add one synchronous component-local in-flight ref before either current Identity call.
- Preserve the current sign-in/register arguments, safe return navigation, registration result, generic unbound failure messages, password reset, accessibility, and password-manager markup.
- Add trustworthy same-act race tests for sign-in and registration plus post-failure retry controls.
- Add one plain-language SOURCE ONLY / NOT LIVE officer procedure.
- Do not add Google sign-in, linking, membership logic, provider/Firebase changes, server idempotency, or deployment.

The old runtime produced the intended RED proof: the two rapid-repeat tests each called their Identity method twice; the two existing retry controls passed.

## Verification

- `CI=true npm test -- --watch=false --runInBand src/pages/login/LoginForm.test.jsx`: 35/35 passed; focused AUTH-006C 4/4.
- `CI=true npm test -- --watch=false --runInBand`: 798/798 passed.
- Repository safety suite: 77/77 passed.
- `npm run test:spa-navigation`: 11/11 passed.
- `npm run lint:ci`: unchanged 110 files / 113 reviewed legacy errors / 6 reviewed legacy warnings.
- Direct optimized build with the sitemap generator bypassed: passed.
- `git diff --check`: passed.
- Three independent reviews approved lifecycle/tests, privacy/scope, and officer continuity.
- Reviewed staged diff SHA-256: `4662e0bbff9d4cf08c1478d33815d5f69353a79fda0fb992480fa19b344ce4b3`.

Hosted Node 20 CI is authoritative. This local shell used unsupported Node 22; no Functions, Rules, commerce, package, lock, or workflow path changed.

## Residual risk

This browser guard does not cancel an admitted request, survive reload/remount or another tab/device/script, arbitrate a result received after navigation or service-context change, impose a total retry cap, provide server idempotency, or make Google sign-in available.

Officer impact: After a future separately approved website publication, rapid repeat submissions of the existing email/password sign-in or Create-account form will start only one request at a time. Existing account/recovery procedures stay unchanged, and Google sign-in remains unavailable.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` — new separately named SOURCE ONLY / NOT LIVE review procedure.

Deployment evidence: Source and synthetic tests only at PR creation. Website publication, exact `runmprc.com` revision, Firebase/Auth/Functions/Rules deployment, Google/provider configuration, production account/data action, and live behavior were not performed or proven. The optimized preview is read-only because it targets production Firebase.