### PR TITLE
OAUTH-001A2F: reject unexpected Strava stats request bodies

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -27,6 +27,7 @@ const STRAVA_ACTIVITY_DATE_MAX_LENGTH = 64;
 const STRAVA_LONG_MAX_AS_NUMBER = 9_223_372_036_854_776_000;
 const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.';
 const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
+const STRAVA_STATS_REQUEST_ERROR_MESSAGE = 'Strava statistics request is invalid.';
 const STRAVA_DISCONNECT_REQUEST_ERROR_MESSAGE = 'Strava disconnect request is invalid.';
 const VISIBLE_ASCII_PATTERN = /^[\x21-\x7e]+$/;
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/u;
@@ -135,6 +136,10 @@ function isExactPlainRecord(record, expectedKeys) {
 }
 
 function isValidStravaDisconnectRequest(data) {
+  return isExactPlainRecord(data, []);
+}
+
+function isValidStravaStatsRequest(data) {
   return isExactPlainRecord(data, []);
 }
 
@@ -943,6 +948,12 @@ exports.stravaFetchStats = functions
     requireAppCheck(context);
     if (!context.auth) {
       throw new functions.https.HttpsError('unauthenticated', 'Sign-in required');
+    }
+    if (!isValidStravaStatsRequest(data)) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        STRAVA_STATS_REQUEST_ERROR_MESSAGE,
+      );
     }
     const { uid } = context.auth;
 

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -314,6 +314,7 @@ const {
 const FIXED_AUTHORIZATION_ERROR = 'Strava authorization could not be completed.';
 const FIXED_REFRESH_ERROR = 'Strava connection could not be refreshed.';
 const FIXED_DATA_ERROR = 'Strava activity data could not be loaded.';
+const FIXED_STATS_REQUEST_ERROR = 'Strava statistics request is invalid.';
 const FIXED_DISCONNECT_REQUEST_ERROR = 'Strava disconnect request is invalid.';
 const FIXED_DISCONNECT_WARNING = 'strava_disconnect_revoke_failed';
 const GUARDED_FETCH = global.fetch;
@@ -2056,6 +2057,247 @@ describe('Strava authorization exchange failure boundary', () => {
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getDeletes()).toEqual([]);
     expect(Timestamp.now).toHaveBeenCalledTimes(3);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});
