### PR TITLE
OAUTH-001B5: fail closed on unconfirmed Strava revocation

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -29,6 +29,7 @@ const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.'
 const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
 const STRAVA_STATS_REQUEST_ERROR_MESSAGE = 'Strava statistics request is invalid.';
 const STRAVA_DISCONNECT_REQUEST_ERROR_MESSAGE = 'Strava disconnect request is invalid.';
+const STRAVA_DISCONNECT_ERROR_MESSAGE = 'Strava disconnect could not be confirmed.';
 const VISIBLE_ASCII_PATTERN = /^[\x21-\x7e]+$/;
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/u;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/u;
@@ -51,6 +52,12 @@ const reflectHas = Reflect.has;
 const reflectOwnKeys = Reflect.ownKeys;
 const regexpTest = RegExp.prototype.test;
 const stringCharCodeAt = String.prototype.charCodeAt;
+const NATIVE_RESPONSE_PROTOTYPE = typeof Response === 'function'
+  ? Response.prototype
+  : null;
+const NATIVE_RESPONSE_OK_GETTER = NATIVE_RESPONSE_PROTOTYPE
+  ? objectGetOwnPropertyDescriptor(NATIVE_RESPONSE_PROTOTYPE, 'ok')?.get
+  : null;
 const INVALID_SELECTED_VALUE = Symbol('invalid-selected-value');
 const MISSING_SELECTED_VALUE = Symbol('missing-selected-value');
 const INVALID_AUTHORIZATION_REQUEST = Symbol('invalid-authorization-request');
