### PR TITLE
OAUTH-001B8: redact Strava disconnect storage-read failures

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -1077,9 +1077,19 @@ exports.stravaDisconnect = functions
       );
     }
     const { uid } = context.auth;
-    const secretSnap = await secretDocRef(uid).get();
-    if (secretSnap.exists) {
-      const accessToken = snapshotStoredDisconnectAccessToken(secretSnap.data());
+    let secretExists = false;
+    let accessToken = null;
+    try {
+      const secretSnap = await secretDocRef(uid).get();
+      secretExists = secretSnap.exists;
+      if (secretExists) {
+        accessToken = snapshotStoredDisconnectAccessToken(secretSnap.data());
+      }
+    } catch (_error) {
+      console.warn('strava_disconnect_secret_read_failed');
+      throw stravaDisconnectError();
+    }
+    if (secretExists) {
       if (accessToken) {
         let revokeResponse;
         try {

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -33,6 +33,8 @@ jest.mock('firebase-admin', () => {
   const directSetAttempts = [];
   const documents = new Map();
   const documentVersions = new Map();
+  const readFailures = new Map();
+  const readSnapshots = new Map();
   const reads = [];
   let transactionCommitFailure;
   let transactionCommitPostApplyFailure;
@@ -81,6 +83,12 @@ jest.mock('firebase-admin', () => {
       },
       get: async () => {
         reads.push(path);
+        if (readFailures.has(path)) {
+          throw readFailures.get(path);
+        }
+        if (readSnapshots.has(path)) {
+          return readSnapshots.get(path);
+        }
         const exists = documents.has(path);
         const data = documents.get(path);
         return {
@@ -227,7 +235,11 @@ jest.mock('firebase-admin', () => {
       documents.clear();
       documentVersions.clear();
     },
-    __clearReads: () => reads.splice(0, reads.length),
+    __clearReads: () => {
+      readFailures.clear();
+      readSnapshots.clear();
+      reads.splice(0, reads.length);
+    },
     __clearWrites: () => {
       batchCommitFailure = undefined;
       batchCommitPostApplyFailure = undefined;
@@ -288,6 +300,8 @@ jest.mock('firebase-admin', () => {
       documents.set(path, data);
       bumpVersion(path);
     },
+    __setReadFailure: (path, error) => readFailures.set(path, error),
+    __setReadSnapshot: (path, snapshot) => readSnapshots.set(path, snapshot),
     __setTransactionCommitFailure: (error) => {
       transactionCommitFailure = error;
     },
@@ -4908,6 +4922,7 @@ describe('Strava disconnect failure log boundary', () => {
   const SYNTHETIC_BASIC_AUTHORIZATION = 'Basic MTIzNDU6YWJjMTIz';
   const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
   const FIXED_CLEANUP_WARNING = 'strava_disconnect_cleanup_failed';
+  const FIXED_SECRET_READ_WARNING = 'strava_disconnect_secret_read_failed';
 
   beforeEach(() => {
     process.env.STRAVA_CLIENT_ID = SYNTHETIC_CLIENT_ID;
@@ -5832,6 +5847,109 @@ describe('Strava disconnect failure log boundary', () => {
     ['debug', 'error', 'info', 'log']
       .forEach((method) => expect(consoleSpies[method]).not.toHaveBeenCalled());
     expectLocalRecordsPreserved();
+  });
+
+  describe('OAUTH-001B8 disconnect storage-read boundary', () => {
+    function hostileReadFailure() {
+      const probes = [
+        jest.fn(() => {
+          throw new Error('read-cause-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('read-details-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('read-json-getter-canary');
+        }),
+      ];
+      const failure = new Error(
+        'read-failure-canary uid=synthetic-member path=members/private token=synthetic-token',
+      );
+      Object.defineProperties(failure, {
+        cause: { configurable: true, enumerable: true, get: probes[0] },
+        details: { configurable: true, enumerable: true, get: probes[1] },
+        toJSON: { configurable: true, enumerable: true, get: probes[2] },
+      });
+      return { failure, probes };
+    }
+
+    function expectFixedReadFailure(rejection, probes) {
+      const exposed = publicError(rejection);
+      expect(exposed).toEqual({
+        code: 'unavailable',
+        message: FIXED_DISCONNECT_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpies.warn).toHaveBeenCalledWith(FIXED_SECRET_READ_WARNING);
+      expect(JSON.stringify({ exposed, logs: consoleSpies.warn.mock.calls }))
+        .not.toMatch(
+          /read-failure-canary|synthetic-member|members\/private|synthetic-token|getter-canary/i,
+        );
+      probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+      ['debug', 'error', 'info', 'log']
+        .forEach((method) => expect(consoleSpies[method]).not.toHaveBeenCalled());
+      expect(admin.__getReads()).toEqual([SECRET_PATH]);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(admin.__getBatchCreateAttempts()).toBe(0);
+      expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+      expect(admin.__getBatchDeletes()).toEqual([]);
+      expect(admin.__getBatchSetAttempts()).toEqual([]);
+      expect(admin.__getBatchCommitAttempts()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__getDirectSetAttempts()).toEqual([]);
+      expect(admin.__getTransactionRunAttempts()).toBe(0);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__hasDocument(SECRET_PATH)).toBe(true);
+      expect(admin.__hasDocument(CONNECTION_PATH)).toBe(true);
+      expect(dateNowSpy).not.toHaveBeenCalled();
+      expect(Timestamp.now).not.toHaveBeenCalled();
+    }
+
+    test('maps a rejected secret read to one fixed result before downstream work', async () => {
+      const { failure, probes } = hostileReadFailure();
+      seedConnectedAccount();
+      admin.__setReadFailure(SECRET_PATH, failure);
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+    });
+
+    test('maps a throwing snapshot exists value to the fixed read boundary', async () => {
+      const { failure, probes } = hostileReadFailure();
+      const exists = jest.fn(() => {
+        throw failure;
+      });
+      const snapshot = {};
+      Object.defineProperty(snapshot, 'exists', {
+        configurable: true,
+        enumerable: true,
+        get: exists,
+      });
+      seedConnectedAccount();
+      admin.__setReadSnapshot(SECRET_PATH, snapshot);
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+      expect(exists).toHaveBeenCalledTimes(1);
+    });
+
+    test('maps a throwing snapshot data method to the fixed read boundary', async () => {
+      const { failure, probes } = hostileReadFailure();
+      const data = jest.fn(() => {
+        throw failure;
+      });
+      seedConnectedAccount();
+      admin.__setReadSnapshot(SECRET_PATH, { exists: true, data });
+
+      const rejection = await captureFailure(() => stravaDisconnect({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+      expect(data).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('OAUTH-001B7 atomic local disconnect cleanup', () => {


### PR DESCRIPTION
Closes #541

## Outcome

Strava disconnect now treats failures while reading or projecting the server-only stored token as one fixed private failure. It does not expose the underlying Firestore value, call Strava, or delete either local record when the read result is unknown.

## Safety invariant

- App Check, Auth, and exact-empty request checks remain first.
- A rejected secret read, throwing snapshot `exists`, throwing snapshot `data()`, or token-projection failure returns the existing fixed `unavailable` disconnect message.
- The log contains only `strava_disconnect_secret_read_failed`; the caught value is never logged, serialized, or returned.
- Provider revoke and the released #536 atomic cleanup cannot start after an unknown read outcome.
- Valid, missing-document, malformed-token, provider-response, and cleanup behavior remain unchanged.

## Scope

- `functions/strava.js`: disconnect secret read/projection boundary only.
- `functions/strava.test.js`: path-scoped read-failure controls and the named OAUTH-001B8 regression block only.

Exact reviewed head: `ce0e50a1e6d3db0fbcdc9bed5dde4e2dfef18a22`

Exact tree: `467f65ed874b6e2b777bc49f86d50d2dd594ee74`

Two-file diff SHA-256: `722a4a56d80a0873fb196fe850abc6553ae1ec716e9e469cf6f37db2d0eec876`

## Verification

- Three independent read-only reviews: GO.
- Focused OAUTH-001B8 tests: 3/3 passed.
- Full Strava suite: 655/655 passed.
- Functions dependency security: 14/14 passed, including released #537 D13.
- Full Functions suite: 6,643 passed; 64 intentionally skipped. The first sandboxed run could not bind loopback for two network-safety tests; the unchanged suite passed when local loopback was allowed.
- Functions ESLint: passed.
- Frontend Jest: 940/940 passed on the same two-file candidate before the controlled refresh; refreshed base changes only released dependency files.
- SPA/repository safety: 11/11 and 80/80 passed on the same candidate before refresh.
- Frontend lint ledger: unchanged at 118 files / 113 errors / 6 warnings.
- Diagnostic build: passed on the same candidate before refresh.
- `git diff --check`: passed.
- Released #537 paths match `origin/main` byte-for-byte.

Hosted Java 21 Rules and commerce-emulator checks remain mandatory because local Java is unavailable.

## Officer continuity

Officer impact: None. This changes a private server failure boundary and does not change an officer task, public message, navigation, or data-entry procedure.

Officer documentation: None — no officer procedure changes; the broader Strava connection/disconnection work remains tracked under #88 and is not live from this source merge.

## Deployment evidence

Website: Not changed or published by this PR.

Firebase: Not deployed or verified live by this PR. Source and tests only until a separately authorized Firebase release succeeds.

Provider surfaces: Strava was not contacted or configured; tests use synthetic mocks only.

Production data: Not read or changed.
