### PR TITLE
PAY-003A2: reject contradictory Checkout Session state

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -709,7 +709,8 @@ Text alternative: a valid unpaid failure or expiry still cancels a pending order
 
 At minimum verify:
 
-- Expected `livemode` for this deployment.
+- Outer Event and embedded Checkout Session `livemode` are booleans and both match the expected deployment mode.
+- Checkout Session lifecycle `status` matches the Event: `complete` for completion and delayed-payment outcomes; `expired` for expiration.
 - Session `mode` and object type.
 - Metadata schema and local record reference.
 - Session ID ownership (or attach it exactly once from trusted metadata for a persistence-first record).
@@ -718,6 +719,8 @@ At minimum verify:
 - `amount_total` equals the allowed expected total after a validated discount policy.
 - Local record is in an allowed predecessor state.
 - PaymentIntent is not already attached to another local business record.
+
+PAY-003A2 [#520](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/520) applies the first two checks before target resolution in the legacy webhook source. Missing, malformed, or contradictory Session evidence receives a fixed processed-review ledger result without a business-record query or change and without a provider binding. Record source changed, tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, a payment performed, production data changed, and live behavior verified as separate states. The repository diff and synthetic tests do not by themselves prove any merged, published, deployed, provider, payment, production-data, or live state. This child does not select a Stripe API version or configure a provider endpoint.
 
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
@@ -896,7 +899,7 @@ Every commerce release must cover:
 - Webhook arriving before the client redirect.
 - Duplicate and out-of-order webhook events.
 - Invalid signature and wrong webhook secret.
-- Wrong livemode, amount, currency, metadata, Session, or PaymentIntent.
+- Wrong outer or embedded livemode, Event/Session lifecycle mismatch, amount, currency, metadata, Session, or PaymentIntent.
 - `completed` with unpaid/processing status.
 - Async payment success and failure.
 - Session expiry and local cancellation with Stripe expiry.

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -20,6 +20,12 @@ const CHECKOUT_EVENT_TYPES = new Set([
   'checkout.session.async_payment_failed',
   'checkout.session.expired',
 ]);
+const CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE = new Map([
+  ['checkout.session.completed', 'complete'],
+  ['checkout.session.async_payment_succeeded', 'complete'],
+  ['checkout.session.async_payment_failed', 'complete'],
+  ['checkout.session.expired', 'expired'],
+]);
 const CHECKOUT_PAYMENT_STATUSES = new Set(['paid', 'unpaid', 'no_payment_required']);
 const DISPUTE_EVENT_TYPES = new Set([
   'charge.dispute.created',
@@ -62,6 +68,32 @@ function validateExpectedLivemode(event, expected) {
     return { ok: false, expected, reason: 'livemode_mismatch' };
   }
   return { ok: true, expected };
+}
+
+function validateEventAdmission(event, expectedLivemode) {
+  const modeValidation = validateExpectedLivemode(event, expectedLivemode);
+  if (!modeValidation.ok || !CHECKOUT_EVENT_TYPES.has(event.type)) {
+    return modeValidation;
+  }
+
+  const session = event.data?.object;
+  if (typeof session?.livemode !== 'boolean'
+    || session.livemode !== event.livemode
+    || session.livemode !== expectedLivemode) {
+    return {
+      ok: false,
+      expected: expectedLivemode,
+      reason: 'checkout_session_livemode_mismatch',
+    };
+  }
+  if (session.status !== CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE.get(event.type)) {
+    return {
+      ok: false,
+      expected: expectedLivemode,
+      reason: 'checkout_session_status_mismatch',
+    };
+  }
+  return modeValidation;
 }
 
 function isValidDocId(value) {
@@ -1199,10 +1231,10 @@ function disputeTransition({ event, dispute, target, record }) {
   };
 }
 
-function transitionForEvent(event, target, targetSnap, modeValidation, ownership) {
-  if (!modeValidation.ok) {
+function transitionForEvent(event, target, targetSnap, admissionValidation, ownership) {
+  if (!admissionValidation.ok) {
     return {
-      outcome: `needs_review:${modeValidation.reason}`,
+      outcome: `needs_review:${admissionValidation.reason}`,
       requiresReview: true,
       patch: null,
     };
@@ -1338,16 +1370,16 @@ async function processEvent(event, expectedLivemode) {
     return { duplicate: true, outcome: existing.data().outcome };
   }
 
-  const modeValidation = validateExpectedLivemode(event, expectedLivemode);
+  const admissionValidation = validateEventAdmission(event, expectedLivemode);
   const ownership = classifyMprcReference(event.data.object);
-  const target = modeValidation.ok ? await resolveTarget(event) : null;
+  const target = admissionValidation.ok ? await resolveTarget(event) : null;
   if (target) await assertExclusiveProviderOwnership(event, target);
   // Checkout creation and the Firestore write are not atomic. A supported
   // event carrying a valid MPRC reference can therefore beat its business
   // record into Firestore. Do not write a final ledger marker in that case:
   // return 5xx and let Stripe redeliver. Unrelated Stripe traffic is handled
   // below without retrying forever.
-  if (modeValidation.ok && isSupportedEventType(event.type)
+  if (admissionValidation.ok && isSupportedEventType(event.type)
     && ownership.status === 'claimed' && !target) {
     throw new Error(`Retryable Stripe target not found for ${event.id}`);
   }
@@ -1362,7 +1394,7 @@ async function processEvent(event, expectedLivemode) {
       return;
     }
     const targetSnap = target ? await tx.get(target.ref) : null;
-    if (modeValidation.ok && isSupportedEventType(event.type)
+    if (admissionValidation.ok && isSupportedEventType(event.type)
       && target && !targetSnap?.exists) {
       throw new Error(`Retryable Stripe target disappeared for ${event.id}`);
     }
@@ -1382,7 +1414,7 @@ async function processEvent(event, expectedLivemode) {
         event,
         target,
         targetSnap,
-        modeValidation,
+        admissionValidation,
         ownership,
       );
     const providerBindingVerified = targetSnap?.exists

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -193,7 +193,15 @@ process.env.STRIPE_LIVEMODE_EXPECTED = 'false';
 
 const { stripeWebhook } = require('./stripeWebhook');
 
+const CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE = Object.freeze({
+  'checkout.session.completed': 'complete',
+  'checkout.session.async_payment_succeeded': 'complete',
+  'checkout.session.async_payment_failed': 'complete',
+  'checkout.session.expired': 'expired',
+});
+
 function stripeEvent(id, type, object) {
+  const checkoutStatus = CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE[type];
   return {
     id,
     object: 'event',
@@ -203,7 +211,11 @@ function stripeEvent(id, type, object) {
     pending_webhooks: 1,
     request: null,
     type,
-    data: { object },
+    data: {
+      object: checkoutStatus
+        ? { livemode: false, status: checkoutStatus, ...object }
+        : object,
+    },
   };
 }
 
@@ -323,6 +335,35 @@ async function deliver(event) {
   const response = mockResponse();
   await stripeWebhook(signedRequest(event), response);
   return response;
+}
+
+function storedCopy(path) {
+  return JSON.parse(JSON.stringify(admin.__get(path)));
+}
+
+function expectCompatibilityQuarantine({ response, event, businessPath, before, reason }) {
+  expect(response.status).not.toHaveBeenCalled();
+  expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+    received: true,
+    duplicate: false,
+    outcome: `needs_review:${reason}`,
+    requiresReview: true,
+  }));
+  expect(admin.__get(businessPath)).toEqual(before);
+  expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+    status: 'processed',
+    outcome: `needs_review:${reason}`,
+    requiresReview: true,
+    targetType: null,
+    targetPath: null,
+    targetSource: null,
+  });
+  expect(admin.__get(
+    `stripeObjectBindings/checkout_session:${event.data.object.id}`,
+  )).toBeUndefined();
+  expect(admin.__get(
+    `stripeObjectBindings/payment_intent:${event.data.object.payment_intent}`,
+  )).toBeUndefined();
 }
 
 describe('stripeWebhook', () => {
@@ -680,6 +721,206 @@ describe('stripeWebhook', () => {
       requiresReview: true,
       targetPath: null,
     });
+  });
+
+  test.each([
+    ['opposite boolean', 'value', true],
+    ['missing', 'delete', undefined],
+    ['null', 'value', null],
+    ['string', 'value', 'false'],
+    ['number', 'value', 0],
+  ])('quarantines a Checkout Session with %s embedded livemode evidence', async (
+    label,
+    mutation,
+    value,
+  ) => {
+    seedRegistration();
+    const businessPath = 'events/race-1/registrations/reg-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      `evt_session_livemode_${label.replace(/[^a-z]+/g, '_')}`,
+      'checkout.session.completed',
+      registrationSession(),
+    );
+    if (mutation === 'delete') delete event.data.object.livemode;
+    else event.data.object.livemode = value;
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({
+      response,
+      event,
+      businessPath,
+      before,
+      reason: 'checkout_session_livemode_mismatch',
+    });
+  });
+
+  test.each([
+    ['completed open', 'checkout.session.completed', 'value', 'open', 'paid'],
+    ['completed expired', 'checkout.session.completed', 'value', 'expired', 'paid'],
+    ['async success open', 'checkout.session.async_payment_succeeded', 'value', 'open', 'paid'],
+    ['async success expired', 'checkout.session.async_payment_succeeded', 'value', 'expired', 'paid'],
+    ['async failure open', 'checkout.session.async_payment_failed', 'value', 'open', 'unpaid'],
+    ['async failure expired', 'checkout.session.async_payment_failed', 'value', 'expired', 'unpaid'],
+    ['expired open', 'checkout.session.expired', 'value', 'open', 'unpaid'],
+    ['expired complete', 'checkout.session.expired', 'value', 'complete', 'unpaid'],
+    ['status missing', 'checkout.session.completed', 'delete', undefined, 'paid'],
+    ['status null', 'checkout.session.completed', 'value', null, 'paid'],
+    ['status unknown', 'checkout.session.completed', 'value', 'unknown', 'paid'],
+    ['status non-string', 'checkout.session.completed', 'value', 1, 'paid'],
+  ])('quarantines a Checkout Session whose lifecycle is %s', async (
+    label,
+    type,
+    mutation,
+    value,
+    paymentStatus,
+  ) => {
+    seedOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      `evt_session_status_${label.replace(/[^a-z]+/g, '_')}`,
+      type,
+      orderSession({ payment_status: paymentStatus }),
+    );
+    if (mutation === 'delete') delete event.data.object.status;
+    else event.data.object.status = value;
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({
+      response,
+      event,
+      businessPath,
+      before,
+      reason: 'checkout_session_status_mismatch',
+    });
+  });
+
+  test.each([
+    ['completion', 'checkout.session.completed', 'paid', 'payment_confirmed', 'paid'],
+    [
+      'async success',
+      'checkout.session.async_payment_succeeded',
+      'paid',
+      'payment_confirmed',
+      'paid',
+    ],
+    ['async failure', 'checkout.session.async_payment_failed', 'unpaid', 'payment_failed', 'cancelled'],
+    ['expiry', 'checkout.session.expired', 'unpaid', 'payment_expired', 'cancelled'],
+  ])('preserves the valid Checkout Session lifecycle for %s', async (
+    label,
+    type,
+    paymentStatus,
+    outcome,
+    status,
+  ) => {
+    seedRegistration();
+    const event = stripeEvent(
+      `evt_valid_session_status_${label.replace(/[^a-z]+/g, '_')}`,
+      type,
+      registrationSession({ payment_status: paymentStatus }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome,
+    }));
+    expect(admin.__get('events/race-1/registrations/reg-1').status).toBe(status);
+  });
+
+  test('quarantines an incompatible claimed Checkout Event without retrying a missing target', async () => {
+    const event = stripeEvent(
+      'evt_incompatible_missing_target',
+      'checkout.session.completed',
+      registrationSession({ status: 'open' }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:checkout_session_status_mismatch',
+      requiresReview: true,
+    }));
+    expect(admin.__get('stripeEvents/evt_incompatible_missing_target')).toMatchObject({
+      status: 'processed',
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    });
+  });
+
+  test('keeps a compatible claimed Checkout Event retryable when its target is missing', async () => {
+    const response = await deliver(stripeEvent(
+      'evt_compatible_missing_target',
+      'checkout.session.completed',
+      registrationSession(),
+    ));
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(response.send).toHaveBeenCalledWith('Webhook handler error');
+    expect(admin.__get('stripeEvents/evt_compatible_missing_target')).toBeUndefined();
+  });
+
+  test('keeps the configured Event livemode mismatch ahead of Session contradictions', async () => {
+    seedRegistration();
+    const businessPath = 'events/race-1/registrations/reg-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_outer_livemode_precedence',
+      'checkout.session.completed',
+      registrationSession({ status: 'open' }),
+    );
+    event.livemode = true;
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'needs_review:livemode_mismatch',
+      requiresReview: true,
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+    expect(admin.__get('stripeEvents/evt_outer_livemode_precedence')).toMatchObject({
+      outcome: 'needs_review:livemode_mismatch',
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    });
+  });
+
+  test('deduplicates an incompatible Checkout Event without a target or binding mutation', async () => {
+    seedOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_incompatible_replay',
+      'checkout.session.expired',
+      orderSession({ payment_status: 'unpaid', status: 'complete' }),
+    );
+
+    const firstResponse = await deliver(event);
+    const replayResponse = await deliver(event);
+
+    expectCompatibilityQuarantine({
+      response: firstResponse,
+      event,
+      businessPath,
+      before,
+      reason: 'checkout_session_status_mismatch',
+    });
+    expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'needs_review:checkout_session_status_mismatch',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
   });
 
   test('confirms a paid registration and records actual Stripe totals atomically', async () => {


### PR DESCRIPTION
Closes #520. Parent #106 remains open.

## Outcome

A supported signed Checkout Event can no longer confirm payment or cancel a pending registration/order when its embedded Checkout Session contradicts the verified Event/configured realm or lifecycle state. Admission now fails before target resolution, records one fixed processed-review ledger result, and creates no business-record change or provider binding.

## Officer impact

None now. Live checkout remains unavailable. This code adds a safety check so conflicting Stripe test/live or checkout-state information cannot mark a registration or order paid or cancelled after a future separately approved Firebase release./

## Officer documentation

None — `docs/officers/EVENTS_SHOP_MEMBERS.md` already marks Stripe checkout, Firebase release, provider configuration, and live behavior as unavailable. This source/test child changes no officer procedure, page structure, permission, account, data-handling step, or release topology. `STRIPE_COMMERCE_DESIGN.md` records the authoritative engineering invariant and evidence boundary.

## Deployment evidence

- Source changed: yes, exact head `9fbb077e06df13aa136cdddd6a9644923492e953` on current base `ba03dfbd02c64b0b187d46cd70c8473fab6fc922`.
- Tests passed: yes, synthetic/local evidence listed below.
- Code merged: no.
- Website preview or publication: no evidence yet.
- `runmprc.com` verified: no.
- Firebase deployed: no.
- Stripe or any outside provider configured/contacted: no.
- Production data changed or inspected: no.
- Checkout/payment performed: no.
- Production behavior verified: no.

## Invariant and compatibility matrix

The existing outer Event/config mismatch retains first precedence as `livemode_mismatch`. For the four supported Checkout Events, embedded `session.livemode` must be a primitive boolean equal to the outer Event and configured mode.

| Event | Required Session `status` |
|---|---|
| `checkout.session.completed` | `complete` |
| `checkout.session.async_payment_succeeded` | `complete` |
| `checkout.session.async_payment_failed` | `complete` |
| `checkout.session.expired` | `expired` |

Missing, null, wrongly typed, unknown, or contradictory embedded evidence produces only `checkout_session_livemode_mismatch` or `checkout_session_status_mismatch`. `payment_status` remains independently validated and cannot substitute for lifecycle state.

## RED and GREEN evidence

RED on the untouched handler: the new focused matrix produced 19 intended failures. Contradictory snapshots were accepted as `payment_confirmed`, `payment_failed`, or `payment_expired`; an incompatible claimed Event with no target returned 500/no ledger.

GREEN on the fix:

- `stripeWebhook.test.js`: 161/161 passed.
- Exact rebased full Functions suite: 6,433 passed; 64 intentional skips.
- Full Functions lint: passed.
- Frontend Jest: 859/859 passed./
- SPA navigation: 11/11 passed.
- CI/release/Firebase verification/artifact/root-dependency static suites: 80/80 passed.
- Frontend lint baseline: 114 files, 113 reviewed legacy errors, 6 reviewed warnings.
- TypeScript no-emit check: passed.
- Diagnostic React build: passed (`main.6bd36381.js`); this is a local artifact, not publication.
- Firestore Rules on the demo emulator with checksum-verified temporary Temurin 21: 408/408 passed.
- Commerce command-journal concurrency suite on the demo emulator: 63/63 passed.
- `git diff --check`: passed; tracked worktree clean.

The test matrix covers embedded realm opposite/missing/null/string/number; every supported Event with incompatible open/complete/expired state; missing/null/unknown/non-string status; registration and order preservation; null ledger target fields; no Session/PaymentIntent binding; exact replay; invalid versus compatible missing-target behavior; and outer mismatch precedence. Existing completion, delayed payment, expiry, duplicate/out-of-order, terminal, refund, dispute, and binding tests remain green.

## Security and compatibility review

- No request body, Checkout URL, token, customer/member data, raw provider value, or caught error is logged or added to a reason.
- Rejection happens before `resolveTarget`, target reads/patches, and provider-binding creation.
- Signature verification, money/payment-status checks, ownership, refund/dispute handling, and accepted state transitions are unchanged.
- No schema migration is required. Already processed historical ledger entries are not re-reduced.
- No dependency or lockfile changed. Read-only production-dependency audits found zero critical findings; existing dependency advisories remain outside this atomic patch and no forced upgrade was applied.

## Explicitly excluded

Stripe API-version/provider inventory, ID-prefix inference, refund/dispute realm expansion, PAY-003B/C reducers/workers/alerts/reconciliation, schemas/backfills, frontend/Rules/workflows/packages, officer procedures, deployment, provider state, production data, checkout/payment, and live verification.