### PR TITLE
MAIL-001A1: escape registration confirmation HTML

### DIFF
--- a/functions/sendConfirmationEmail.js
+++ b/functions/sendConfirmationEmail.js
@@ -15,6 +15,29 @@ const { loadServerConfig } = require('./serverConfig');
 
 const CONFIRMED_STATUSES = new Set(['paid', 'comp']);
 
+function escapeHtml(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return '';
+    }
+  });
+}
+
+function encodePathSegment(value) {
+  if (typeof value !== 'string') return '';
+  try {
+    return encodeURIComponent(value);
+  } catch {
+    return '';
+  }
+}
+
 function moneyUsd(cents) {
   return `$${((cents || 0) / 100).toFixed(2)}`;
 }
@@ -29,19 +52,25 @@ function eventDate(ts) {
 
 function buildEmail({ reg, event, siteOrigin }) {
   const slug = event.slug || reg.eventId;
+  const eventUrl = `${siteOrigin}/events/${encodePathSegment(slug)}`;
+  const eventTitleHtml = escapeHtml(event.title);
+  const firstNameHtml = escapeHtml(reg.runner?.firstName);
+  const eventDateHtml = escapeHtml(eventDate(event.startAt));
+  const eventLocationHtml = escapeHtml(event.location);
+  const registrationIdHtml = escapeHtml(reg.id);
   const receiptLine = reg.priceTier === 'comp'
     ? '<p>Your registration is comped — thanks for supporting MPRC!</p>'
     : `<p>Amount paid: <strong>${moneyUsd(reg.amountCents)}</strong></p>`;
   const html = `
     <div style="font-family:system-ui,Arial,sans-serif;max-width:560px;margin:0 auto;color:#111">
-      <h2>You're registered for ${event.title}</h2>
-      <p>Hi ${reg.runner?.firstName || ''},</p>
-      <p>Your registration for <strong>${event.title}</strong> is confirmed.</p>
-      <p><strong>When:</strong> ${eventDate(event.startAt)}<br/>
-      <strong>Where:</strong> ${event.location || ''}</p>
+      <h2>You're registered for ${eventTitleHtml}</h2>
+      <p>Hi ${firstNameHtml},</p>
+      <p>Your registration for <strong>${eventTitleHtml}</strong> is confirmed.</p>
+      <p><strong>When:</strong> ${eventDateHtml}<br/>
+      <strong>Where:</strong> ${eventLocationHtml}</p>
       ${receiptLine}
-      <p>Registration ID: <code>${reg.id || ''}</code></p>
-      <p><a href="${siteOrigin}/events/${slug}">Event page</a></p>
+      <p>Registration ID: <code>${registrationIdHtml}</code></p>
+      <p><a href="${escapeHtml(eventUrl)}">Event page</a></p>
       <hr/>
       <p style="color:#666;font-size:12px">Mid-Peninsula Running Club · runmprc.com</p>
     </div>
@@ -52,7 +81,7 @@ function buildEmail({ reg, event, siteOrigin }) {
     `Where: ${event.location || ''}`,
     reg.priceTier === 'comp' ? 'Your registration is comped.' : `Amount paid: ${moneyUsd(reg.amountCents)}`,
     `Registration ID: ${reg.id || ''}`,
-    `${siteOrigin}/events/${slug}`,
+    eventUrl,
   ].join('\n\n');
   return { html, text };
 }

--- a/functions/serverConfigEntryPoints.test.js
+++ b/functions/serverConfigEntryPoints.test.js
@@ -69,25 +69,31 @@ function setValidTestConfig() {
   ].join('_');
 }
 
-function qualifyingUpdateChange() {
+function confirmationRegistration(overrides = {}) {
+  const { runner = {}, ...registration } = overrides;
+  return {
+    status: 'paid',
+    ...registration,
+    runner: {
+      email: 'runner@example.test',
+      ...runner,
+    },
+  };
+}
+
+function qualifyingUpdateChange(overrides = {}) {
   return {
     before: { data: () => ({ status: 'pending' }) },
     after: {
-      data: () => ({
-        status: 'paid',
-        runner: { email: 'runner@example.test' },
-      }),
+      data: () => confirmationRegistration(overrides),
       ref: { update: mockMarkerUpdate },
     },
   };
 }
 
-function qualifyingCreateSnapshot() {
+function qualifyingCreateSnapshot(overrides = {}) {
   return {
-    data: () => ({
-      status: 'paid',
-      runner: { email: 'runner@example.test' },
-    }),
+    data: () => confirmationRegistration(overrides),
     ref: { update: mockMarkerUpdate },
   };
 }
@@ -212,6 +218,9 @@ describe('server configuration entry-point guards', () => {
     expect(mockMailAdd).toHaveBeenCalledWith(expect.objectContaining({
       to: 'runner@example.test',
       message: expect.objectContaining({
+        html: expect.stringContaining(
+          'href="https://runmprc.test/events/synthetic-race"',
+        ),
         text: expect.stringContaining(
           'https://runmprc.test/events/synthetic-race',
         ),
@@ -219,6 +228,115 @@ describe('server configuration entry-point guards', () => {
     }));
     expect(mockMarkerUpdate).toHaveBeenCalledTimes(1);
     expect(mockStripeConstructor).not.toHaveBeenCalled();
+  });
+
+  describe('MAIL-001A1 hostile confirmation HTML', () => {
+    const hostileTitle = 'Race </h2><a href="https://attacker.example.test/title">title-canary</a> & "quoted"';
+    const hostileFirstName = 'Runner <img src=x onerror="runner-canary"> & \'quoted\'';
+    const hostileLocation = 'Park <svg onload="location-canary"> & \'quoted\'';
+    const hostileRegistrationId = 'reg/"><img src=x onerror="id-canary">';
+    const hostileSlug = 'race/../?next="><a href="https://attacker.example.test/slug">&part=1';
+
+    test.each([
+      ['update', 'sendConfirmationEmail', qualifyingUpdateChange],
+      ['create', 'sendConfirmationEmailOnCreate', qualifyingCreateSnapshot],
+    ])('escapes record-derived HTML on the %s trigger', async (
+      _name,
+      exportName,
+      inputFactory,
+    ) => {
+      mockEventGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'hostile-event',
+        data: () => ({
+          location: hostileLocation,
+          slug: hostileSlug,
+          title: hostileTitle,
+        }),
+      });
+      const emailFunctions = require('./sendConfirmationEmail');
+
+      await emailFunctions[exportName](
+        inputFactory({
+          runner: {
+            firstName: hostileFirstName,
+          },
+        }),
+        {
+          params: {
+            eventId: 'hostile-event',
+            regId: hostileRegistrationId,
+          },
+        },
+      );
+
+      expect(mockMailAdd).toHaveBeenCalledTimes(1);
+      const queuedMail = mockMailAdd.mock.calls[0][0];
+      const { html, subject, text } = queuedMail.message;
+      const encodedSlug = encodeURIComponent(hostileSlug);
+
+      expect(html).toContain(
+        'Runner &lt;img src=x onerror=&quot;runner-canary&quot;&gt; &amp; &#39;quoted&#39;',
+      );
+      expect(html).toContain(
+        'Race &lt;/h2&gt;&lt;a href=&quot;https://attacker.example.test/title&quot;&gt;title-canary&lt;/a&gt; &amp; &quot;quoted&quot;',
+      );
+      expect(html).toContain(
+        'Park &lt;svg onload=&quot;location-canary&quot;&gt; &amp; &#39;quoted&#39;',
+      );
+      expect(html).toContain(
+        'reg/&quot;&gt;&lt;img src=x onerror=&quot;id-canary&quot;&gt;',
+      );
+      expect(html).toContain(
+        `href="https://runmprc.test/events/${encodedSlug}"`,
+      );
+      expect(html).not.toMatch(/<(?:img|svg)\b/i);
+      expect(html).not.toContain('<a href="https://attacker.example.test/');
+      expect(html.match(/<a href=/g)).toHaveLength(1);
+
+      expect(subject).toBe(`Registration confirmed — ${hostileTitle}`);
+      expect(text).toContain(hostileTitle);
+      expect(text).toContain(hostileLocation);
+      expect(text).toContain(`https://runmprc.test/events/${encodedSlug}`);
+      expect(queuedMail.to).toBe('runner@example.test');
+      expect(mockMailAdd.mock.invocationCallOrder[0])
+        .toBeLessThan(mockMarkerUpdate.mock.invocationCallOrder[0]);
+      expect(mockMarkerUpdate).toHaveBeenCalledTimes(1);
+      expect(mockStripeConstructor).not.toHaveBeenCalled();
+    });
+
+    test('uses a fixed safe link when a stored slug cannot be URI encoded', async () => {
+      const malformedSlug = 'synthetic-unpaired-surrogate-\ud800';
+      mockEventGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'malformed-slug-event',
+        data: () => ({
+          location: 'Synthetic Park',
+          slug: malformedSlug,
+          title: 'Synthetic Race',
+        }),
+      });
+      const { sendConfirmationEmailOnCreate } = require('./sendConfirmationEmail');
+
+      await sendConfirmationEmailOnCreate(
+        qualifyingCreateSnapshot({ runner: { firstName: 'Synthetic Runner' } }),
+        {
+          params: {
+            eventId: 'malformed-slug-event',
+            regId: 'malformed-slug-registration',
+          },
+        },
+      );
+
+      const queuedMail = mockMailAdd.mock.calls[0][0];
+      expect(queuedMail.message.html).toContain(
+        '<a href="https://runmprc.test/events/">Event page</a>',
+      );
+      expect(queuedMail.message.text).toContain('https://runmprc.test/events/');
+      expect(queuedMail.message.html).not.toContain(malformedSlug);
+      expect(queuedMail.message.text).not.toContain(malformedSlug);
+      expect(mockMarkerUpdate).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('cached Stripe client never bypasses a later configuration failure', () => {


### PR DESCRIPTION
## Outcome

Registration confirmation mail now treats every stored record value as text before placing it in HTML. The event link uses one encoded path segment and an escaped quoted attribute, with a fixed safe fallback when stored Unicode cannot be encoded.

Closes #525.

## Exact scope

- `functions/sendConfirmationEmail.js`: two dependency-free encoding helpers and the `buildEmail` HTML/event-link hunk only.
- `functions/serverConfigEntryPoints.test.js`: named hostile-HTML tests for both confirmation triggers plus minimal existing-harness support.

Trigger admission, recipient, subject/plain-text semantics, outbox document shape, write order, and marker behavior are preserved. Idempotency, delivery-state truth, templates, sender/DNS, provider configuration, schema, deployment, and live mail remain outside this child.

## Evidence

- Trustworthy RED on released base: 3/3 hostile-input cases failed before the runtime edit.
- Focused hostile-input tests: 3/3 passed.
- Complete entry-point test file: 10/10 passed.
- Full Functions suite: 6,439 passed; 64 intentional skips.
- Functions lint passed.
- Frontend suite: 859/859 passed.
- Repository safety: 80/80 passed.
- SPA safety: 11/11 passed.
- Frontend lint baseline: 114 files / 113 reviewed legacy errors / 6 reviewed legacy warnings.
- Diagnostic frontend build and diff check passed.
- Three independent read-only reviews returned GO.
- Exact head: `41a5eeaa31758fb4400e11a4de79fe277e926108`.
- Exact two-file binary diff SHA-256: `5b853a939e86e5cdcfd02e663cefdaf6d60b43d69205f0f022a2d472c3fcce3c`.

## Officer handoff

Officer impact: None. No officer action, interface, permission, data flow, or procedure changed.

Officer documentation: None — this is a source-only output-encoding containment, and the existing MAIL/RISK planning remains conservatively accurate.

Deployment evidence: No website publication, Firebase deploy, mail extension/SMTP/provider action, production-data access, migration, or live email test occurred. Green checks prove source behavior only.