+
+describe('Strava statistics request admission boundary', () => {
+  let fetchMock;
+  let consoleSpies;
+  let dateNowSpy;
+
+  beforeEach(() => {
+    admin.__clearDeletes();
+    admin.__clearDocuments();
+    admin.__clearReads();
+    admin.__clearWrites();
+    Timestamp.now.mockClear();
+    requireAppCheck.mockReset();
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    consoleSpies = ['debug', 'error', 'info', 'log', 'warn']
+      .map((method) => jest.spyOn(console, method).mockImplementation(() => undefined));
+  });
+
+  afterEach(() => {
+    global.fetch = GUARDED_FETCH;
+    dateNowSpy.mockRestore();
+    consoleSpies.forEach((spy) => spy.mockRestore());
+  });
+
+  function expectNoStatisticsSideEffects() {
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dateNowSpy).not.toHaveBeenCalled();
+    expect(Timestamp.now).not.toHaveBeenCalled();
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  }
+
+  async function expectRejectedStatisticsRequest(data) {
+    const rejection = await captureFailure(() => stravaFetchStats(data, CONTEXT));
+
+    expect(publicError(rejection)).toEqual({
+      code: 'invalid-argument',
+      message: FIXED_STATS_REQUEST_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
+    expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+    expectNoStatisticsSideEffects();
+  }
+
+  test('runs App Check before Auth, request reflection, or side effects', async () => {
+    const appCheckFailure = new functions.https.HttpsError(
+      'failed-precondition',
+      'synthetic app check rejection',
+    );
+    requireAppCheck.mockImplementationOnce(() => {
+      throw appCheckFailure;
+    });
+    const authGetter = jest.fn(() => CONTEXT.auth);
+    const context = Object.defineProperty(
+      { app: CONTEXT.app },
+      'auth',
+      { enumerable: true, get: authGetter },
+    );
+    const traps = {
+      getPrototypeOf: jest.fn(() => {
+        throw new Error('stats-request-order-canary prototype trap');
+      }),
+      isExtensible: jest.fn(() => {
+        throw new Error('stats-request-order-canary extensible trap');
+      }),
+      ownKeys: jest.fn(() => {
+        throw new Error('stats-request-order-canary ownKeys trap');
+      }),
+    };
+    const data = new Proxy({}, traps);
+
+    await expect(stravaFetchStats(data, context)).rejects.toBe(appCheckFailure);
+
+    expect(requireAppCheck).toHaveBeenCalledWith(context);
+    expect(authGetter).not.toHaveBeenCalled();
+    Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    expectNoStatisticsSideEffects();
+  });
+
+  test('rejects a missing caller before request reflection or side effects', async () => {
+    const traps = {
+      getPrototypeOf: jest.fn(() => {
+        throw new Error('stats-request-auth-order-canary prototype trap');
+      }),
+      isExtensible: jest.fn(() => {
+        throw new Error('stats-request-auth-order-canary extensible trap');
+      }),
+      ownKeys: jest.fn(() => {
+        throw new Error('stats-request-auth-order-canary ownKeys trap');
+      }),
+    };
+    const data = new Proxy({}, traps);
+    const rejection = await captureFailure(() => (
+      stravaFetchStats(data, { ...CONTEXT, auth: null })
+    ));
+
+    expect(publicError(rejection)).toEqual({
+      code: 'unauthenticated',
+      message: 'Sign-in required',
+      details: undefined,
+      cause: undefined,
+    });
+    expect(requireAppCheck).toHaveBeenCalledTimes(1);
+    Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    expectNoStatisticsSideEffects();
+  });
+
+  describe('request validation before side effects', () => {
+    class StatisticsRequest {
+      constructor() {
+        this.unexpected = true;
+      }
+    }
+
+    const nonEnumerableRequest = {};
+    Object.defineProperty(nonEnumerableRequest, 'unexpected', {
+      configurable: true,
+      enumerable: false,
+      value: true,
+    });
+    const symbolRequest = { [Symbol('unexpected')]: true };
+
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a boolean', false],
+      ['a number', 0],
+      ['a bigint', 0n],
+      ['a string', ''],
+      ['a symbol', Symbol('stats-request-canary')],
+      ['a function', () => undefined],
+      ['an array', []],
+      ['a Date', new Date(0)],
+      ['a class instance', new StatisticsRequest()],
+      ['a null-prototype record', Object.create(null)],
+      ['a custom-prototype record', Object.create({ inherited: true })],
+      ['an enumerable extra key', { unexpected: true }],
+      ['a non-enumerable extra key', nonEnumerableRequest],
+      ['a symbol extra key', symbolRequest],
+    ])('rejects %s before Firestore, provider, timestamp, write, delete, or log work', async (
+      _case,
+      data,
+    ) => {
+      await expectRejectedStatisticsRequest(data);
+    });
+
+    test('rejects a Proxy without invoking any trap', async () => {
+      const traps = {
+        get: jest.fn(() => {
+          throw new Error('stats-request-canary get trap');
+        }),
+        getOwnPropertyDescriptor: jest.fn(() => {
+          throw new Error('stats-request-canary descriptor trap');
+        }),
+        getPrototypeOf: jest.fn(() => {
+          throw new Error('stats-request-canary prototype trap');
+        }),
+        has: jest.fn(() => {
+          throw new Error('stats-request-canary has trap');
+        }),
+        isExtensible: jest.fn(() => {
+          throw new Error('stats-request-canary extensible trap');
+        }),
+        ownKeys: jest.fn(() => {
+          throw new Error('stats-request-canary ownKeys trap');
+        }),
+      };
+      const data = new Proxy({}, traps);
+
+      await expectRejectedStatisticsRequest(data);
+
+      Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    });
+
+    test('rejects a revoked Proxy without reflection', async () => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      await expectRejectedStatisticsRequest(proxy);
+    });
+
+    test('rejects an accessor-backed record without invoking the accessor', async () => {
+      const getter = jest.fn(() => {
+        throw new Error('stats-request-canary getter');
+      });
+      const data = {};
+      Object.defineProperty(data, 'unexpected', {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+
+      await expectRejectedStatisticsRequest(data);
+
+      expect(getter).not.toHaveBeenCalled();
+    });
+
+    test('does not invoke coercion, iteration, or JSON hooks', async () => {
+      const hooks = {
+        toJSON: jest.fn(() => 'stats-request-canary'),
+        toString: jest.fn(() => 'stats-request-canary'),
+        valueOf: jest.fn(() => 'stats-request-canary'),
+        [Symbol.iterator]: jest.fn(() => [][Symbol.iterator]()),
+        [Symbol.toPrimitive]: jest.fn(() => 'stats-request-canary'),
+      };
+
+      await expectRejectedStatisticsRequest(hooks);
+
+      expect(hooks.toJSON).not.toHaveBeenCalled();
+      expect(hooks.toString).not.toHaveBeenCalled();
+      expect(hooks.valueOf).not.toHaveBeenCalled();
+      expect(hooks[Symbol.iterator]).not.toHaveBeenCalled();
+      expect(hooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+    });
+  });
+
+  test('accepts one ordinary exact empty request and reaches the connection lookup', async () => {
+    const request = {};
+
+    await expect(stravaFetchStats(request, CONTEXT)).rejects.toMatchObject({
+      code: 'failed-precondition',
+      message: 'Strava not connected',
+    });
+
+    expect(Object.getPrototypeOf(request)).toBe(Object.prototype);
+    expect(Reflect.ownKeys(request)).toEqual([]);
+    expect(admin.__getReads()).toEqual([CONNECTION_PATH]);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dateNowSpy).not.toHaveBeenCalled();
+    expect(Timestamp.now).not.toHaveBeenCalled();
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 });

--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -1459,6 +1459,31 @@ describe('Strava disconnect empty-request service contract', () => {
   });
 });
 
