### PR TITLE
PAY-003A3: reject contradictory refund and dispute realms

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -709,7 +709,7 @@ Text alternative: a valid unpaid failure or expiry still cancels a pending order
 
 At minimum verify:
 
-- Outer Event and embedded Checkout Session `livemode` are booleans and both match the expected deployment mode.
+- The outer Event `livemode` matches the expected deployment mode. For Checkout Events, the embedded Checkout Session `livemode` is a primitive boolean equal to both the outer Event and the expected mode. For `charge.refunded`, apply the same rule to the embedded [Charge](https://docs.stripe.com/api/charges/object?api-version=2024-06-20). For `charge.dispute.created`, `charge.dispute.updated`, and `charge.dispute.closed`, apply it to the embedded [Dispute](https://docs.stripe.com/api/disputes/object).
 - Checkout Session lifecycle `status` matches the Event: `complete` for completion and delayed-payment outcomes; `expired` for expiration.
 - Session `mode` and object type.
 - Metadata schema and local record reference.
@@ -721,6 +721,10 @@ At minimum verify:
 - PaymentIntent is not already attached to another local business record.
 
 PAY-003A2 [#520](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/520) applies the first two checks before target resolution in the legacy webhook source. Missing, malformed, or contradictory Session evidence receives a fixed processed-review ledger result without a business-record query or change and without a provider binding. Record source changed, tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, a payment performed, production data changed, and live behavior verified as separate states. The repository diff and synthetic tests do not by themselves prove any merged, published, deployed, provider, payment, production-data, or live state. This child does not select a Stripe API version or configure a provider endpoint.
+
+PAY-003A3 [#526](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/526) extends only the pre-target realm check to the embedded Charge for `charge.refunded` and the embedded Dispute for the three supported dispute Events. An opposite boolean, missing field, `null`, string, or number receives the fixed `charge_livemode_mismatch` or `dispute_livemode_mismatch` processed-review outcome. The outer Event/configuration mismatch keeps first precedence. Admission failure leaves the business record byte-for-byte unchanged, records null target fields, creates no Charge, PaymentIntent, or Dispute binding, and deduplicates an exact replay. A compatible claimed Event with no target remains retryable. This does not narrow refund or dispute lifecycle states, infer realm from an ID, select an API version, or reprocess historical Events.
+
+PAY-003A3 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, payment/refund/dispute performed, production data changed, and live behavior verified. A repository diff and synthetic tests prove only their named source and test states. They do not prove a merge, website publication, Firebase deployment, provider configuration, payment/refund/dispute, production-data change, or live behavior.
 
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
@@ -900,6 +904,7 @@ Every commerce release must cover:
 - Duplicate and out-of-order webhook events.
 - Invalid signature and wrong webhook secret.
 - Wrong outer or embedded livemode, Event/Session lifecycle mismatch, amount, currency, metadata, Session, or PaymentIntent.
+- Embedded-realm admission matrix: opposite boolean, missing, `null`, string, and number for the refund Charge and each supported dispute Event; assert a target-null ledger, unchanged registration/order, no provider binding, deterministic replay, outer-mismatch precedence, missing-target retry behavior, and the existing valid refund/dispute paths.
 - `completed` with unpaid/processing status.
 - Async payment success and failure.
 - Session expiry and local cancellation with Stripe expiry.

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -70,28 +70,38 @@ function validateExpectedLivemode(event, expected) {
   return { ok: true, expected };
 }
 
+function validateEmbeddedLivemode(event, expected, reason) {
+  const object = event.data?.object;
+  if (typeof object?.livemode !== 'boolean'
+    || object.livemode !== event.livemode
+    || object.livemode !== expected) {
+    return { ok: false, expected, reason };
+  }
+  return { ok: true, expected };
+}
+
 function validateEventAdmission(event, expectedLivemode) {
   const modeValidation = validateExpectedLivemode(event, expectedLivemode);
-  if (!modeValidation.ok || !CHECKOUT_EVENT_TYPES.has(event.type)) {
-    return modeValidation;
-  }
+  if (!modeValidation.ok) return modeValidation;
 
-  const session = event.data?.object;
-  if (typeof session?.livemode !== 'boolean'
-    || session.livemode !== event.livemode
-    || session.livemode !== expectedLivemode) {
-    return {
-      ok: false,
-      expected: expectedLivemode,
-      reason: 'checkout_session_livemode_mismatch',
-    };
-  }
-  if (session.status !== CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE.get(event.type)) {
-    return {
-      ok: false,
-      expected: expectedLivemode,
-      reason: 'checkout_session_status_mismatch',
-    };
+  if (CHECKOUT_EVENT_TYPES.has(event.type)) {
+    const sessionRealm = validateEmbeddedLivemode(
+      event,
+      expectedLivemode,
+      'checkout_session_livemode_mismatch',
+    );
+    if (!sessionRealm.ok) return sessionRealm;
+    if (event.data?.object?.status !== CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE.get(event.type)) {
+      return {
+        ok: false,
+        expected: expectedLivemode,
+        reason: 'checkout_session_status_mismatch',
+      };
+    }
+  } else if (event.type === 'charge.refunded') {
+    return validateEmbeddedLivemode(event, expectedLivemode, 'charge_livemode_mismatch');
+  } else if (DISPUTE_EVENT_TYPES.has(event.type)) {
+    return validateEmbeddedLivemode(event, expectedLivemode, 'dispute_livemode_mismatch');
   }
   return modeValidation;
 }

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -199,9 +199,42 @@ const CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE = Object.freeze({
   'checkout.session.async_payment_failed': 'complete',
   'checkout.session.expired': 'expired',
 });
+const PROVIDER_OBJECT_REALM_EVENT_TYPES = new Set([
+  'charge.refunded',
+  'charge.dispute.created',
+  'charge.dispute.updated',
+  'charge.dispute.closed',
+]);
+const INVALID_EMBEDDED_LIVEMODE_CASES = [
+  ['opposite boolean', 'value', true],
+  ['missing', 'delete', undefined],
+  ['null', 'value', null],
+  ['string', 'value', 'false'],
+  ['number', 'value', 0],
+];
+const DISPUTE_REALM_CASES = [
+  ['created', 'charge.dispute.created', 'needs_response'],
+  ['updated', 'charge.dispute.updated', 'under_review'],
+  ['closed', 'charge.dispute.closed', 'won'],
+].flatMap(([lifecycle, type, status]) => (
+  INVALID_EMBEDDED_LIVEMODE_CASES.map(([evidence, mutation, value]) => [
+    lifecycle,
+    evidence,
+    type,
+    status,
+    mutation,
+    value,
+  ])
+));
 
 function stripeEvent(id, type, object) {
   const checkoutStatus = CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE[type];
+  let providerObject = object;
+  if (checkoutStatus) {
+    providerObject = { livemode: false, status: checkoutStatus, ...object };
+  } else if (PROVIDER_OBJECT_REALM_EVENT_TYPES.has(type)) {
+    providerObject = { livemode: false, ...object };
+  }
   return {
     id,
     object: 'event',
@@ -212,9 +245,7 @@ function stripeEvent(id, type, object) {
     request: null,
     type,
     data: {
-      object: checkoutStatus
-        ? { livemode: false, status: checkoutStatus, ...object }
-        : object,
+      object: providerObject,
     },
   };
 }
@@ -274,6 +305,35 @@ function orderSession(overrides = {}) {
         country: 'US',
       },
     },
+    ...overrides,
+  };
+}
+
+function orderRefundCharge(overrides = {}) {
+  return {
+    id: 'ch_order_realm',
+    object: 'charge',
+    payment_intent: 'pi_order_1',
+    amount: 2000,
+    amount_refunded: 500,
+    currency: 'usd',
+    metadata: { type: 'merch', orderId: 'order-1' },
+    refunds: { data: [{ id: 're_order_realm' }] },
+    ...overrides,
+  };
+}
+
+function orderDispute(overrides = {}) {
+  return {
+    id: 'dp_order_realm',
+    object: 'dispute',
+    charge: 'ch_order_1',
+    payment_intent: 'pi_order_1',
+    amount: 2000,
+    currency: 'usd',
+    reason: 'fraudulent',
+    status: 'needs_response',
+    metadata: { type: 'merch', orderId: 'order-1' },
     ...overrides,
   };
 }
@@ -341,6 +401,26 @@ function storedCopy(path) {
   return JSON.parse(JSON.stringify(admin.__get(path)));
 }
 
+function providerBindingPaths(event) {
+  const object = event.data.object;
+  const descriptors = [];
+  if (CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE[event.type]) {
+    descriptors.push(['checkout_session', object.id]);
+    descriptors.push(['payment_intent', object.payment_intent]);
+    descriptors.push(['payment_link', object.payment_link]);
+  } else if (event.type === 'charge.refunded') {
+    descriptors.push(['charge', object.id]);
+    descriptors.push(['payment_intent', object.payment_intent]);
+  } else if (event.type.startsWith('charge.dispute.')) {
+    descriptors.push(['dispute', object.id]);
+    descriptors.push(['charge', object.charge]);
+    descriptors.push(['payment_intent', object.payment_intent]);
+  }
+  return descriptors
+    .filter(([, id]) => typeof id === 'string' && id.length > 0)
+    .map(([type, id]) => `stripeObjectBindings/${type}:${id}`);
+}
+
 function expectCompatibilityQuarantine({ response, event, businessPath, before, reason }) {
   expect(response.status).not.toHaveBeenCalled();
   expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
@@ -358,12 +438,9 @@ function expectCompatibilityQuarantine({ response, event, businessPath, before, 
     targetPath: null,
     targetSource: null,
   });
-  expect(admin.__get(
-    `stripeObjectBindings/checkout_session:${event.data.object.id}`,
-  )).toBeUndefined();
-  expect(admin.__get(
-    `stripeObjectBindings/payment_intent:${event.data.object.payment_intent}`,
-  )).toBeUndefined();
+  providerBindingPaths(event).forEach((path) => {
+    expect(admin.__get(path)).toBeUndefined();
+  });
 }
 
 describe('stripeWebhook', () => {
@@ -919,6 +996,188 @@ describe('stripeWebhook', () => {
       received: true,
       duplicate: true,
       outcome: 'needs_review:checkout_session_status_mismatch',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+  });
+
+  test.each(INVALID_EMBEDDED_LIVEMODE_CASES)(
+    'quarantines a refund Charge with %s embedded livemode evidence',
+    async (label, mutation, value) => {
+      seedOrder({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: 'pi_order_1',
+        stripeAmountTotalCents: 2000,
+      });
+      const businessPath = 'orders/order-1';
+      const before = storedCopy(businessPath);
+      const slug = label.replace(/[^a-z]+/g, '_');
+      const event = stripeEvent(
+        `evt_charge_livemode_${slug}`,
+        'charge.refunded',
+        orderRefundCharge({ id: `ch_charge_livemode_${slug}` }),
+      );
+      if (mutation === 'delete') delete event.data.object.livemode;
+      else event.data.object.livemode = value;
+
+      const response = await deliver(event);
+
+      expectCompatibilityQuarantine({
+        response,
+        event,
+        businessPath,
+        before,
+        reason: 'charge_livemode_mismatch',
+      });
+    },
+  );
+
+  test.each(DISPUTE_REALM_CASES)(
+    'quarantines a %s Dispute with %s embedded livemode evidence',
+    async (lifecycle, evidence, type, status, mutation, value) => {
+      seedOrder({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: 'pi_order_1',
+        stripeChargeId: 'ch_order_1',
+        stripeAmountTotalCents: 2000,
+      });
+      const businessPath = 'orders/order-1';
+      const before = storedCopy(businessPath);
+      const slug = evidence.replace(/[^a-z]+/g, '_');
+      const event = stripeEvent(
+        `evt_dispute_${lifecycle}_livemode_${slug}`,
+        type,
+        orderDispute({ id: `dp_${lifecycle}_livemode_${slug}`, status }),
+      );
+      if (mutation === 'delete') delete event.data.object.livemode;
+      else event.data.object.livemode = value;
+
+      const response = await deliver(event);
+
+      expectCompatibilityQuarantine({
+        response,
+        event,
+        businessPath,
+        before,
+        reason: 'dispute_livemode_mismatch',
+      });
+    },
+  );
+
+  test('quarantines an incompatible claimed Dispute before resolving its missing target', async () => {
+    const event = stripeEvent(
+      'evt_dispute_missing_target',
+      'charge.dispute.created',
+      orderDispute({
+        id: 'dp_incompatible_missing_target',
+        charge: 'ch_incompatible_missing_target',
+        payment_intent: 'pi_incompatible_missing_target',
+        metadata: { type: 'merch', orderId: 'order-missing' },
+        livemode: true,
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:dispute_livemode_mismatch',
+      requiresReview: true,
+    }));
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      status: 'processed',
+      outcome: 'needs_review:dispute_livemode_mismatch',
+      requiresReview: true,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    });
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
+    });
+  });
+
+  test.each([
+    [
+      'Charge',
+      'charge.refunded',
+      orderRefundCharge({ livemode: null }),
+    ],
+    [
+      'Dispute',
+      'charge.dispute.updated',
+      orderDispute({ status: 'under_review', livemode: null }),
+    ],
+  ])('keeps the configured Event livemode mismatch ahead of embedded %s contradictions', async (
+    label,
+    type,
+    object,
+  ) => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_order_1',
+      stripeChargeId: 'ch_order_1',
+      stripeAmountTotalCents: 2000,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(`evt_outer_precedence_${label.toLowerCase()}`, type, object);
+    event.livemode = true;
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({
+      response,
+      event,
+      businessPath,
+      before,
+      reason: 'livemode_mismatch',
+    });
+  });
+
+  test('deduplicates an incompatible refund Charge without target or binding mutation', async () => {
+    seedRegistration({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_reg_1',
+      stripeAmountTotalCents: 5000,
+    });
+    const businessPath = 'events/race-1/registrations/reg-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_refund_charge_realm_replay',
+      'charge.refunded',
+      {
+        id: 'ch_registration_replay',
+        object: 'charge',
+        payment_intent: 'pi_reg_1',
+        amount: 5000,
+        amount_refunded: 500,
+        currency: 'usd',
+        metadata: { eventId: 'race-1', registrationId: 'reg-1' },
+        refunds: { data: [{ id: 're_registration_replay' }] },
+        livemode: true,
+      },
+    );
+
+    const firstResponse = await deliver(event);
+    const replayResponse = await deliver(event);
+
+    expectCompatibilityQuarantine({
+      response: firstResponse,
+      event,
+      businessPath,
+      before,
+      reason: 'charge_livemode_mismatch',
+    });
+    expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'needs_review:charge_livemode_mismatch',
     }));
     expect(admin.__get(businessPath)).toEqual(before);
   });


