### PR TITLE
OAUTH-001B6: use supported Strava revoke endpoint

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -2,12 +2,12 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const { Timestamp } = require('firebase-admin/firestore');
 const { createHash, randomBytes, timingSafeEqual } = require('node:crypto');
-const { URL: NodeURL } = require('node:url');
+const { URL: NodeURL, URLSearchParams: NodeURLSearchParams } = require('node:url');
 const { types: { isProxy } } = require('node:util');
 const { requireAppCheck } = require('./stripeHelpers');
 
 const STRAVA_TOKEN_URL = 'https://www.strava.com/api/v3/oauth/token';
-const STRAVA_DEAUTH_URL = 'https://www.strava.com/oauth/deauthorize';
+const STRAVA_REVOKE_URL = 'https://www.strava.com/oauth/revoke';
 const STRAVA_ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities';
 const STRAVA_STATS_URL = (id) => `https://www.strava.com/api/v3/athletes/${id}/stats`;
 const STRAVA_AUTHORIZATION_ERROR_MESSAGE = 'Strava authorization could not be completed.';
@@ -1083,9 +1083,21 @@ exports.stravaDisconnect = functions
       if (accessToken) {
         let revokeResponse;
         try {
-          revokeResponse = await fetch(STRAVA_DEAUTH_URL, {
+          const { clientId, clientSecret } = getStravaCreds();
+          const basicCredentials = Buffer
+            .from(`${clientId}:${clientSecret}`, 'utf8')
+            .toString('base64');
+          const body = new NodeURLSearchParams([
+            ['token', accessToken],
+            ['token_type_hint', 'access_token'],
+          ]).toString();
+          revokeResponse = await fetch(STRAVA_REVOKE_URL, {
             method: 'POST',
-            headers: { Authorization: `Bearer ${accessToken}` },
+            headers: {
+              Authorization: `Basic ${basicCredentials}`,
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body,
           });
         } catch (_error) {
           console.warn('strava_disconnect_revoke_failed');

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -4877,7 +4877,15 @@ describe('Strava disconnect failure log boundary', () => {
   let consoleSpies;
   let dateNowSpy;
 
+  const STRAVA_REVOKE_URL = 'https://www.strava.com/oauth/revoke';
+  const SYNTHETIC_CLIENT_ID = '12345';
+  const SYNTHETIC_CLIENT_SECRET = 'abc123';
+  const SYNTHETIC_BASIC_AUTHORIZATION = 'Basic MTIzNDU6YWJjMTIz';
+  const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
   beforeEach(() => {
+    process.env.STRAVA_CLIENT_ID = SYNTHETIC_CLIENT_ID;
+    process.env.STRAVA_CLIENT_SECRET = SYNTHETIC_CLIENT_SECRET;
     admin.__clearDeletes();
     admin.__clearDocuments();
     admin.__clearReads();
@@ -4900,6 +4908,8 @@ describe('Strava disconnect failure log boundary', () => {
     global.fetch = GUARDED_FETCH;
     dateNowSpy.mockRestore();
     Object.values(consoleSpies).forEach((spy) => spy.mockRestore());
+    delete process.env.STRAVA_CLIENT_ID;
+    delete process.env.STRAVA_CLIENT_SECRET;
   });
 
   function seedStoredSecret(secret) {
@@ -4951,6 +4961,32 @@ describe('Strava disconnect failure log boundary', () => {
     expect(dateNowSpy).not.toHaveBeenCalled();
     expect(Timestamp.now).not.toHaveBeenCalled();
     expectNoLogs();
+  }
+
+  function expectSupportedRevokeRequest(accessToken, expectedBody) {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+
+    expect(url).toBe(STRAVA_REVOKE_URL);
+    expect(init).toEqual({
+      method: 'POST',
+      headers: {
+        Authorization: SYNTHETIC_BASIC_AUTHORIZATION,
+        'Content-Type': FORM_CONTENT_TYPE,
+      },
+      body: expect.any(String),
+    });
+    expect(init.body).not.toContain(SYNTHETIC_CLIENT_ID);
+    expect(init.body).not.toContain(SYNTHETIC_CLIENT_SECRET);
+    if (expectedBody !== undefined) expect(init.body).toBe(expectedBody);
+
+    const params = new URLSearchParams(init.body);
+    expect([...params.keys()]).toEqual(['token', 'token_type_hint']);
+    expect(params.getAll('token')).toEqual([accessToken]);
+    expect(params.getAll('token_type_hint')).toEqual(['access_token']);
+    expect(params.has('access_token')).toBe(false);
+    expect(params.has('client_id')).toBe(false);
+    expect(params.has('client_secret')).toBe(false);
   }
 
   async function expectRejectedDisconnectRequest(data) {
@@ -5156,6 +5192,124 @@ describe('Strava disconnect failure log boundary', () => {
     expectNoLogs();
   });
 
+  describe('OAUTH-001B6 supported revoke request contract', () => {
+    test('uses Basic credentials and an exact encoded token form without URL or field injection', async () => {
+      const accessToken = 'synthetic+disconnect&token=%=:?/';
+      seedConnectedAccount(accessToken);
+      fetchMock.mockResolvedValue({ ok: true });
+
+      const result = await stravaDisconnect({}, CONTEXT);
+
+      expect(result).toEqual({ ok: true });
+      expectSupportedRevokeRequest(
+        accessToken,
+        'token=synthetic%2Bdisconnect%26token%3D%25%3D%3A%3F%2F'
+          + '&token_type_hint=access_token',
+      );
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).not.toContain(accessToken);
+      expectLocalDeletes();
+      expectNoLogs();
+    });
+
+    test.each([
+      ['client ID', 'STRAVA_CLIENT_ID'],
+      ['client secret', 'STRAVA_CLIENT_SECRET'],
+    ])('fails closed when the synthetic %s is missing', async (_case, variable) => {
+      delete process.env[variable];
+      seedConnectedAccount();
+      fetchMock.mockResolvedValue({ ok: true });
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedDisconnectError(rejection);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectLocalRecordsPreserved();
+      expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpies.warn).toHaveBeenCalledWith(FIXED_DISCONNECT_WARNING);
+      expect(JSON.stringify({
+        public: publicError(rejection),
+        logs: consoleSpies.warn.mock.calls,
+      })).not.toMatch(/12345|abc123|credentials not configured/i);
+      ['debug', 'error', 'info', 'log']
+        .forEach((method) => expect(consoleSpies[method]).not.toHaveBeenCalled());
+    });
+
+    test.each([
+      ['no secret document', null],
+      ['a rejected stored token', { access_token: 'token with space' }],
+    ])('does not require provider credentials for %s cleanup', async (_case, secret) => {
+      delete process.env.STRAVA_CLIENT_ID;
+      delete process.env.STRAVA_CLIENT_SECRET;
+      if (secret !== null) seedStoredSecret(secret);
+
+      const result = await stravaDisconnect({}, CONTEXT);
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectLocalDeletes();
+      expectNoLogs();
+    });
+
+    test('keeps both local records until provider success is admitted', async () => {
+      let signalFetchCalled;
+      let resolveResponse;
+      const fetchCalled = new Promise((resolve) => {
+        signalFetchCalled = resolve;
+      });
+      const providerResponse = new Promise((resolve) => {
+        resolveResponse = resolve;
+      });
+      seedConnectedAccount();
+      fetchMock.mockImplementation(() => {
+        signalFetchCalled();
+        return providerResponse;
+      });
+
+      const pendingDisconnect = stravaDisconnect({}, CONTEXT);
+      await fetchCalled;
+
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
+      expectLocalRecordsPreserved();
+      expectNoLogs();
+
+      resolveResponse({ ok: true });
+      await expect(pendingDisconnect).resolves.toEqual({ ok: true });
+      expectLocalDeletes();
+      expectNoLogs();
+    });
+
+    test('preserves records after a lost acknowledgement and permits a later HTTP 200 retry', async () => {
+      seedConnectedAccount();
+      fetchMock.mockRejectedValue(
+        new Error('first-attempt-lost-acknowledgement canary'),
+      );
+
+      const firstFailure = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedDisconnectError(firstFailure);
+      expectLocalRecordsPreserved();
+      expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpies.warn).toHaveBeenCalledWith(FIXED_DISCONNECT_WARNING);
+      expect(JSON.stringify(consoleSpies.warn.mock.calls))
+        .not.toMatch(/lost-acknowledgement|canary/i);
+
+      fetchMock.mockReset();
+      consoleSpies.warn.mockClear();
+      const response = new Response('synthetic-provider-response-body-canary', {
+        status: 200,
+      });
+      fetchMock.mockResolvedValue(response);
+
+      const result = await stravaDisconnect({}, CONTEXT);
+
+      expect(result).toEqual({ ok: true });
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
+      expect(response.bodyUsed).toBe(false);
+      expectLocalDeletes();
+      expectNoLogs();
+    });
+  });
+
   describe('stored disconnect token validation before provider use', () => {
     class DisconnectSecret {
       constructor() {
@@ -5325,13 +5479,7 @@ describe('Strava disconnect failure log boundary', () => {
       expect(result).toEqual({ ok: true });
       unknownGetters.forEach(({ getter }) => expect(getter).not.toHaveBeenCalled());
       expect(symbolGetter).not.toHaveBeenCalled();
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://www.strava.com/oauth/deauthorize',
-        {
-          method: 'POST',
-          headers: { Authorization: 'Bearer synthetic_disconnect_access_token_test' },
-        },
-      );
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
       expectLocalDeletes();
       expectNoLogs();
     });
@@ -5347,13 +5495,7 @@ describe('Strava disconnect failure log boundary', () => {
       const result = await stravaDisconnect({}, CONTEXT);
 
       expect(result).toEqual({ ok: true });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://www.strava.com/oauth/deauthorize',
-        {
-          method: 'POST',
-          headers: { Authorization: 'Bearer synthetic_disconnect_access_token_test' },
-        },
-      );
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
       expect(secret.access_token).toBe('mutated_disconnect_access_token_test');
       expectLocalDeletes();
       expectNoLogs();
@@ -5369,13 +5511,7 @@ describe('Strava disconnect failure log boundary', () => {
       const result = await stravaDisconnect({}, CONTEXT);
 
       expect(result).toEqual({ ok: true });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://www.strava.com/oauth/deauthorize',
-        {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${accessToken}` },
-        },
-      );
+      expectSupportedRevokeRequest(accessToken);
       expectLocalDeletes();
       expectNoLogs();
     });
@@ -5395,19 +5531,13 @@ describe('Strava disconnect failure log boundary', () => {
       const result = await stravaDisconnect({}, CONTEXT);
 
       expect(result).toEqual({ ok: true });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://www.strava.com/oauth/deauthorize',
-        {
-          method: 'POST',
-          headers: { Authorization: 'Bearer synthetic_disconnect_access_token_test' },
-        },
-      );
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
       expectLocalDeletes();
       expectNoLogs();
     });
   });
 
-  test('preserves the successful best-effort provider POST and local deletes', async () => {
+  test('preserves the successful provider POST and local deletes', async () => {
     seedAccessToken();
     fetchMock.mockResolvedValue({ ok: true });
 
@@ -5415,26 +5545,23 @@ describe('Strava disconnect failure log boundary', () => {
 
     expect(result).toEqual({ ok: true });
     expect(admin.__getReads()).toEqual([SECRET_PATH]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://www.strava.com/oauth/deauthorize',
-      {
-        method: 'POST',
-        headers: { Authorization: 'Bearer synthetic_disconnect_access_token_test' },
-      },
-    );
+    expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
     expectLocalDeletes();
     expectNoLogs();
   });
 
   test('accepts a genuine successful Node Response before local deletes', async () => {
     seedAccessToken();
-    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    const response = new Response('synthetic-provider-response-body-canary', {
+      status: 200,
+    });
+    fetchMock.mockResolvedValue(response);
 
     const result = await stravaDisconnect({}, CONTEXT);
 
     expect(result).toEqual({ ok: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.bodyUsed).toBe(false);
     expectLocalDeletes();
     expectNoLogs();
   });


### PR DESCRIPTION
Closes #530

## Outcome

Moves Strava disconnect from the legacy bearer-token `/oauth/deauthorize` request to Strava's supported `POST /oauth/revoke` contract. The server now sends client credentials with HTTP Basic authentication and sends the admitted server-only access token as a form-encoded `token` field. The browser contract and fixed public error remain unchanged.

Official provider contract: https://developers.strava.com/docs/authentication/#deauthorization

## Safety boundary

- App Check, signed-in caller, exact-empty request, and stored-token admission still run before credentials or provider access.
- Provider credentials are read only for an admitted stored token and stay inside the existing fixed caught boundary.
- The access token is not placed in the URL or Authorization header.
- The body has exactly `token` and `token_type_hint=access_token`; there is no `access_token`, `client_id`, or `client_secret` form field.
- Provider bodies are never read or logged, including successful native `Response` objects.
- Missing credentials, request construction failure, transport failure, and unconfirmed provider results keep both local records and return the same fixed unavailable result.
- Only admitted provider success reaches the existing local cleanup and `{ok:true}` result.

## RED / GREEN evidence

Before the runtime change, the new focused contract tests had three intended failures: the old URL was used and missing client credentials did not fail closed. Two compatibility cases already passed for local cleanup when no usable stored token exists.

Final exact candidate:

- Base: `5e23f66fe6f246e0a4950dd836451dd8eb88edfb`
- Head: `3b85d9e4730eba72e3048429e0738070c788b156`
- Tree: `db1904460db16c17595a95f1c728efb414961183`
- Exact two-file binary diff SHA-256: `a28d245942235b62c8e472660ab16f709871567d5de29f037e4ac66519e3b707`
- OAUTH-001B6 focused tests: 7/7 passed
- Full Strava suite: 648/648 passed
- Full Functions suite: 6,572 passed; 64 intentional skips
- Frontend Jest: 928/928 passed
- Repository safety: 80/80 passed
- SPA navigation: 11/11 passed
- Functions lint: passed
- Frontend lint: 118 files; 113 reviewed legacy errors; 6 reviewed legacy warnings
- Diagnostic production build: passed
- `git diff --check`: passed

Local Rules and commerce-emulator suites could not start because Java is absent on this machine. The hosted Java 21 jobs are required and must pass on this exact head before merge.

Three independent security, mutation-test, and scope/compatibility reviews approved the exact corrected diff. The test review first found and then verified a fix for a bodyless-`Response` blind spot.

## Compatibility and residuals

The Firebase callable wrapper, secret binding, response admission, request/result shape, and local cleanup behavior are preserved. This does not complete #88. Durable disconnect audit/cleanup, provider configuration, deployment, and live revocation proof remain open.

Officer impact: None now. This is a server source and test correction; it changes no officer screen or task.

Officer documentation: None — no officer procedure, page structure, permission, account ownership, data workflow, deployment workflow, or verified live behavior changed.

Deployment evidence: Source changed and local tests passed. Code is not yet merged. Firebase Functions were not deployed. Strava was not called or configured. No website was published or verified. No production data was read or changed. Production behavior is not verified.
