### PR TITLE
WEB-PRIVACY-001Y: redact sitemap generator failures

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -78,8 +78,8 @@ async function loadEventEntries() {
         priority: '0.9',
       };
     });
-  } catch (err) {
-    console.warn('Failed to load events for sitemap:', err.message);
+  } catch {
+    console.warn('sitemap_dynamic_events_unavailable');
     return [];
   }
 }
@@ -102,7 +102,7 @@ ${allEntries.map(urlEntry).join('\n')}
   console.log(`Wrote sitemap with ${allEntries.length} URLs → ${OUTPUT}`);
 }
 
-main().catch((err) => {
-  console.error(err);
+main().catch(() => {
+  console.error('sitemap_generation_failed');
   process.exit(1);
 });

--- a/tests/test-artifact-safety.test.js
+++ b/tests/test-artifact-safety.test.js
@@ -8,6 +8,7 @@ const test = require('node:test');
 
 const REPOSITORY = path.resolve(__dirname, '..');
 const SCANNER = path.join(REPOSITORY, '.github/scripts/scan-test-artifacts.mjs');
+const SITEMAP_GENERATOR = path.join(REPOSITORY, 'scripts/generate-sitemap.js');
 const CI_PATH = path.join(REPOSITORY, '.github/workflows/ci.yml');
 const RELEASE_PATH = path.join(REPOSITORY, '.github/workflows/deploy.yml');
 const ciWorkflow = fs.readFileSync(CI_PATH, 'utf8');
@@ -120,6 +121,27 @@ function runScanner(...roots) {
   return spawnSync(process.execPath, [SCANNER, ...roots], {
     cwd: REPOSITORY,
     encoding: 'utf8',
+  });
+}
+
+function makeSitemapFixture(name = 'sitemap-fixture') {
+  const { root } = makeArtifactRoot(name);
+  const script = path.join(root, 'scripts/generate-sitemap.js');
+  fs.mkdirSync(path.dirname(script), { recursive: true });
+  fs.copyFileSync(SITEMAP_GENERATOR, script);
+  return { root, script };
+}
+
+function runSitemapGenerator(fixture, environment = {}) {
+  const env = { ...process.env };
+  delete env.FIREBASE_SERVICE_ACCOUNT;
+  delete env.GOOGLE_APPLICATION_CREDENTIALS;
+  delete env.SITE_ORIGIN;
+  Object.assign(env, environment);
+  return spawnSync(process.execPath, [fixture.script], {
+    cwd: fixture.root,
+    encoding: 'utf8',
+    env,
   });
 }
 
@@ -316,6 +338,72 @@ function releaseErrors(workflow) {
   }
   return errors;
 }
+
+test('WEB-PRIVACY-001Y sitemap failures expose only fixed log codes', async (t) => {
+  await t.test('recoverable provider errors keep the static sitemap without details', () => {
+    const providerCanary = 'sitemap-provider-error-canary';
+    const fixture = makeSitemapFixture();
+    fs.mkdirSync(path.join(fixture.root, 'public'), { recursive: true });
+    writeArtifact(
+      fixture.root,
+      'node_modules/firebase-admin/index.js',
+      `module.exports = {
+  apps: [],
+  credential: { cert() { return {}; } },
+  initializeApp() {},
+  firestore() {
+    return {
+      collection() {
+        return {
+          where() { return this; },
+          get() {
+            const error = new Error(${JSON.stringify(providerCanary)});
+            error.stack = ${JSON.stringify(`synthetic stack ${providerCanary}`)};
+            return Promise.reject(error);
+          },
+        };
+      },
+    };
+  },
+};
+`,
+    );
+
+    const result = runSitemapGenerator(fixture, {
+      FIREBASE_SERVICE_ACCOUNT: '{}',
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.signal, null);
+    assert.equal(result.status, 0);
+    assert.equal(result.stderr, 'sitemap_dynamic_events_unavailable\n');
+    assert.doesNotMatch(result.stdout, new RegExp(providerCanary, 'u'));
+    const sitemap = fs.readFileSync(
+      path.join(fixture.root, 'public/sitemap.xml'),
+      'utf8',
+    );
+    assert.match(sitemap, /<loc>https:\/\/runmprc\.com\/<\/loc>/u);
+    assert.doesNotMatch(sitemap, new RegExp(providerCanary, 'u'));
+  });
+
+  await t.test('fatal output errors fail closed without paths or stacks', () => {
+    const pathCanary = 'sitemap-fatal-path-canary';
+    const fixture = makeSitemapFixture(pathCanary);
+    const result = runSitemapGenerator(fixture);
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.signal, null);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(
+      result.stderr,
+      'No Firestore credentials; skipping dynamic event URLs\n'
+        + 'sitemap_generation_failed\n',
+    );
+    assert.doesNotMatch(result.stderr, new RegExp(pathCanary, 'u'));
+    assert.doesNotMatch(result.stderr, /ENOENT|Error:|generate-sitemap\.js/iu);
+  });
+});
 
 test('safe synthetic nested reports pass and source outside explicit roots is ignored', () => {
   const { root, temporaryDirectory } = makeArtifactRoot();


### PR DESCRIPTION
## Outcome

Sitemap generation now emits fixed, non-sensitive log codes when Firestore lookup or sitemap output fails. Provider messages, filesystem paths, stacks, causes, and arbitrary thrown fields are never read or logged.

Closes #512

## Invariant and behavior

- Recoverable dynamic-event failures still fall back to the static sitemap and exit 0.
- Fatal sitemap-output failures still exit 1.
- The existing no-credentials warning and all sitemap URLs/XML/query behavior remain unchanged.
- Both catch bindings are omitted so caught values cannot be inspected or serialized.

## Tests

- Trustworthy RED: both black-box witnesses failed on released base `af826f7` by exposing a synthetic provider canary and a fatal filesystem path/stack.
- GREEN on exact head `2deb72214801cdaf83ac8a5db2865844b0555c8c`:
  - Node 20 artifact-safety suite: 25/25
  - Hostile inherited `SITE_ORIGIN` fixture: 25/25
  - Frontend Jest: 806/806 on the identical #512 patch before the disjoint #510 refresh
  - SPA navigation: 11/11
  - Repository safety suites: 80/80 on the identical #512 patch before the disjoint #510 refresh
  - Frontend lint ledger: 110 files / 113 reviewed legacy errors / 6 reviewed legacy warnings
  - Diagnostic production build: passed on the identical #512 patch before the disjoint #510 refresh
  - `git diff --check`: passed
- Two independent read-only reviews: GO after one fixture-environment determinism correction.
- Exact two-file binary diff SHA-256: `53b16b2f1bd36e10ac61d8d976b62590b1b48f72a8a259e28c87c8dd1a8c13ff`.

## Scope

Only `scripts/generate-sitemap.js` and one named black-box block plus fixture helpers in `tests/test-artifact-safety.test.js` change. The separate `/activities` static-page edit, `public/sitemap.xml`, packages, workflows, docs, Firebase/provider configuration, and production data are excluded.

Officer impact: No officer workflow changes. Build failures expose stable diagnostic codes instead of provider or filesystem details.

Officer documentation: None — permissions, deployment steps, page structure, data movement, and officer procedures are unchanged; existing root security policy already requires sanitized log codes.

Deployment evidence: Source and local tests only at PR creation. Website not published; `runmprc.com` not verified for this change; Firebase not deployed; outside providers not configured or called; production data unchanged. Hosted exact-head CI is pending.