### PR DESCRIPTION
## Outcome

Signed refund and dispute Events can no longer change a registration/order or create provider-object bindings when the embedded Charge or Dispute contradicts the verified test/live realm.

Closes #526.

Officer impact: None now. Live checkout remains unavailable. This source-only guard changes no officer task or public workflow.

Officer documentation: None — no officer procedure, page, navigation, permission, account, data-handling step, deployment path, or topology changed. Existing officer guides already mark Stripe checkout, Firebase release, provider configuration, payment handling, and live behavior unavailable.

Deployment evidence: Source and synthetic demo/test evidence only. No website publication, `runmprc.com` verification, Firebase deployment, Stripe/provider configuration, payment/refund/dispute operation, production-data access or change, or live-behavior verification occurred or is claimed.

## Change

- Keep the outer Event/configuration `livemode_mismatch` check first.
- Before target resolution, require a primitive embedded Charge realm for `charge.refunded` or Dispute realm for `charge.dispute.created|updated|closed`, equal to both the outer Event and configured realm.
- Quarantine contradictions with fixed `charge_livemode_mismatch` or `dispute_livemode_mismatch` outcomes in a processed, target-null Event ledger row.
- Default signed Charge/Dispute fixtures to explicit test realm and cover opposite boolean, missing, `null`, string, and numeric evidence across all four Event types.
- Preserve compatible missing-target retries, valid refund/dispute transitions, replay dedupe, Checkout admission, money/currency checks, terminal protection, and binding-conflict behavior.

