### PR TITLE
AUTH-006F: fence My Account profile saves by current context

### DIFF
--- a/src/pages/account/Account.test.tsx
+++ b/src/pages/account/Account.test.tsx
@@ -513,6 +513,437 @@ describe('Account profile recovery', () => {
     expect(screen.queryByTestId('strava-section')).not.toBeInTheDocument();
   });
 
+  describe('AUTH-006F profile-save context isolation', () => {
+    const userB = {
+      uid: 'synthetic-user-b',
+      email: 'member-b@example.test',
+      role: 'unverified' as const,
+    };
+    const appB = { name: 'synthetic-app-b' };
+    const firestoreB = { name: 'synthetic-firestore-b' };
+    const identityServiceA = { signOut, resendVerificationEmail };
+    const identityServiceB = {
+      signOut: jest.fn(),
+      resendVerificationEmail: jest.fn(),
+    };
+    const servicesA = {
+      firebaseResources: { app, firestore },
+      identityService: identityServiceA,
+    };
+    const servicesB = {
+      firebaseResources: { app: appB, firestore: firestoreB },
+      identityService: identityServiceB,
+    };
+    const profileB = {
+      ...PROFILE,
+      uid: userB.uid,
+      email: userB.email,
+      fullName: 'Current Account B',
+    };
+    const privateRegistrations = {
+      registrations: [{
+        amountCents: 4321,
+        cancelledAt: null,
+        createdAt: null,
+        currency: 'usd',
+        eventId: 'old-account-private-event',
+        id: 'old-account-private-registration',
+        paidAt: null,
+        priceTier: 'synthetic-tier',
+        refundedAt: null,
+        runner: {
+          email: 'old-account-runner@example.test',
+          firstName: 'Old',
+          lastName: 'Account Runner',
+          shirtSize: null,
+        },
+        status: 'paid',
+      }],
+      events: {
+        'old-account-private-event': {
+          id: 'old-account-private-event',
+          location: 'Old Account Private Location',
+          slug: 'old-account-private-event',
+          startAt: {
+            toDate: () => new Date('2099-01-01T12:00:00Z'),
+            toMillis: () => new Date('2099-01-01T12:00:00Z').getTime(),
+          },
+          title: 'Old Account Private Race',
+        },
+      },
+    };
+
+    function useAccountServices(services: typeof servicesA | null) {
+      (useServiceLocator as jest.Mock).mockReturnValue({
+        services,
+        isReady: Boolean(services),
+      });
+    }
+
+    async function startSave(fullName: string, expectedWrites = 1) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+      fireEvent.change(screen.getByLabelText('Full name'), {
+        target: { value: fullName },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(expectedWrites));
+    }
+
+    test('never commits old private data after a Firestore-only change', async () => {
+      const replacementProfile = accountDeferred<typeof PROFILE>();
+      useAccountServices(servicesA);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockReturnValueOnce(replacementProfile.promise);
+      (listMyRegistrations as jest.Mock).mockResolvedValue(privateRegistrations);
+      const commits: string[] = [];
+      const onCommit = (text: string) => commits.push(text);
+      const view = render(<AccountCommitProbe onCommit={onCommit} />);
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      expect(await screen.findByText('Old Account Private Race')).toBeInTheDocument();
+      commits.length = 0;
+      useAccountServices({
+        firebaseResources: { app, firestore: firestoreB },
+        identityService: identityServiceA,
+      });
+
+      await act(async () => view.rerender(
+        <AccountCommitProbe onCommit={onCommit} />,
+      ));
+
+      expect(commits.length).toBeGreaterThan(0);
+      expect(commits.join(' ')).toContain('Loading profile...');
+      expect(commits.join(' ')).not.toMatch(
+        /Synthetic Member|member@example\.com|Old Account Private Race|\$43\.21/,
+      );
+      expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+    });
+
+    test('never recommits old private data after unavailable and same-context return', async () => {
+      const restoredProfile = accountDeferred<typeof PROFILE>();
+      useAccountServices(servicesA);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockReturnValueOnce(restoredProfile.promise);
+      (listMyRegistrations as jest.Mock).mockResolvedValue(privateRegistrations);
+      const commits: string[] = [];
+      const onCommit = (text: string) => commits.push(text);
+      const view = render(<AccountCommitProbe onCommit={onCommit} />);
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      expect(await screen.findByText('Old Account Private Race')).toBeInTheDocument();
+      useAccountServices(null);
+      await act(async () => view.rerender(
+        <AccountCommitProbe onCommit={onCommit} />,
+      ));
+      expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+
+      commits.length = 0;
+      useAccountServices(servicesA);
+      await act(async () => view.rerender(
+        <AccountCommitProbe onCommit={onCommit} />,
+      ));
+
+      expect(commits.length).toBeGreaterThan(0);
+      expect(commits.join(' ')).toContain('Loading profile...');
+      expect(commits.join(' ')).not.toMatch(
+        /Synthetic Member|member@example\.com|Old Account Private Race|\$43\.21/,
+      );
+      expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+    });
+
+    test.each([
+      [
+        'UID',
+        servicesA,
+        userB,
+      ],
+      [
+        'Firebase app',
+        {
+          firebaseResources: { app: appB, firestore },
+          identityService: identityServiceA,
+        },
+        USER,
+      ],
+      [
+        'Firestore service',
+        {
+          firebaseResources: { app, firestore: firestoreB },
+          identityService: identityServiceA,
+        },
+        USER,
+      ],
+      [
+        'Identity service',
+        {
+          firebaseResources: { app, firestore },
+          identityService: identityServiceB,
+        },
+        USER,
+      ],
+    ])('does not read or show an old result after a %s-only change', async (
+      transition,
+      nextServices,
+      nextUser,
+    ) => {
+      const oldUpdate = accountDeferred<void>();
+      const currentProfile = {
+        ...PROFILE,
+        uid: nextUser.uid,
+        email: nextUser.email,
+        fullName: `Current After ${transition}`,
+      };
+      const staleProfile = {
+        ...PROFILE,
+        fullName: `Old Private Result After ${transition}`,
+      };
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock).mockReturnValueOnce(oldUpdate.promise);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockResolvedValueOnce(currentProfile)
+        .mockResolvedValueOnce(staleProfile);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave('Old Account Pending Edit');
+      expect(updateMyProfile).toHaveBeenCalledWith(
+        firestore,
+        USER.uid,
+        { fullName: 'Old Account Pending Edit' },
+      );
+
+      useAccountServices(nextServices);
+      view.rerender(accountView(nextUser));
+      expect(await screen.findByText(currentProfile.fullName)).toBeInTheDocument();
+
+      await act(async () => oldUpdate.resolve());
+
+      expect(getMyProfile).toHaveBeenCalledTimes(2);
+      expect(screen.getByText(currentProfile.fullName)).toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent(staleProfile.fullName);
+      expect(document.body).not.toHaveTextContent('Old Account Pending Edit');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    test('keeps a save current across a new wrapper with the same resources', async () => {
+      const update = accountDeferred<void>();
+      const savedProfile = {
+        ...PROFILE,
+        fullName: 'Saved Through Equivalent Wrapper',
+      };
+      const secondSavedProfile = {
+        ...PROFILE,
+        fullName: 'Saved Through Deliberate Second Attempt',
+      };
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock).mockReturnValueOnce(update.promise);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockResolvedValueOnce(PROFILE)
+        .mockResolvedValueOnce(savedProfile)
+        .mockResolvedValueOnce(secondSavedProfile);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave(savedProfile.fullName);
+      useAccountServices({
+        ...servicesA,
+        firebaseResources: { ...servicesA.firebaseResources },
+      });
+      view.rerender(accountView());
+      await waitFor(() => expect(getMyProfile).toHaveBeenCalledTimes(2));
+
+      await act(async () => update.resolve());
+
+      expect(await screen.findByText(savedProfile.fullName)).toBeInTheDocument();
+      expect(getMyProfile).toHaveBeenCalledTimes(3);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled();
+
+      await startSave(secondSavedProfile.fullName, 2);
+
+      expect(await screen.findByText(secondSavedProfile.fullName)).toBeInTheDocument();
+      expect(getMyProfile).toHaveBeenCalledTimes(4);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled();
+    });
+
+    test('ignores an old confirmation read that settles after context changes', async () => {
+      const oldConfirmation = accountDeferred<typeof PROFILE>();
+      const staleProfile = {
+        ...PROFILE,
+        fullName: 'Old Confirmation Private Result',
+      };
+      useAccountServices(servicesA);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockReturnValueOnce(oldConfirmation.promise)
+        .mockResolvedValueOnce(profileB);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave('Old Confirmation Pending Edit');
+      await waitFor(() => expect(getMyProfile).toHaveBeenCalledTimes(2));
+
+      useAccountServices(servicesB);
+      view.rerender(accountView(userB));
+      expect(await screen.findByText(profileB.fullName)).toBeInTheDocument();
+
+      await act(async () => oldConfirmation.resolve(staleProfile));
+
+      expect(getMyProfile).toHaveBeenCalledTimes(3);
+      expect(screen.getByText(profileB.fullName)).toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent(staleProfile.fullName);
+      expect(document.body).not.toHaveTextContent('Old Confirmation Pending Edit');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    test('keeps an old rejection inert after the new account is ready', async () => {
+      const oldUpdate = accountDeferred<void>();
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock).mockReturnValueOnce(oldUpdate.promise);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockResolvedValueOnce(profileB);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave('Old Account Rejected Edit');
+      useAccountServices(servicesB);
+      view.rerender(accountView(userB));
+      expect(await screen.findByText(profileB.fullName)).toBeInTheDocument();
+
+      await act(async () => oldUpdate.reject(
+        new Error('old-profile-rejection-canary@example.test'),
+      ));
+
+      expect(screen.getByText(profileB.fullName)).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent(/old-profile-rejection-canary/i);
+    });
+
+    test('does not let an old completion unlock or replace a newer save', async () => {
+      const oldUpdate = accountDeferred<void>();
+      const currentUpdate = accountDeferred<void>();
+      const savedProfileB = {
+        ...profileB,
+        fullName: 'Saved Account B',
+      };
+      let accountAReads = 0;
+      let accountBReads = 0;
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock)
+        .mockReturnValueOnce(oldUpdate.promise)
+        .mockReturnValueOnce(currentUpdate.promise);
+      (getMyProfile as jest.Mock).mockImplementation(async (database, uid) => {
+        if (database === firestore && uid === USER.uid) {
+          accountAReads += 1;
+          return accountAReads === 1
+            ? PROFILE
+            : { ...PROFILE, fullName: 'Obsolete Account A' };
+        }
+        if (database === firestoreB && uid === userB.uid) {
+          accountBReads += 1;
+          return accountBReads === 1 ? profileB : savedProfileB;
+        }
+        throw new Error('Unexpected synthetic profile context.');
+      });
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave('Pending Account A');
+      useAccountServices(servicesB);
+      view.rerender(accountView(userB));
+      expect(await screen.findByText(profileB.fullName)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const currentInput = screen.getByLabelText('Full name');
+      const currentSave = screen.getByRole('button', { name: 'Save' });
+      expect(currentInput).toBeEnabled();
+      expect(currentSave).toBeEnabled();
+      fireEvent.change(currentInput, { target: { value: savedProfileB.fullName } });
+      fireEvent.click(currentSave);
+      await waitFor(() => expect(updateMyProfile).toHaveBeenCalledTimes(2));
+      expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+
+      await act(async () => oldUpdate.resolve());
+
+      expect(accountAReads).toBe(1);
+      expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+      expect(screen.getByLabelText('Full name')).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+      expect(document.body).not.toHaveTextContent('Obsolete Account A');
+
+      await act(async () => currentUpdate.resolve());
+
+      expect(await screen.findByText(savedProfileB.fullName)).toBeInTheDocument();
+      expect(accountBReads).toBe(2);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled();
+    });
+
+    test('invalidates an old generation across unavailable and same-context return', async () => {
+      const oldUpdate = accountDeferred<void>();
+      const restoredProfile = {
+        ...PROFILE,
+        fullName: 'Restored Current Account',
+      };
+      const staleProfile = {
+        ...PROFILE,
+        fullName: 'First Generation Private Result',
+      };
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock).mockReturnValueOnce(oldUpdate.promise);
+      (getMyProfile as jest.Mock)
+        .mockResolvedValueOnce(PROFILE)
+        .mockResolvedValueOnce(restoredProfile)
+        .mockResolvedValueOnce(staleProfile);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      await startSave('First Generation Pending Edit');
+      useAccountServices(null);
+      view.rerender(accountView());
+      expect(screen.getByRole('status')).toHaveTextContent('Loading profile...');
+
+      useAccountServices(servicesA);
+      view.rerender(accountView());
+      expect(await screen.findByText(restoredProfile.fullName)).toBeInTheDocument();
+
+      await act(async () => oldUpdate.resolve());
+
+      expect(getMyProfile).toHaveBeenCalledTimes(2);
+      expect(screen.getByText(restoredProfile.fullName)).toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent(staleProfile.fullName);
+    });
+
+    test('starts one write for rapid repeats and makes unmounted completion inert', async () => {
+      const update = accountDeferred<void>();
+      useAccountServices(servicesA);
+      (updateMyProfile as jest.Mock).mockReturnValue(update.promise);
+      (getMyProfile as jest.Mock).mockResolvedValueOnce(PROFILE);
+      const view = renderAccount();
+
+      expect(await screen.findByText(PROFILE.fullName)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      fireEvent.change(screen.getByLabelText('Full name'), {
+        target: { value: 'One Attempt Profile' },
+      });
+      const save = screen.getByRole('button', { name: 'Save' });
+      await act(async () => {
+        fireEvent.click(save);
+        fireEvent.click(save);
+        await Promise.resolve();
+      });
+
+      expect(updateMyProfile).toHaveBeenCalledTimes(1);
+      view.unmount();
+      await act(async () => update.resolve());
+
+      expect(getMyProfile).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test('reports request acceptance without claiming delivery and blocks rapid repeats', async () => {
     let finishRequest: (() => void) | undefined;
     resendVerificationEmail.mockImplementationOnce(() => new Promise<void>((resolve) => {

--- a/src/pages/account/Account.tsx
+++ b/src/pages/account/Account.tsx
@@ -260,22 +260,40 @@ export function AccountContent({
   const [regsError, setRegsError] = useState<string | null>(null);
   const identityService = services?.identityService || null;
   const firebaseApp = services?.firebaseResources.app || null;
+  const firebaseFirestore = services?.firebaseResources.firestore || null;
   type AccountContext = {
     firebaseApp: typeof firebaseApp;
     identityService: typeof identityService;
     uid: string;
   };
+  type ProfileServiceContext = AccountContext & {
+    firebaseFirestore: typeof firebaseFirestore;
+  };
+  type ProfileDataContext = ProfileServiceContext & {
+    generation: number;
+  };
+  type ProfileSaveAttempt = ProfileDataContext & { attemptId: number };
   type SignOutOutcome = AccountContext & {
     attemptId: number;
     attemptNumber: 1 | 2;
     generation: number;
     status: 'pending' | 'retry' | 'terminal';
   };
-  const [profileContext, setProfileContext] = useState<AccountContext | null>(null);
+  const [profileContext, setProfileContext] = useState<ProfileDataContext | null>(null);
   const [registrationsContext, setRegistrationsContext] = useState<
-    AccountContext | null
+    ProfileDataContext | null
   >(null);
   const [signOutOutcome, setSignOutOutcome] = useState<SignOutOutcome | null>(null);
+  const profileSaveAttemptIdRef = useRef(0);
+  const profileSaveBlockedRef = useRef(false);
+  const profileContextGenerationRef = useRef(0);
+  const profileContextMountedRef = useRef(false);
+  const currentProfileContextRef = useRef<ProfileServiceContext>({
+    firebaseApp,
+    firebaseFirestore,
+    identityService,
+    uid: user.uid,
+  });
   const signOutAttemptIdRef = useRef(0);
   const signOutAttemptsRef = useRef(0);
   const signOutBlockedRef = useRef(false);
@@ -286,6 +304,27 @@ export function AccountContent({
     identityService,
     uid: user.uid,
   });
+
+  useLayoutEffect(() => {
+    currentProfileContextRef.current = {
+      firebaseApp,
+      firebaseFirestore,
+      identityService,
+      uid: user.uid,
+    };
+    profileContextMountedRef.current = true;
+    profileContextGenerationRef.current += 1;
+    profileSaveBlockedRef.current = false;
+    setSaving(false);
+    setEditing(false);
+    setSaveError(null);
+
+    return () => {
+      profileContextMountedRef.current = false;
+      profileContextGenerationRef.current += 1;
+      profileSaveBlockedRef.current = true;
+    };
+  }, [firebaseApp, firebaseFirestore, identityService, user.uid]);
 
   useLayoutEffect(() => {
     currentSignOutContextRef.current = {
@@ -311,8 +350,10 @@ export function AccountContent({
     const activeServices = services;
     const loadContext = {
       firebaseApp: activeServices.firebaseResources.app,
+      firebaseFirestore: activeServices.firebaseResources.firestore,
       identityService: activeServices.identityService,
       uid: user.uid,
+      generation: profileContextGenerationRef.current,
     };
     let active = true;
 
@@ -352,8 +393,10 @@ export function AccountContent({
     if (!services || profileState !== 'ready') return undefined;
     const loadContext = {
       firebaseApp: services.firebaseResources.app,
+      firebaseFirestore: services.firebaseResources.firestore,
       identityService: services.identityService,
       uid: user.uid,
+      generation: profileContextGenerationRef.current,
     };
     let active = true;
     setRegsData(null);
@@ -376,6 +419,17 @@ export function AccountContent({
     return () => { active = false; };
   }, [services, profileState, user.uid]);
 
+  function isCurrentProfileSave(attempt: ProfileSaveAttempt) {
+    const currentContext = currentProfileContextRef.current;
+    return profileContextMountedRef.current
+      && profileContextGenerationRef.current === attempt.generation
+      && profileSaveAttemptIdRef.current === attempt.attemptId
+      && currentContext.firebaseApp === attempt.firebaseApp
+      && currentContext.firebaseFirestore === attempt.firebaseFirestore
+      && currentContext.identityService === attempt.identityService
+      && currentContext.uid === attempt.uid;
+  }
+
   async function handleSave() {
     if (!services) return;
     const validation = validateMemberProfileFields({ fullName });
@@ -383,15 +437,41 @@ export function AccountContent({
       setSaveError(validation.message);
       return;
     }
+    const saveContext = {
+      firebaseApp: services.firebaseResources.app,
+      firebaseFirestore: services.firebaseResources.firestore,
+      identityService: services.identityService,
+      uid: user.uid,
+    };
+    const currentContext = currentProfileContextRef.current;
+    if (
+      profileSaveBlockedRef.current
+      || !profileContextMountedRef.current
+      || currentContext.firebaseApp !== saveContext.firebaseApp
+      || currentContext.firebaseFirestore !== saveContext.firebaseFirestore
+      || currentContext.identityService !== saveContext.identityService
+      || currentContext.uid !== saveContext.uid
+    ) return;
+
+    profileSaveBlockedRef.current = true;
+    const attemptId = profileSaveAttemptIdRef.current + 1;
+    profileSaveAttemptIdRef.current = attemptId;
+    const attempt = {
+      ...saveContext,
+      attemptId,
+      generation: profileContextGenerationRef.current,
+    };
     setSaving(true);
     setSaveError(null);
     try {
       await updateMyProfile(
-        services.firebaseResources.firestore,
-        user.uid,
+        attempt.firebaseFirestore,
+        attempt.uid,
         validation.fields,
       );
-      const fresh = await getMyProfile(services.firebaseResources.firestore, user.uid);
+      if (!isCurrentProfileSave(attempt)) return;
+      const fresh = await getMyProfile(attempt.firebaseFirestore, attempt.uid);
+      if (!isCurrentProfileSave(attempt)) return;
       if (!fresh) throw new Error('Profile unavailable after save.');
       setProfile(fresh);
       setFullName(fresh.fullName || '');
@@ -399,13 +479,17 @@ export function AccountContent({
       setProfileState('ready');
       setEditing(false);
     } catch {
+      if (!isCurrentProfileSave(attempt)) return;
       setProfile(null);
       setEditing(false);
       setSaveError(null);
       setProfileError(PROFILE_CHANGE_UNCONFIRMED_MESSAGE);
       setProfileState('unavailable');
     } finally {
-      setSaving(false);
+      if (isCurrentProfileSave(attempt)) {
+        profileSaveBlockedRef.current = false;
+        setSaving(false);
+      }
     }
   }
 
@@ -474,11 +558,15 @@ export function AccountContent({
   const profileBelongsToCurrentContext = profileContext
     && profileContext.uid === user.uid
     && profileContext.identityService === identityService
-    && profileContext.firebaseApp === firebaseApp;
+    && profileContext.firebaseApp === firebaseApp
+    && profileContext.firebaseFirestore === firebaseFirestore
+    && profileContext.generation === profileContextGenerationRef.current;
   const registrationsBelongToCurrentContext = registrationsContext
     && registrationsContext.uid === user.uid
     && registrationsContext.identityService === identityService
-    && registrationsContext.firebaseApp === firebaseApp;
+    && registrationsContext.firebaseApp === firebaseApp
+    && registrationsContext.firebaseFirestore === firebaseFirestore
+    && registrationsContext.generation === profileContextGenerationRef.current;
 
   if (currentSignOutOutcome) {
     const isRetry = currentSignOutOutcome.status === 'retry';


### PR DESCRIPTION
Closes #531

## Outcome

My Account profile saves are now one-attempt and bound to the exact current Firebase app, Firestore service, identity service, UID, and opaque context generation. An old write, confirmation read, rejection, or `finally` cannot overwrite or unlock a newer account. Private profile and registration data is admitted to a render only when that same exact context still owns it.

## Safety invariants

- A rapid repeated Save activation starts one write.
- A confirmation read starts only if the completed write still belongs to the current context.
- Confirmation success, failure, and final unlock all recheck mounted state, generation, attempt ID, app, Firestore, identity service, and UID.
- UID/app/Firestore/identity transitions, unmount, StrictMode replay, and `A -> unavailable -> A` invalidate old work.
- A new service wrapper around the same exact resources stays compatible.
- Raw rejection details are neither inspected nor rendered.
- No schema, Rules, Function, provider, or production-data behavior changes.

## Verification

- Trustworthy RED: released behavior failed five save-race cases; separately scoped commit probes then demonstrated Firestore-only and unavailable/same-context stale private-data commits before the render fence was added.
- Focused AUTH-006F: 12/12 passed.
- Full Account: 152/152 passed on exact head.
- Full frontend: 940/940 passed.
- Full Functions on refreshed base: 6,572 passed; 64 intentional skips.
- Firestore Rules in demo emulators: 418/418 passed.
- Repository safety: 80/80 passed.
- SPA navigation: 11/11 passed.
- Frontend lint baseline: 118 files / 113 reviewed legacy errors / 6 reviewed legacy warnings, unchanged.
- TypeScript, direct Account ESLint, diagnostic build, and diff checks passed.
- Three independent security/privacy, mutation-test, and scope/compatibility reviews returned GO with no findings.
- Base: `98f1e5d3be1402ab0d9eff139182086c905fc602`
- Head: `8714511032213ff570cc4d15fe0f7a31175b16e8`
- Exact two-file binary diff SHA-256: `5fe87dd506abee7186ae59e4f2e119a381123907ed3a878ef0cb8b7a41297a63`

## Handoff

Officer impact: Members do not need a new step. Profile saves and private account rendering now remain tied to the current account context.

Officer documentation: None — this is an invisible internal lifecycle/privacy correction and changes no officer procedure, page structure, permission, collected field, provider account, or navigation.

Deployment evidence: Source/tests only at PR creation. No website publication, Firebase deployment, provider call/configuration, production-data action, or live behavior verification occurred. Hosted exact-head and post-main evidence remain required before closure.

Migration impact: None. No persisted data or API shape changes.