@@ -68,6 +75,10 @@ function stravaRefreshError(code) {
 
 function stravaDataError(code) {
   return new functions.https.HttpsError(code, STRAVA_DATA_ERROR_MESSAGE);
+}
+
+function stravaDisconnectError() {
+  return new functions.https.HttpsError('unavailable', STRAVA_DISCONNECT_ERROR_MESSAGE);
 }
 
 function patternMatches(pattern, value) {
@@ -141,6 +152,35 @@ function isValidStravaDisconnectRequest(data) {
 
 function isValidStravaStatsRequest(data) {
   return isExactPlainRecord(data, []);
+}
+
+function isConfirmedStravaDisconnectResponse(response) {
+  if (isPlainJsonRecord(response)) {
+    return selectedOwnDataValue(response, 'ok', true) === true;
+  }
+  if (
+    NATIVE_RESPONSE_PROTOTYPE === null
+    || typeof NATIVE_RESPONSE_OK_GETTER !== 'function'
+    || response === null
+    || typeof response !== 'object'
+    || isProxy(response)
+  ) {
+    return false;
+  }
+
+  let responsePrototype;
+  try {
+    responsePrototype = objectGetPrototypeOf(response);
+  } catch (_error) {
+    return false;
+  }
+  if (responsePrototype !== NATIVE_RESPONSE_PROTOTYPE) return false;
+
+  try {
+    return reflectApply(NATIVE_RESPONSE_OK_GETTER, response, []) === true;
+  } catch (_error) {
+    return false;
+  }
 }
 
 function isBoundedVisibleAscii(value, maxLength) {
@@ -1041,13 +1081,18 @@ exports.stravaDisconnect = functions
     if (secretSnap.exists) {
       const accessToken = snapshotStoredDisconnectAccessToken(secretSnap.data());
       if (accessToken) {
+        let revokeResponse;
         try {
-          await fetch(STRAVA_DEAUTH_URL, {
+          revokeResponse = await fetch(STRAVA_DEAUTH_URL, {
             method: 'POST',
             headers: { Authorization: `Bearer ${accessToken}` },
           });
         } catch (_error) {
           console.warn('strava_disconnect_revoke_failed');
+          throw stravaDisconnectError();
+        }
+        if (!isConfirmedStravaDisconnectResponse(revokeResponse)) {
+          throw stravaDisconnectError();
         }
       }
     }

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -316,6 +316,7 @@ const FIXED_REFRESH_ERROR = 'Strava connection could not be refreshed.';
 const FIXED_DATA_ERROR = 'Strava activity data could not be loaded.';
 const FIXED_STATS_REQUEST_ERROR = 'Strava statistics request is invalid.';
 const FIXED_DISCONNECT_REQUEST_ERROR = 'Strava disconnect request is invalid.';
+const FIXED_DISCONNECT_ERROR = 'Strava disconnect could not be confirmed.';
 const FIXED_DISCONNECT_WARNING = 'strava_disconnect_revoke_failed';
 const GUARDED_FETCH = global.fetch;
 const AUTH_TIME = 1_700_000_000;
@@ -4909,9 +4910,33 @@ describe('Strava disconnect failure log boundary', () => {
     seedStoredSecret({ access_token: accessToken });
   }
 
+  function seedConnectedAccount(accessToken = 'synthetic_disconnect_access_token_test') {
+    seedAccessToken(accessToken);
+    admin.__setDocument(CONNECTION_PATH, {
+      provider: 'strava',
+      connected: true,
+    });
+  }
+
   function expectLocalDeletes() {
     expect(admin.__getDeletes()).toEqual([SECRET_PATH, CONNECTION_PATH]);
     expect(admin.__getWrites()).toEqual([]);
+  }
+
+  function expectLocalRecordsPreserved() {
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getWrites()).toEqual([]);
+    expect(admin.__hasDocument(SECRET_PATH)).toBe(true);
+    expect(admin.__hasDocument(CONNECTION_PATH)).toBe(true);
+  }
+
+  function expectFixedDisconnectError(error) {
+    expect(publicError(error)).toEqual({
+      code: 'unavailable',
+      message: FIXED_DISCONNECT_ERROR,
+      details: undefined,
+      cause: undefined,
+    });
   }
 
   function expectNoLogs() {
@@ -5402,31 +5427,217 @@ describe('Strava disconnect failure log boundary', () => {
     expectNoLogs();
   });
 
-  test('preserves current HTTP non-success handling without reading the provider body', async () => {
+  test('accepts a genuine successful Node Response before local deletes', async () => {
     seedAccessToken();
-    const text = jest.fn().mockResolvedValue(
-      'provider-body-canary access_token=provider-secret-canary',
-    );
-    const json = jest.fn();
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 599,
-      text,
-      json,
-    });
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
 
     const result = await stravaDisconnect({}, CONTEXT);
 
     expect(result).toEqual({ ok: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expectLocalDeletes();
+    expectNoLogs();
+  });
+
+  test.each([400, 401, 429, 500])(
+    'rejects provider HTTP %i without reading its body or deleting locally',
+    async (status) => {
+      seedConnectedAccount();
+      const text = jest.fn().mockResolvedValue(
+        'provider-body-canary access_token=provider-secret-canary',
+      );
+      const json = jest.fn();
+      const statusGetter = jest.fn(() => status);
+      const bodyGetter = jest.fn(() => 'provider-body-canary');
+      const statusTextGetter = jest.fn(() => 'provider-status-text-canary');
+      const response = { ok: false, text, json };
+      Object.defineProperties(response, {
+        body: {
+          configurable: true,
+          enumerable: true,
+          get: bodyGetter,
+        },
+        status: {
+          configurable: true,
+          enumerable: true,
+          get: statusGetter,
+        },
+        statusText: {
+          configurable: true,
+          enumerable: true,
+          get: statusTextGetter,
+        },
+      });
+      fetchMock.mockResolvedValue(response);
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedDisconnectError(rejection);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(text).not.toHaveBeenCalled();
+      expect(json).not.toHaveBeenCalled();
+      expect(bodyGetter).not.toHaveBeenCalled();
+      expect(statusGetter).not.toHaveBeenCalled();
+      expect(statusTextGetter).not.toHaveBeenCalled();
+      expectLocalRecordsPreserved();
+      expectNoLogs();
+    },
+  );
+
+  test('rejects a genuine non-success Node Response without reading its body', async () => {
+    seedConnectedAccount();
+    const response = new Response('provider-body-canary access_token=secret-canary', {
+      status: 503,
+    });
+    fetchMock.mockResolvedValue(response);
+
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+    expectFixedDisconnectError(rejection);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.bodyUsed).toBe(false);
+    expectLocalRecordsPreserved();
+    expectNoLogs();
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a boolean', true],
+    ['a number', 1],
+    ['a string', 'ok'],
+    ['an array', [{ ok: true }]],
+    ['a Date', Object.assign(new Date(0), { ok: true })],
+    ['a plain record missing ok', {}],
+    ['own undefined ok', { ok: undefined }],
+    ['own null ok', { ok: null }],
+    ['numeric ok', { ok: 1 }],
+    ['string ok', { ok: 'true' }],
+    ['custom-prototype ok', Object.assign(Object.create({ inherited: true }), { ok: true })],
+  ])('rejects provider success evidence that is %s', async (_case, response) => {
+    seedConnectedAccount();
+    fetchMock.mockResolvedValue(response);
+
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+    expectFixedDisconnectError(rejection);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expectLocalRecordsPreserved();
+    expectNoLogs();
+  });
+
+  test('rejects an own ok accessor without invoking it', async () => {
+    seedConnectedAccount();
+    const okGetter = jest.fn(() => true);
+    const response = {};
+    Object.defineProperty(response, 'ok', {
+      configurable: true,
+      enumerable: true,
+      get: okGetter,
+    });
+    fetchMock.mockResolvedValue(response);
+
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+    expectFixedDisconnectError(rejection);
+    expect(okGetter).not.toHaveBeenCalled();
+    expectLocalRecordsPreserved();
+    expectNoLogs();
+  });
+
+  test('rejects an inherited ok accessor without invoking it', async () => {
+    seedConnectedAccount();
+    const okGetter = jest.fn(() => true);
+    const prototype = {};
+    Object.defineProperty(prototype, 'ok', {
+      configurable: true,
+      enumerable: true,
+      get: okGetter,
+    });
+    fetchMock.mockResolvedValue(Object.create(prototype));
+
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+    expectFixedDisconnectError(rejection);
+    expect(okGetter).not.toHaveBeenCalled();
+    expectLocalRecordsPreserved();
+    expectNoLogs();
+  });
+
+  test('rejects a Proxy provider result without inspecting it after Promise resolution', async () => {
+    seedConnectedAccount();
+    const traps = {
+      get: jest.fn((_target, key) => {
+        if (key === 'then') return undefined;
+        throw new Error('disconnect-response-canary get trap');
+      }),
+      getOwnPropertyDescriptor: jest.fn(() => {
+        throw new Error('disconnect-response-canary descriptor trap');
+      }),
+      getPrototypeOf: jest.fn(() => {
+        throw new Error('disconnect-response-canary prototype trap');
+      }),
+      ownKeys: jest.fn(() => {
+        throw new Error('disconnect-response-canary ownKeys trap');
+      }),
+    };
+    fetchMock.mockResolvedValue(new Proxy({ ok: true }, traps));
+
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+    expectFixedDisconnectError(rejection);
+    const requestedKeys = traps.get.mock.calls.map(([, key]) => key);
+    expect(requestedKeys.length).toBeGreaterThanOrEqual(1);
+    expect(requestedKeys.every((key) => key === 'then')).toBe(true);
+    [traps.getOwnPropertyDescriptor, traps.getPrototypeOf, traps.ownKeys]
+      .forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    expectLocalRecordsPreserved();
+    expectNoLogs();
+  });
+
+  test('accepts an own true result without consulting hostile unknown fields', async () => {
+    seedAccessToken();
+    const unknownGetter = jest.fn(() => {
+      throw new Error('disconnect-response-canary unknown getter');
+    });
+    const text = jest.fn();
+    const json = jest.fn();
+    const bodyGetter = jest.fn(() => 'disconnect-response-canary body');
+    const statusTextGetter = jest.fn(() => 'disconnect-response-canary status text');
+    const response = { ok: true, text, json };
+    Object.defineProperties(response, {
+      body: {
+        configurable: true,
+        enumerable: true,
+        get: bodyGetter,
+      },
+      status: {
+        configurable: true,
+        enumerable: true,
+        get: unknownGetter,
+      },
+      statusText: {
+        configurable: true,
+        enumerable: true,
+        get: statusTextGetter,
+      },
+    });
+    fetchMock.mockResolvedValue(response);
+
+    const result = await stravaDisconnect({}, CONTEXT);
+
+    expect(result).toEqual({ ok: true });
+    expect(unknownGetter).not.toHaveBeenCalled();
+    expect(bodyGetter).not.toHaveBeenCalled();
+    expect(statusTextGetter).not.toHaveBeenCalled();
     expect(text).not.toHaveBeenCalled();
     expect(json).not.toHaveBeenCalled();
     expectLocalDeletes();
     expectNoLogs();
   });
 
-  test('replaces a raw provider exception with one fixed warning before local deletes', async () => {
-    seedAccessToken();
+  test('replaces a raw provider exception with one fixed warning and preserves local records', async () => {
+    seedConnectedAccount();
     fetchMock.mockRejectedValue(Object.assign(
       new Error('transport-canary https://provider.example.test/?token=secret-canary'),
       {
@@ -5436,9 +5647,9 @@ describe('Strava disconnect failure log boundary', () => {
       },
     ));
 
-    const result = await stravaDisconnect({}, CONTEXT);
+    const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
 
-    expect(result).toEqual({ ok: true });
+    expectFixedDisconnectError(rejection);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpies.warn).toHaveBeenCalledWith(FIXED_DISCONNECT_WARNING);
@@ -5448,7 +5659,7 @@ describe('Strava disconnect failure log boundary', () => {
       );
     ['debug', 'error', 'info', 'log']
       .forEach((method) => expect(consoleSpies[method]).not.toHaveBeenCalled());
-    expectLocalDeletes();
+    expectLocalRecordsPreserved();
   });
 
   test('preserves swallowed local delete failures and the current success result', async () => {


### PR DESCRIPTION
Closes #518. Child of #88.

## Outcome

Strava disconnect now reports success only after the provider confirms a successful revocation response. A transport failure, HTTP failure, or malformed response returns one fixed non-identifying error and preserves both local records for reload/retry instead of deleting the only retry credential.

## Boundary and compatibility

- Preserves App Check, Auth, exact-empty request, and stored-token admission order.
- Accepts a genuine successful Node 20 `Response` and the existing exact plain `{ok: true}` test double.
- Rejects HTTP failures, transport failures, null/malformed results, Proxies, inherited/accessor-backed evidence, and non-boolean success evidence.
- Never reads provider bodies, JSON, status text, caught values, tokens, or unknown fields.
- Preserves the existing cleanup behavior when no valid stored token exists.
- Leaves retry/backoff, lost-ack reconciliation, durable revoke audit, transactional cleanup, and migration to Strava's newer `/oauth/revoke` endpoint under #88.

Exact scope: `functions/strava.js` and `functions/strava.test.js` only.

## Verification

- RED: the pre-fix HTTP-failure witness returned success and deleted both records.
- Focused disconnect tests: 84/84 passed on Node 20.20.2.
- Full Strava tests: 641/641 passed.
- Full Functions tests: 6,408 passed; 64 skipped.
- Functions lint: passed.
- Frontend Jest: 16 suites, 855/855 passed.
- Repository-safety tests: 80/80 passed.
- SPA navigation: 11/11 passed.
- Frontend lint ledger: 114 files, 113 reviewed legacy errors, 6 reviewed legacy warnings.
- Diagnostic production build: passed.
- `git diff --check`: passed.
- Three independent exact-head reviews: security GO, tests GO, scope/docs GO.
- Local Rules and commerce-emulator checks were not rerun because this environment lacks the required Java runtime; the hosted Java 21 jobs are required before merge.

Reviewed head: `074b8dc25779d4c97a53053249784376a8f6ee19`

Base: `ce49d4a06220dd5cdce844964f933b8bf1451308`

Binary diff SHA-256: `1da6a9ead0ae2baf22eb88b7f4f3d2f429d6abce81a5f3577bcc923707fe1f2d`

## Officer continuity

Officer impact: A signed-in member is no longer told that Strava disconnected when revocation was not confirmed. The browser continues to show the existing fixed message and reload-before-retry guidance.

Officer documentation: None — `docs/officers/EVENTS_SHOP_MEMBERS.md` already documents this exact unknown-disconnect outcome under #252. This source-only child changes no officer step, page structure, permission, or data-flow diagram.

Deployment evidence: Source and synthetic-test evidence only at PR creation. No Firebase deployment, Strava/provider call or configuration, production-data action, website publication, or live behavior is claimed. Merge requires all five hosted checks. Post-merge evidence will distinguish source merged from any live deployment.

## Residual risk

The current endpoint can still lose acknowledgement after provider success, and local delete failures after confirmed revocation remain best-effort. Provider endpoint migration, retry-safe reconciliation, durable audit, and live verification remain open in #88.