+describe('Strava statistics empty-request service contract', () => {
+  const functions = { name: 'synthetic-functions' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getFunctions as jest.Mock).mockReturnValue(functions);
+  });
+
+  test('sends one exact empty request and preserves the callable result', async () => {
+    const callable = jest.fn().mockResolvedValue({ data: STRAVA_STATS });
+    (httpsCallable as jest.Mock).mockReturnValue(callable);
+
+    await expect(ActualStravaService.stravaFetchStats(app))
+      .resolves.toEqual(STRAVA_STATS);
+
+    expect(getFunctions).toHaveBeenCalledWith(app);
+    expect(httpsCallable).toHaveBeenCalledWith(functions, 'stravaFetchStats');
+    expect(callable).toHaveBeenCalledTimes(1);
+    expect(callable.mock.calls[0]).toHaveLength(1);
+    const [request] = callable.mock.calls[0];
+    expect(Object.getPrototypeOf(request)).toBe(Object.prototype);
+    expect(Reflect.ownKeys(request)).toEqual([]);
+  });
+});
+
 describe('Strava authorization start browser boundary', () => {
   const originalClientId = process.env.REACT_APP_STRAVA_CLIENT_ID;
   let locationRecorder: ReturnType<typeof installStravaLocationRecorder> | null;

--- a/src/services/strava/stravaService.ts
+++ b/src/services/strava/stravaService.ts
@@ -137,8 +137,11 @@ export async function stravaExchangeCode(
 
 export async function stravaFetchStats(app: FirebaseApp): Promise<StravaStatsResult> {
   const functions = getFunctions(app);
-  const callable = httpsCallable<void, StravaStatsResult>(functions, 'stravaFetchStats');
-  const result = await callable();
+  const callable = httpsCallable<Record<string, never>, StravaStatsResult>(
+    functions,
+    'stravaFetchStats',
+  );
+  const result = await callable({});
   return result.data;
 }
 


### PR DESCRIPTION
Closes #510

## Outcome

`stravaFetchStats` now admits only one ordinary exact empty request after App Check and sign-in, before any Firestore, provider, clock, write, delete, or logging work. The browser service now sends that exact `{}` explicitly.

This is a focused child of #88. It does not complete the parent Strava hardening work.

## Security invariant

- App Check runs first.
- Authentication runs second.
- Exact-empty request admission runs third.
- Rejected input produces one fixed non-identifying `invalid-argument` result.
- Rejected input cannot invoke getters, Proxy traps, coercion, iteration, or serialization hooks.
- Rejected input causes zero Firestore reads/writes/deletes, provider calls, clock/timestamp use, or logs.
- Existing valid statistics behavior and provider-failure handling remain unchanged.

## Exact changes

- `functions/strava.js`: fixed request error, pure exact-empty predicate, and the pre-side-effect stats gate.
- `functions/strava.test.js`: focused ordering, hostile-input, zero-side-effect, mutation-resistant Proxy, and valid `{}` tests.
- `src/services/strava/stravaService.ts`: request type is `Record<string, never>` and the callable receives `{}`.
- `src/pages/account/Account.test.tsx`: one actual-service empty-request wire-contract block.

No package, lockfile, Rules, workflow, provider, production-data, officer-guide, or deployment file changed. The corrective #503 officer guide from exact base `a9094e85811ed31aa1e43da75559e596e16118ae` is preserved byte-for-byte.

## Verification

- RED: 20 malformed-body cases failed against the prior server behavior by reaching the connection lookup instead of the fixed request rejection.
- Focused Node 20 Strava: 619/619.
- Focused actual Account/service: 139/139.
- Full Node 20 Functions: 65/65 active suites, 6,274 passed; 64 intentionally skipped.
- Full frontend: 14/14 suites, 807/807.
- Functions lint: passed.
- Frontend lint baseline: 110 files / 113 reviewed legacy errors / 6 reviewed legacy warnings.
- TypeScript `--noEmit`: passed.
- Repository safety: 77/77.
- SPA navigation: 11/11.
- Diagnostic production build: passed.
- Three independent reviews: security GO, scope/compatibility GO, and test/mutation GO after adding `isExtensible` Proxy-trap canaries.
- Hosted CI run `30709514729`: all five required jobs passed on exact head `3071b849696c8eedd6f46c0a92f3515f1373087a`, including Firestore Rules and the commerce emulator. The isolated Netlify preview also passed; it is not a production release.

## Compatibility and release order

Source and tests can merge without changing production. A future production rollout must publish and verify the `{}`-sending website first, then deploy the strict Function. Deploying the Function first would reject the currently published no-argument client because Firebase encodes it as `null`.

Officer impact: None — valid member-visible statistics behavior and officer duties are unchanged.

Officer documentation: None — this is an internal callable input and compatibility boundary; no verified officer procedure, permission, topology, or data flow changed.

Deployment evidence: Source/tests only. No website publication, `runmprc.com` verification, Firebase deployment, Strava/provider action, production-data action, migration, or live behavior is claimed.
