### PR TITLE
OAUTH-001B7: make Strava cleanup atomic

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -1108,9 +1108,15 @@ exports.stravaDisconnect = functions
         }
       }
     }
-    await Promise.all([
-      secretDocRef(uid).delete().catch(() => {}),
-      connectionDocRef(uid).delete().catch(() => {}),
-    ]);
+    try {
+      const db = admin.firestore();
+      const cleanup = db.batch();
+      cleanup.delete(secretDocRef(uid, db));
+      cleanup.delete(connectionDocRef(uid, db));
+      await cleanup.commit();
+    } catch (_error) {
+      console.warn('strava_disconnect_cleanup_failed');
+      throw stravaDisconnectError();
+    }
     return { ok: true };
   });

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -23,6 +23,9 @@ jest.mock('firebase-admin', () => {
   let batchCreateAttempts = 0;
   let batchCreationFailure;
   const batchCommitAttempts = [];
+  const batchDeleteAttempts = [];
+  const batchDeleteFailures = new Map();
+  const batchDeletes = [];
   const batchSetAttempts = [];
   const batchSetFailures = new Map();
   const deleteFailures = new Map();
@@ -105,6 +108,15 @@ jest.mock('firebase-admin', () => {
         }
         const staged = [];
         const batch = {
+          delete: (ref) => {
+            const operation = { type: 'delete', path: ref.path };
+            batchDeleteAttempts.push(ref.path);
+            if (batchDeleteFailures.has(ref.path)) {
+              throw batchDeleteFailures.get(ref.path);
+            }
+            staged.push(operation);
+            return batch;
+          },
           set: (ref, data, options) => {
             const operation = { path: ref.path, data, options };
             batchSetAttempts.push(operation);
@@ -120,11 +132,18 @@ jest.mock('firebase-admin', () => {
               throw batchCommitFailure;
             }
             for (const operation of staged) {
-              if (writeFailures.has(operation.path)) {
+              if (operation.type !== 'delete' && writeFailures.has(operation.path)) {
                 throw writeFailures.get(operation.path);
               }
             }
-            staged.forEach(applyWrite);
+            staged.forEach((operation) => {
+              if (operation.type === 'delete') {
+                batchDeletes.push(operation.path);
+                applyDelete(operation.path);
+              } else {
+                applyWrite(operation);
+              }
+            });
             if (batchCommitPostApplyFailure) {
               throw batchCommitPostApplyFailure;
             }
@@ -215,6 +234,9 @@ jest.mock('firebase-admin', () => {
       batchCreateAttempts = 0;
       batchCreationFailure = undefined;
       batchCommitAttempts.splice(0, batchCommitAttempts.length);
+      batchDeleteAttempts.splice(0, batchDeleteAttempts.length);
+      batchDeleteFailures.clear();
+      batchDeletes.splice(0, batchDeletes.length);
       batchSetAttempts.splice(0, batchSetAttempts.length);
       batchSetFailures.clear();
       directSetAttempts.splice(0, directSetAttempts.length);
@@ -235,6 +257,8 @@ jest.mock('firebase-admin', () => {
     },
     __getBatchCommitAttempts: () => [...batchCommitAttempts],
     __getBatchCreateAttempts: () => batchCreateAttempts,
+    __getBatchDeleteAttempts: () => [...batchDeleteAttempts],
+    __getBatchDeletes: () => [...batchDeletes],
     __getBatchSetAttempts: () => [...batchSetAttempts],
     __getDeletes: () => [...deletes],
     __getDirectSetAttempts: () => [...directSetAttempts],
@@ -256,6 +280,7 @@ jest.mock('firebase-admin', () => {
     __setBatchCreationFailure: (error) => {
       batchCreationFailure = error;
     },
+    __setBatchDeleteFailure: (path, error) => batchDeleteFailures.set(path, error),
     __setBatchSetFailure: (path, error) => batchSetFailures.set(path, error),
     __setDeleteFailure: (path, error) => deleteFailures.set(path, error),
     __removeDocument: (path) => applyDelete(path),
@@ -4882,6 +4907,7 @@ describe('Strava disconnect failure log boundary', () => {
   const SYNTHETIC_CLIENT_SECRET = 'abc123';
   const SYNTHETIC_BASIC_AUTHORIZATION = 'Basic MTIzNDU6YWJjMTIz';
   const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+  const FIXED_CLEANUP_WARNING = 'strava_disconnect_cleanup_failed';
 
   beforeEach(() => {
     process.env.STRAVA_CLIENT_ID = SYNTHETIC_CLIENT_ID;
@@ -4929,12 +4955,27 @@ describe('Strava disconnect failure log boundary', () => {
   }
 
   function expectLocalDeletes() {
-    expect(admin.__getDeletes()).toEqual([SECRET_PATH, CONNECTION_PATH]);
+    const operations = [
+      { type: 'delete', path: SECRET_PATH },
+      { type: 'delete', path: CONNECTION_PATH },
+    ];
+    expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getBatchCreateAttempts()).toBe(1);
+    expect(admin.__getBatchDeleteAttempts()).toEqual([SECRET_PATH, CONNECTION_PATH]);
+    expect(admin.__getBatchDeletes()).toEqual([SECRET_PATH, CONNECTION_PATH]);
+    expect(admin.__getBatchSetAttempts()).toEqual([]);
+    expect(admin.__getBatchCommitAttempts()).toEqual([operations]);
     expect(admin.__getWrites()).toEqual([]);
+    expect(admin.__hasDocument(SECRET_PATH)).toBe(false);
+    expect(admin.__hasDocument(CONNECTION_PATH)).toBe(false);
   }
 
   function expectLocalRecordsPreserved() {
     expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getBatchCreateAttempts()).toBe(0);
+    expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+    expect(admin.__getBatchDeletes()).toEqual([]);
+    expect(admin.__getBatchCommitAttempts()).toEqual([]);
     expect(admin.__getWrites()).toEqual([]);
     expect(admin.__hasDocument(SECRET_PATH)).toBe(true);
     expect(admin.__hasDocument(CONNECTION_PATH)).toBe(true);
@@ -4956,6 +4997,10 @@ describe('Strava disconnect failure log boundary', () => {
   function expectNoDisconnectSideEffects() {
     expect(admin.__getReads()).toEqual([]);
     expect(admin.__getDeletes()).toEqual([]);
+    expect(admin.__getBatchCreateAttempts()).toBe(0);
+    expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+    expect(admin.__getBatchDeletes()).toEqual([]);
+    expect(admin.__getBatchCommitAttempts()).toEqual([]);
     expect(admin.__getWrites()).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(dateNowSpy).not.toHaveBeenCalled();
@@ -5789,21 +5834,131 @@ describe('Strava disconnect failure log boundary', () => {
     expectLocalRecordsPreserved();
   });
 
-  test('preserves swallowed local delete failures and the current success result', async () => {
-    admin.__setDeleteFailure(
-      SECRET_PATH,
-      new Error('synthetic secret delete failure'),
-    );
-    admin.__setDeleteFailure(
-      CONNECTION_PATH,
-      new Error('synthetic connection delete failure'),
-    );
+  describe('OAUTH-001B7 atomic local disconnect cleanup', () => {
+    const cleanupOperations = [
+      { type: 'delete', path: SECRET_PATH },
+      { type: 'delete', path: CONNECTION_PATH },
+    ];
 
-    const result = await stravaDisconnect({}, CONTEXT);
+    function hostileCleanupFailure() {
+      const probes = [
+        jest.fn(() => {
+          throw new Error('cleanup-cause-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('cleanup-details-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('cleanup-json-getter-canary');
+        }),
+      ];
+      const failure = new Error(
+        'cleanup-failure-canary token=synthetic-provider-secret-canary',
+      );
+      Object.defineProperties(failure, {
+        cause: { configurable: true, enumerable: true, get: probes[0] },
+        details: { configurable: true, enumerable: true, get: probes[1] },
+        toJSON: { configurable: true, enumerable: true, get: probes[2] },
+      });
+      return { failure, probes };
+    }
 
-    expect(result).toEqual({ ok: true });
-    expect(fetchMock).not.toHaveBeenCalled();
-    expectLocalDeletes();
-    expectNoLogs();
+    function expectFixedCleanupFailure(rejection, probes) {
+      const exposed = publicError(rejection);
+      expect(exposed).toEqual({
+        code: 'unavailable',
+        message: FIXED_DISCONNECT_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpies.warn).toHaveBeenCalledWith(FIXED_CLEANUP_WARNING);
+      expect(JSON.stringify({ exposed, logs: consoleSpies.warn.mock.calls }))
+        .not.toMatch(/cleanup-|token=|provider-secret|canary/i);
+      probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+      ['debug', 'error', 'info', 'log']
+        .forEach((method) => expect(consoleSpies[method]).not.toHaveBeenCalled());
+    }
+
+    test.each([
+      [
+        'batch construction',
+        (failure) => admin.__setBatchCreationFailure(failure),
+        [],
+        [],
+      ],
+      [
+        'secret delete staging',
+        (failure) => admin.__setBatchDeleteFailure(SECRET_PATH, failure),
+        [SECRET_PATH],
+        [],
+      ],
+      [
+        'connection delete staging',
+        (failure) => admin.__setBatchDeleteFailure(CONNECTION_PATH, failure),
+        [SECRET_PATH, CONNECTION_PATH],
+        [],
+      ],
+      [
+        'pre-apply commit',
+        (failure) => admin.__setBatchCommitFailure(failure),
+        [SECRET_PATH, CONNECTION_PATH],
+        [cleanupOperations],
+      ],
+    ])('maps %s failure to one fixed result and preserves both records', async (
+      _stage,
+      configure,
+      expectedDeleteAttempts,
+      expectedCommitAttempts,
+    ) => {
+      const { failure, probes } = hostileCleanupFailure();
+      seedConnectedAccount();
+      fetchMock.mockResolvedValue({ ok: true });
+      configure(failure);
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedCleanupFailure(rejection, probes);
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
+      expect(admin.__getBatchCreateAttempts()).toBe(1);
+      expect(admin.__getBatchDeleteAttempts()).toEqual(expectedDeleteAttempts);
+      expect(admin.__getBatchDeletes()).toEqual([]);
+      expect(admin.__getBatchSetAttempts()).toEqual([]);
+      expect(admin.__getBatchCommitAttempts()).toEqual(expectedCommitAttempts);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__hasDocument(SECRET_PATH)).toBe(true);
+      expect(admin.__hasDocument(CONNECTION_PATH)).toBe(true);
+    });
+
+    test('returns an unknown result after lost acknowledgement and converges on retry', async () => {
+      const { failure, probes } = hostileCleanupFailure();
+      seedConnectedAccount();
+      fetchMock.mockResolvedValue({ ok: true });
+      admin.__setBatchCommitPostApplyFailure(failure);
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedCleanupFailure(rejection, probes);
+      expectSupportedRevokeRequest('synthetic_disconnect_access_token_test');
+      expect(admin.__getBatchDeleteAttempts()).toEqual([SECRET_PATH, CONNECTION_PATH]);
+      expect(admin.__getBatchDeletes()).toEqual([SECRET_PATH, CONNECTION_PATH]);
+      expect(admin.__getBatchCommitAttempts()).toEqual([cleanupOperations]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__hasDocument(SECRET_PATH)).toBe(false);
+      expect(admin.__hasDocument(CONNECTION_PATH)).toBe(false);
+
+      admin.__clearWrites();
+      admin.__clearReads();
+      fetchMock.mockReset();
+      consoleSpies.warn.mockClear();
+
+      const retryResult = await stravaDisconnect({}, CONTEXT);
+
+      expect(retryResult).toEqual({ ok: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectLocalDeletes();
+      expectNoLogs();
+    });
   });
 });


### PR DESCRIPTION
## Outcome

Strava disconnect now reports success only after one atomic Firestore batch has deleted both local Strava records. This closes the false-success gap where either delete could fail silently.

Closes #536

## Safety invariant

- The supported provider revoke request remains before local cleanup.
- One Firestore `WriteBatch` deletes both the server-only secret and the public connection projection.
- Success is returned only after the batch commit is acknowledged.
- Construction, staging, commit, or acknowledgement failure returns the existing fixed `unavailable` result.
- Cleanup failures log only `strava_disconnect_cleanup_failed`; caught values are not read, logged, or returned.
- Pre-apply failures preserve both records.
- A lost acknowledgement may leave both records deleted, but cannot intentionally split them; a retry converges without another provider call when the secret is gone.

## Scope

- `functions/strava.js`: final local disconnect cleanup only.
- `functions/strava.test.js`: minimal WriteBatch-delete mock support and focused construction/staging/commit/lost-ack/redaction/retry coverage.

No schema, endpoint, package, Rule, frontend, provider-configuration, or production-data change.

## Verification

- Red proof: 5/5 new cases failed against the old swallowed-delete behavior.
- Focused OAUTH-001B7: 5/5 passed.
- Full Strava: 652/652 passed.
- Full Functions: 6,576 passed; 64 skipped.
- Functions lint: passed.
- Frontend Jest: 940/940 passed.
- Repository safety: 80/80 passed.
- SPA navigation: 11/11 passed.
- Frontend lint ledger: 118 files / 113 reviewed errors / 6 reviewed warnings.
- Diagnostic production build: passed.
- `git diff --check`: passed.
- Three independent exact-head reviews: GO.
- Local Rules and commerce-emulator suites were not run because Java is unavailable; hosted Java 21 CI is required before merge.

## Compatibility and residual risk

No migration is required. Existing records remain compatible. Provider revocation and Firestore cleanup cannot be one distributed transaction, so an acknowledgement-loss response remains intentionally unknown. Durable audit/tombstones, automatic reconciliation, provider configuration, deployment, and live verification remain open under #88.

Officer impact: None now. This is a server cleanup reliability correction with no officer screen or task change.

Officer documentation: None — the existing disconnect guide already tells officers to refresh after an unknown result, and this source-only change adds no new procedure.

Deployment evidence: Source and tests only. No Firebase deployment, Strava/provider call or configuration, website publication, production-data action, or live-behavior verification was performed.
