### PR TITLE
AUTH-006E: bind auth projection to identity context

### DIFF
--- a/src/services/hooks/useAuth.ts
+++ b/src/services/hooks/useAuth.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useServiceLocator } from '../ServiceLocatorContext';
-import { AuthUser, RegistrationResult } from '../identity/Identity';
+import type { AuthUser, RegistrationResult } from '../identity/Identity';
 
 export interface UseAuthResult {
   user: AuthUser | null;
@@ -13,30 +13,53 @@ export interface UseAuthResult {
   register: (email: string, password: string) => Promise<RegistrationResult>;
 }
 
+interface AuthSnapshot {
+  contextToken: symbol | null;
+  isLoading: boolean;
+  user: AuthUser | null;
+}
+
 export function useAuth(): UseAuthResult {
   const { services, isReady } = useServiceLocator();
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const identityService = isReady && services ? services.identityService : null;
+  const contextToken = useMemo(() => Symbol('auth-context'), [identityService]);
+  const [authSnapshot, setAuthSnapshot] = useState<AuthSnapshot>({
+    contextToken: null,
+    isLoading: true,
+    user: null,
+  });
 
   useEffect(() => {
-    if (!isReady || !services) {
+    if (!identityService) {
       return undefined;
     }
 
-    const { identityService } = services;
+    let active = true;
+    const publishUser = (authUser: AuthUser | null) => {
+      if (!active) return;
+      setAuthSnapshot({
+        contextToken,
+        isLoading: false,
+        user: authUser,
+      });
+    };
 
     // Set initial user state
-    setUser(identityService.currentUser);
-    setIsLoading(false);
+    publishUser(identityService.currentUser);
 
     // Subscribe to auth state changes
-    const unsubscribe = identityService.onAuthStateChanged((authUser: AuthUser | null) => {
-      setUser(authUser);
-      setIsLoading(false);
-    });
+    const unsubscribe = identityService.onAuthStateChanged(publishUser);
 
-    return unsubscribe;
-  }, [services, isReady]);
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [contextToken, identityService]);
+
+  const snapshotIsCurrent = identityService !== null
+    && authSnapshot.contextToken === contextToken;
+  const user = snapshotIsCurrent ? authSnapshot.user : null;
+  const isLoading = !snapshotIsCurrent || authSnapshot.isLoading;
 
   const signIn = async (email: string, password: string): Promise<void> => {
     if (!services) {
@@ -64,7 +87,7 @@ export function useAuth(): UseAuthResult {
 
   return {
     user,
-    isLoading: !isReady || isLoading,
+    isLoading,
     isAuthenticated: user !== null,
     isMember: user?.role === 'member' || user?.role === 'admin',
     isAdmin: user?.role === 'admin',

--- a/src/services/identity/Identity.test.ts
+++ b/src/services/identity/Identity.test.ts
@@ -1,5 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import React, { useLayoutEffect } from 'react';
+import { act, render } from '@testing-library/react';
+import ServiceLocatorContext from '../ServiceLocatorContext';
+import type { ServiceLocatorContextValue } from '../ServiceLocatorContext';
+import { useAuth } from '../hooks/useAuth';
+import type { UseAuthResult } from '../hooks/useAuth';
+import type { AuthStateCallback, AuthUser } from './Identity';
 
 export {};
 
@@ -1211,5 +1218,236 @@ describe('Identity email verification action', () => {
     expect(JSON.stringify(consoleSpies.flatMap((spy) => spy.mock.calls)))
       .not.toMatch(/unknown-private|synthetic-member|unknown-code/);
     consoleSpies.forEach((spy) => spy.mockRestore());
+  });
+});
+
+describe('AUTH-006E useAuth identity-context isolation', () => {
+  type HookIdentityService = NonNullable<
+    ServiceLocatorContextValue['services']
+  >['identityService'];
+
+  interface IdentityHarness {
+    listeners: AuthStateCallback[];
+    service: HookIdentityService;
+    setCurrentUser: (user: AuthUser | null) => void;
+    unsubscribes: jest.Mock[];
+  }
+
+  interface AuthCommit {
+    context: string;
+    isAdmin: boolean;
+    isAuthenticated: boolean;
+    isLoading: boolean;
+    isMember: boolean;
+    user: AuthUser | null;
+  }
+
+  function projectedUser(uid: string, role: AuthUser['role']): AuthUser {
+    return {
+      email: `${uid}@example.test`,
+      role,
+      uid,
+    };
+  }
+
+  function createIdentityHarness(initialUser: AuthUser | null): IdentityHarness {
+    let currentUser = initialUser;
+    const listeners: AuthStateCallback[] = [];
+    const unsubscribes: jest.Mock[] = [];
+    const service = {
+      get currentUser() {
+        return currentUser;
+      },
+      onAuthStateChanged: jest.fn((callback: AuthStateCallback) => {
+        listeners.push(callback);
+        const unsubscribe = jest.fn();
+        unsubscribes.push(unsubscribe);
+        return unsubscribe;
+      }),
+      register: jest.fn(),
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+    } as unknown as HookIdentityService;
+
+    return {
+      listeners,
+      service,
+      setCurrentUser(user) {
+        currentUser = user;
+      },
+      unsubscribes,
+    };
+  }
+
+  function readyLocator(
+    identityService: HookIdentityService,
+  ): ServiceLocatorContextValue {
+    return {
+      isReady: true,
+      services: {
+        firebaseResources: {},
+        identityService,
+      },
+    } as unknown as ServiceLocatorContextValue;
+  }
+
+  function AuthProbe({
+    commits,
+    context,
+  }: {
+    commits: AuthCommit[];
+    context: string;
+  }) {
+    const auth: UseAuthResult = useAuth();
+    useLayoutEffect(() => {
+      commits.push({
+        context,
+        isAdmin: auth.isAdmin,
+        isAuthenticated: auth.isAuthenticated,
+        isLoading: auth.isLoading,
+        isMember: auth.isMember,
+        user: auth.user,
+      });
+    });
+    return null;
+  }
+
+  function authTree(
+    locator: ServiceLocatorContextValue,
+    context: string,
+    commits: AuthCommit[],
+  ) {
+    return React.createElement(
+      ServiceLocatorContext.Provider,
+      { value: locator },
+      React.createElement(AuthProbe, { commits, context }),
+    );
+  }
+
+  function lastCommit(commits: AuthCommit[]): AuthCommit {
+    const commit = commits[commits.length - 1];
+    if (!commit) throw new Error('missing synthetic auth commit');
+    return commit;
+  }
+
+  function expectUnprivileged(commit: AuthCommit, loading: boolean): void {
+    expect(commit).toMatchObject({
+      isAdmin: false,
+      isAuthenticated: false,
+      isLoading: loading,
+      isMember: false,
+      user: null,
+    });
+  }
+
+  test('never commits service A admin state under signed-out service B', () => {
+    const serviceA = createIdentityHarness(projectedUser('admin-a', 'admin'));
+    const serviceB = createIdentityHarness(null);
+    const commits: AuthCommit[] = [];
+    const view = render(authTree(readyLocator(serviceA.service), 'A', commits));
+
+    expect(lastCommit(commits)).toMatchObject({
+      context: 'A',
+      isAdmin: true,
+      isAuthenticated: true,
+      isLoading: false,
+      isMember: true,
+      user: projectedUser('admin-a', 'admin'),
+    });
+
+    const firstBCommit = commits.length;
+    view.rerender(authTree(readyLocator(serviceB.service), 'B', commits));
+    const bCommits = commits.slice(firstBCommit);
+
+    expect(bCommits.length).toBeGreaterThanOrEqual(2);
+    expectUnprivileged(bCommits[0], true);
+    bCommits.forEach((commit) => {
+      expect(commit.context).toBe('B');
+      expect(commit.user).toBeNull();
+      expect(commit.isAuthenticated).toBe(false);
+      expect(commit.isMember).toBe(false);
+      expect(commit.isAdmin).toBe(false);
+    });
+    expectUnprivileged(lastCommit(bCommits), false);
+  });
+
+  test('ignores a retained service A callback after service B settles', () => {
+    const serviceA = createIdentityHarness(projectedUser('member-a', 'member'));
+    const serviceB = createIdentityHarness(null);
+    const commits: AuthCommit[] = [];
+    const view = render(authTree(readyLocator(serviceA.service), 'A', commits));
+    const retainedAListener = serviceA.listeners[0];
+
+    view.rerender(authTree(readyLocator(serviceB.service), 'B', commits));
+    expectUnprivileged(lastCommit(commits), false);
+    expect(serviceA.unsubscribes[0]).toHaveBeenCalledTimes(1);
+    const settledCommitCount = commits.length;
+
+    act(() => {
+      retainedAListener(projectedUser('stale-admin-a', 'admin'));
+    });
+
+    expect(commits).toHaveLength(settledCommitCount);
+    expectUnprivileged(lastCommit(commits), false);
+  });
+
+  test('treats A after an unavailable context as a new generation', () => {
+    const serviceA = createIdentityHarness(projectedUser('old-admin-a', 'admin'));
+    const commits: AuthCommit[] = [];
+    const locatorA = readyLocator(serviceA.service);
+    const view = render(authTree(locatorA, 'A1', commits));
+    const firstGenerationListener = serviceA.listeners[0];
+
+    view.rerender(authTree({ isReady: false, services: null }, 'unavailable', commits));
+    expectUnprivileged(lastCommit(commits), true);
+    serviceA.setCurrentUser(null);
+
+    const firstA3Commit = commits.length;
+    view.rerender(authTree(locatorA, 'A3', commits));
+    const a3Commits = commits.slice(firstA3Commit);
+    expectUnprivileged(a3Commits[0], true);
+    expectUnprivileged(lastCommit(a3Commits), false);
+    expect(serviceA.listeners).toHaveLength(2);
+
+    const settledCommitCount = commits.length;
+    act(() => {
+      firstGenerationListener(projectedUser('stale-admin-a', 'admin'));
+    });
+    expect(commits).toHaveLength(settledCommitCount);
+    expectUnprivileged(lastCommit(commits), false);
+
+    act(() => {
+      serviceA.listeners[1](projectedUser('current-member-a', 'member'));
+    });
+    expect(lastCommit(commits)).toMatchObject({
+      context: 'A3',
+      isAdmin: false,
+      isAuthenticated: true,
+      isLoading: false,
+      isMember: true,
+      user: projectedUser('current-member-a', 'member'),
+    });
+  });
+
+  test('keeps one subscription for an equivalent wrapper with the same service', () => {
+    const serviceA = createIdentityHarness(projectedUser('member-a', 'member'));
+    const commits: AuthCommit[] = [];
+    const locatorA1 = readyLocator(serviceA.service);
+    const locatorA2 = readyLocator(serviceA.service);
+    const view = render(authTree(locatorA1, 'A1', commits));
+
+    expect(serviceA.listeners).toHaveLength(1);
+    view.rerender(authTree(locatorA2, 'A2', commits));
+
+    expect(lastCommit(commits)).toMatchObject({
+      context: 'A2',
+      isAdmin: false,
+      isAuthenticated: true,
+      isLoading: false,
+      isMember: true,
+      user: projectedUser('member-a', 'member'),
+    });
+    expect(serviceA.listeners).toHaveLength(1);
+    expect(serviceA.unsubscribes[0]).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #519.

## Outcome

The browser auth projection is now bound to the effective Identity service generation. A role/user snapshot from service A cannot render under service B, an unavailable context, or a later A generation after an unavailable interval.

## Security invariant and transitions

- Only a snapshot tagged by the current effective Identity service generation can produce authenticated, member, or admin UI state.
- A -> B renders signed-out/loading before B publishes its own state.
- A -> unavailable -> A creates a new generation; callbacks retained from the first A are inert.
- Cleanup disables the old callback before calling unsubscribe.
- Equivalent Service Locator wrappers around the same Identity service keep one subscription.
- Sign-in, sign-out, registration, server authorization, provider behavior, and logging are unchanged.

## Failure and compatibility behavior

- Missing or unready services fail closed to user null, loading true, and all privilege booleans false.
- Stale callbacks cannot publish after cleanup and pre-cleanup stale snapshots are rejected during render by the generation tag.
- No schema, migration, package, Firebase Rules, Functions, provider, or production-data change is required.

## Verification

- Trustworthy RED on the released pre-fix runtime: 4/4 focused lifecycle regressions failed for stale A-under-B state, retained callbacks, A/unavailable/A reuse, and unnecessary same-service resubscription.
- Node 20 focused GREEN: 4/4.
- Full frontend: 16 suites, 859/859 tests.
- Frontend lint ledger: 114 files / 113 reviewed legacy errors / 6 reviewed legacy warnings.
- Direct ESLint on both changed files: passed.
- TypeScript noEmit: passed.
- SPA navigation: 11/11.
- Diagnostic production build: passed.
- git diff --check: passed.
- Independent lifecycle/test review: GO.
- Final exact-commit security/scope review: GO for 986ca75a0f0e2f83ad01c5b36197bdf79f4c5a82.

Exact two-file binary diff SHA-256: a83d83bdb4a9bc18278126e3d99e72a9205d4ee7da8c16dc68cacfe1acb340ac.

## Officer continuity

Officer impact: None — this is an internal fail-closed browser projection correction. It does not change officer tasks, permissions, page structure, collected data, or account recovery.

Officer documentation: None — no officer procedure, topology, data movement, external account, provider, or deployment behavior changed.

Deployment evidence: Source and local tests only at PR creation. No website publication, runmprc.com verification, Firebase deployment, outside-provider action, production-data action, or live behavior proof has occurred. Hosted exact-head CI is required before merge; post-merge source and deployment-state evidence will be recorded separately.
