### PR TITLE
OAUTH-001B4: validate Strava disconnect request body

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -134,6 +134,10 @@ function isExactPlainRecord(record, expectedKeys) {
   return isPlainJsonRecord(record) && hasExactOwnKeys(record, expectedKeys);
 }
 
+function isValidStravaDisconnectRequest(data) {
+  return isExactPlainRecord(data, []);
+}
+
 function isBoundedVisibleAscii(value, maxLength) {
   return typeof value === 'string'
     && value.length > 0
@@ -1015,7 +1019,7 @@ exports.stravaDisconnect = functions
     if (!context.auth) {
       throw new functions.https.HttpsError('unauthenticated', 'Sign-in required');
     }
-    if (!isExactPlainRecord(data, [])) {
+    if (!isValidStravaDisconnectRequest(data)) {
       throw new functions.https.HttpsError(
         'invalid-argument',
         STRAVA_DISCONNECT_REQUEST_ERROR_MESSAGE,

--- a/functions/strava.js
+++ b/functions/strava.js
@@ -27,6 +27,7 @@ const STRAVA_ACTIVITY_DATE_MAX_LENGTH = 64;
 const STRAVA_LONG_MAX_AS_NUMBER = 9_223_372_036_854_776_000;
 const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.';
 const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
+const STRAVA_DISCONNECT_REQUEST_ERROR_MESSAGE = 'Strava disconnect request is invalid.';
 const VISIBLE_ASCII_PATTERN = /^[\x21-\x7e]+$/;
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/u;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/u;
@@ -1013,6 +1014,12 @@ exports.stravaDisconnect = functions
     requireAppCheck(context);
     if (!context.auth) {
       throw new functions.https.HttpsError('unauthenticated', 'Sign-in required');
+    }
+    if (!isExactPlainRecord(data, [])) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        STRAVA_DISCONNECT_REQUEST_ERROR_MESSAGE,
+      );
     }
     const { uid } = context.auth;
     const secretSnap = await secretDocRef(uid).get();

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -4632,6 +4632,7 @@ describe('Strava activity data failure boundary', () => {
 describe('Strava disconnect failure log boundary', () => {
   let fetchMock;
   let consoleSpies;
+  let dateNowSpy;
 
   beforeEach(() => {
     admin.__clearDeletes();
@@ -4640,6 +4641,7 @@ describe('Strava disconnect failure log boundary', () => {
     admin.__clearWrites();
     requireAppCheck.mockReset();
     Timestamp.now.mockClear();
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
     fetchMock = jest.fn();
     global.fetch = fetchMock;
     consoleSpies = Object.fromEntries(
@@ -4653,6 +4655,7 @@ describe('Strava disconnect failure log boundary', () => {
 
   afterEach(() => {
     global.fetch = GUARDED_FETCH;
+    dateNowSpy.mockRestore();
     Object.values(consoleSpies).forEach((spy) => spy.mockRestore());
   });
 
@@ -4673,7 +4676,20 @@ describe('Strava disconnect failure log boundary', () => {
     Object.values(consoleSpies).forEach((spy) => expect(spy).not.toHaveBeenCalled());
   }
 
+  function expectNoDisconnectSideEffects() {
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dateNowSpy).not.toHaveBeenCalled();
+    expect(Timestamp.now).not.toHaveBeenCalled();
+    expectNoLogs();
+  }
+
   async function expectRejectedDisconnectRequest(data) {
+    seedAccessToken('synthetic_disconnect_request_boundary_token');
+    fetchMock.mockRejectedValue(new Error('disconnect-request provider canary'));
+
     const rejection = await captureFailure(() => stravaDisconnect(data, CONTEXT));
 
     expect(publicError(rejection)).toEqual({
@@ -4684,12 +4700,7 @@ describe('Strava disconnect failure log boundary', () => {
     });
     expect(requireAppCheck).toHaveBeenCalledTimes(1);
     expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
-    expect(Timestamp.now).not.toHaveBeenCalled();
-    expect(admin.__getReads()).toEqual([]);
-    expect(admin.__getDeletes()).toEqual([]);
-    expect(admin.__getWrites()).toEqual([]);
-    expect(fetchMock).not.toHaveBeenCalled();
-    expectNoLogs();
+    expectNoDisconnectSideEffects();
   }
 
   async function expectRejectedStoredSecret(secret) {
@@ -4733,10 +4744,7 @@ describe('Strava disconnect failure log boundary', () => {
     expect(requireAppCheck).toHaveBeenCalledWith(context);
     expect(authGetter).not.toHaveBeenCalled();
     Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
-    expect(admin.__getReads()).toEqual([]);
-    expect(admin.__getDeletes()).toEqual([]);
-    expect(fetchMock).not.toHaveBeenCalled();
-    expectNoLogs();
+    expectNoDisconnectSideEffects();
   });
 
   test('rejects a missing caller before Firestore, provider access, or deletion', async () => {
@@ -4762,10 +4770,7 @@ describe('Strava disconnect failure log boundary', () => {
 
     expect(requireAppCheck).toHaveBeenCalledTimes(1);
     Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
-    expect(admin.__getReads()).toEqual([]);
-    expect(admin.__getDeletes()).toEqual([]);
-    expect(fetchMock).not.toHaveBeenCalled();
-    expectNoLogs();
+    expectNoDisconnectSideEffects();
   });
 
   describe('request validation before side effects', () => {
@@ -4817,6 +4822,9 @@ describe('Strava disconnect failure log boundary', () => {
         }),
         getPrototypeOf: jest.fn(() => {
           throw new Error('disconnect-request-canary prototype trap');
+        }),
+        has: jest.fn(() => {
+          throw new Error('disconnect-request-canary has trap');
         }),
         ownKeys: jest.fn(() => {
           throw new Error('disconnect-request-canary ownKeys trap');

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -314,6 +314,7 @@ const {
 const FIXED_AUTHORIZATION_ERROR = 'Strava authorization could not be completed.';
 const FIXED_REFRESH_ERROR = 'Strava connection could not be refreshed.';
 const FIXED_DATA_ERROR = 'Strava activity data could not be loaded.';
+const FIXED_DISCONNECT_REQUEST_ERROR = 'Strava disconnect request is invalid.';
 const FIXED_DISCONNECT_WARNING = 'strava_disconnect_revoke_failed';
 const GUARDED_FETCH = global.fetch;
 const AUTH_TIME = 1_700_000_000;
@@ -4638,6 +4639,7 @@ describe('Strava disconnect failure log boundary', () => {
     admin.__clearReads();
     admin.__clearWrites();
     requireAppCheck.mockReset();
+    Timestamp.now.mockClear();
     fetchMock = jest.fn();
     global.fetch = fetchMock;
     consoleSpies = Object.fromEntries(
@@ -4671,6 +4673,25 @@ describe('Strava disconnect failure log boundary', () => {
     Object.values(consoleSpies).forEach((spy) => expect(spy).not.toHaveBeenCalled());
   }
 
+  async function expectRejectedDisconnectRequest(data) {
+    const rejection = await captureFailure(() => stravaDisconnect(data, CONTEXT));
+
+    expect(publicError(rejection)).toEqual({
+      code: 'invalid-argument',
+      message: FIXED_DISCONNECT_REQUEST_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+    expect(Timestamp.now).not.toHaveBeenCalled();
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expectNoLogs();
+  }
+
   async function expectRejectedStoredSecret(secret) {
     seedStoredSecret(secret);
 
@@ -4691,10 +4712,27 @@ describe('Strava disconnect failure log boundary', () => {
     requireAppCheck.mockImplementationOnce(() => {
       throw appCheckFailure;
     });
+    const authGetter = jest.fn(() => CONTEXT.auth);
+    const context = Object.defineProperty(
+      { app: CONTEXT.app },
+      'auth',
+      { enumerable: true, get: authGetter },
+    );
+    const traps = {
+      getPrototypeOf: jest.fn(() => {
+        throw new Error('disconnect-request-order-canary prototype trap');
+      }),
+      ownKeys: jest.fn(() => {
+        throw new Error('disconnect-request-order-canary ownKeys trap');
+      }),
+    };
+    const data = new Proxy({}, traps);
 
-    await expect(stravaDisconnect({}, CONTEXT)).rejects.toBe(appCheckFailure);
+    await expect(stravaDisconnect(data, context)).rejects.toBe(appCheckFailure);
 
-    expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+    expect(requireAppCheck).toHaveBeenCalledWith(context);
+    expect(authGetter).not.toHaveBeenCalled();
+    Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getDeletes()).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
@@ -4702,14 +4740,135 @@ describe('Strava disconnect failure log boundary', () => {
   });
 
   test('rejects a missing caller before Firestore, provider access, or deletion', async () => {
-    await expect(stravaDisconnect({}, { ...CONTEXT, auth: null }))
-      .rejects.toMatchObject({ code: 'unauthenticated' });
+    const traps = {
+      getPrototypeOf: jest.fn(() => {
+        throw new Error('disconnect-request-auth-order-canary prototype trap');
+      }),
+      ownKeys: jest.fn(() => {
+        throw new Error('disconnect-request-auth-order-canary ownKeys trap');
+      }),
+    };
+    const data = new Proxy({}, traps);
+    const rejection = await captureFailure(() => (
+      stravaDisconnect(data, { ...CONTEXT, auth: null })
+    ));
+
+    expect(publicError(rejection)).toEqual({
+      code: 'unauthenticated',
+      message: 'Sign-in required',
+      details: undefined,
+      cause: undefined,
+    });
 
     expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getDeletes()).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
     expectNoLogs();
+  });
+
+  describe('request validation before side effects', () => {
+    class DisconnectRequest {
+      constructor() {
+        this.unexpected = true;
+      }
+    }
+
+    const nonEnumerableRequest = {};
+    Object.defineProperty(nonEnumerableRequest, 'unexpected', {
+      configurable: true,
+      enumerable: false,
+      value: true,
+    });
+    const symbolRequest = { [Symbol('unexpected')]: true };
+
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a boolean', false],
+      ['a number', 0],
+      ['a bigint', 0n],
+      ['a string', ''],
+      ['a symbol', Symbol('disconnect-request-canary')],
+      ['a function', () => undefined],
+      ['an array', []],
+      ['a Date', new Date(0)],
+      ['a class instance', new DisconnectRequest()],
+      ['a null-prototype record', Object.create(null)],
+      ['a custom-prototype record', Object.create({ inherited: true })],
+      ['an enumerable extra key', { unexpected: true }],
+      ['a non-enumerable extra key', nonEnumerableRequest],
+      ['a symbol extra key', symbolRequest],
+    ])('rejects %s before Firestore, provider, delete, timestamp, or log work', async (
+      _case,
+      data,
+    ) => {
+      await expectRejectedDisconnectRequest(data);
+    });
+
+    test('rejects a Proxy without invoking any trap', async () => {
+      const traps = {
+        get: jest.fn(() => {
+          throw new Error('disconnect-request-canary get trap');
+        }),
+        getOwnPropertyDescriptor: jest.fn(() => {
+          throw new Error('disconnect-request-canary descriptor trap');
+        }),
+        getPrototypeOf: jest.fn(() => {
+          throw new Error('disconnect-request-canary prototype trap');
+        }),
+        ownKeys: jest.fn(() => {
+          throw new Error('disconnect-request-canary ownKeys trap');
+        }),
+      };
+      const data = new Proxy({}, traps);
+
+      await expectRejectedDisconnectRequest(data);
+
+      Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    });
+
+    test('rejects a revoked Proxy without reflection', async () => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      await expectRejectedDisconnectRequest(proxy);
+    });
+
+    test('rejects an accessor-backed record without invoking the accessor', async () => {
+      const getter = jest.fn(() => {
+        throw new Error('disconnect-request-canary getter');
+      });
+      const data = {};
+      Object.defineProperty(data, 'unexpected', {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+
+      await expectRejectedDisconnectRequest(data);
+
+      expect(getter).not.toHaveBeenCalled();
+    });
+
+    test('does not invoke coercion, iteration, or JSON hooks', async () => {
+      const hooks = {
+        toJSON: jest.fn(() => 'disconnect-request-canary'),
+        toString: jest.fn(() => 'disconnect-request-canary'),
+        valueOf: jest.fn(() => 'disconnect-request-canary'),
+        [Symbol.iterator]: jest.fn(() => [][Symbol.iterator]()),
+        [Symbol.toPrimitive]: jest.fn(() => 'disconnect-request-canary'),
+      };
+
+      await expectRejectedDisconnectRequest(hooks);
+
+      expect(hooks.toJSON).not.toHaveBeenCalled();
+      expect(hooks.toString).not.toHaveBeenCalled();
+      expect(hooks.valueOf).not.toHaveBeenCalled();
+      expect(hooks[Symbol.iterator]).not.toHaveBeenCalled();
+      expect(hooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+    });
   });
 
   test('skips provider access when no server-only token exists and still deletes locally', async () => {

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -1434,6 +1434,31 @@ describe('Strava authorization service boundary', () => {
   });
 });
 
+describe('Strava disconnect empty-request service contract', () => {
+  const functions = { name: 'synthetic-functions' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getFunctions as jest.Mock).mockReturnValue(functions);
+  });
+
+  test('sends one exact empty request and preserves the callable result', async () => {
+    const callable = jest.fn().mockResolvedValue({ data: { ok: true } });
+    (httpsCallable as jest.Mock).mockReturnValue(callable);
+
+    await expect(ActualStravaService.stravaDisconnect(app))
+      .resolves.toEqual({ ok: true });
+
+    expect(getFunctions).toHaveBeenCalledWith(app);
+    expect(httpsCallable).toHaveBeenCalledWith(functions, 'stravaDisconnect');
+    expect(callable).toHaveBeenCalledTimes(1);
+    expect(callable.mock.calls[0]).toHaveLength(1);
+    const [request] = callable.mock.calls[0];
+    expect(Object.getPrototypeOf(request)).toBe(Object.prototype);
+    expect(Reflect.ownKeys(request)).toEqual([]);
+  });
+});
+
 describe('Strava authorization start browser boundary', () => {
   const originalClientId = process.env.REACT_APP_STRAVA_CLIENT_ID;
   let locationRecorder: ReturnType<typeof installStravaLocationRecorder> | null;

--- a/src/services/strava/stravaService.ts
+++ b/src/services/strava/stravaService.ts
@@ -144,8 +144,11 @@ export async function stravaFetchStats(app: FirebaseApp): Promise<StravaStatsRes
 
 export async function stravaDisconnect(app: FirebaseApp): Promise<{ ok: boolean }> {
   const functions = getFunctions(app);
-  const callable = httpsCallable<void, { ok: boolean }>(functions, 'stravaDisconnect');
-  const result = await callable();
+  const callable = httpsCallable<Record<string, never>, { ok: boolean }>(
+    functions,
+    'stravaDisconnect',
+  );
+  const result = await callable({});
   return result.data;
 }
 


### PR DESCRIPTION
## Outcome

Strava disconnect now rejects every request body except one exact plain empty object before any Firestore read, provider request, deletion, timestamp, write, or log. The browser service now sends that exact `{}` request explicitly so the source remains backward-compatible with the currently deployed Function.

Closes #502. This is one child of #88; #88 remains open for the remaining disconnect, provider, audit, and deployment work.

## Security invariant

- App Check runs first.
- Authentication runs second.
- The request body must be an ordinary object with `Object.prototype` and no own string, non-enumerable, or symbol keys.
- Invalid input receives one fixed `invalid-argument` result and causes no side effect or input-dependent log.
- Existing valid disconnect behavior is unchanged.

## Exact scope

- `functions/strava.js`
- `functions/strava.test.js`
- `src/services/strava/stravaService.ts`
- the separately named disconnect service-contract block in `src/pages/account/Account.test.tsx`

## Verification

- Node 20 focused Functions Strava suite: 596/596 passed.
- Node 20 focused Account suite: 138/138 passed.
- Node 20 full Functions suite: 65 suites passed, 2 skipped; 6,251 tests passed and 64 skipped.
- Node 20 full frontend suite: 14 suites / 799 tests passed.
- Functions lint passed.
- Frontend lint baseline passed: 110 files / 113 reviewed legacy errors / 6 reviewed legacy warnings.
- TypeScript `tsc --noEmit` passed.
- Repository safety 77/77 and SPA navigation 11/11 passed on the reviewed candidate.
- Diagnostic production build passed.
- `git diff --check` passed.
- Three independent exact-head reviews approved `cb11bbbd5478e0dd3f101043fb3e2e4b49735c7f` after a final two-file test-hardening commit.
- Local Firestore Rules execution was unavailable because Java is absent; hosted Java CI is required before merge.

## Release order and evidence

This PR changes source and tests only. It does not publish the website or deploy Firebase.

If this behavior is later released, publish and verify the `{}`-sending website first. Deploy the strict Function only after that client is live. Reversing this order would make the currently published no-argument client send `null`, which the strict Function correctly rejects.

Deployment evidence: source and local tests only at PR creation; website not published, `runmprc.com` not verified, Firebase not deployed, Strava provider not changed or called, and production data not read or changed.

Officer impact: None — valid member-visible disconnect behavior and officer duties are unchanged.

Officer documentation: None — this is an internal input-validation and compatibility boundary with no verified live procedure, permission, data-flow, or topology change.