No refund/dispute lifecycle state, API version, provider setting, schema, migration, frontend, Rule, workflow, package, lockfile, or officer guide changed.

## Verification

Exact reviewed head: `aef1fae98f97a07f1112cd5fa773b2ae58346635`

Exact base/current main: `9e61a023301d10c0580253738e67cbc7867ea38b`

Exact binary patch SHA-256: `c1ca4ef8aa33995470b9d5a44082cc2a06d198333039fd03b86907671c429b37`

RED on the base admitted all 20 contradictory Charge/Dispute cases: refunds returned `partially_refunded`; disputes returned `dispute_needs_response`, `dispute_under_review`, or `dispute_won`.

Explicit Node `20.20.2` and Java `21.0.12` gates after clean lockfile installs:

- Focused webhook: 185/185 passed.
- Functions lint and full unit suite: 6,565 passed; 64 intentional skips.
- Frontend lint and Jest: 928/928 passed.
- Firestore Rules emulator: 418/418 passed.
- Commerce command-journal emulator: 63/63 passed.
- Repository workflow/release/artifact/dependency safety: 80/80 passed.
- SPA navigation: 11/11 passed.
- TypeScript and diagnostic production build passed.
- `git diff --check` passed; worktree clean.
- Independent payment/security, lifecycle/test, and backup-officer/scope reviews returned GO on the exact rebased head.

Read-only audits retain existing unrelated findings: root has 4 findings (1 high), and Functions has 11 findings (1 high). This PR changes no dependency or lockfile and does not apply forced or unrelated upgrades.

## Evidence boundaries and residual risk

- Source changed: yes, at the exact head above.
- Synthetic tests passed: yes, with the exact counts above.
- Code merged: no, pending this PR.
- Website published: no.
- `runmprc.com` verified: no.
- Firebase deployed: no.
- Stripe/provider configured: no.
- Payment/refund/dispute performed: no.
- Production data changed: no.
- Live behavior verified: no.

PAY-003B/C, endpoint API-version/provider inventory, durable operations, deployment, and live proof remain open under #106. Historical processed Events are not re-reduced; no migration is required.
