### PR TITLE
PAY-003A5: reject incompatible refund Charge status

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -744,6 +744,23 @@ Text alternative: after the earlier realm and Checkout lifecycle checks, a suppo
 
 PAY-003A4 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, payment/refund/dispute performed, production data changed, and live behavior verified. Source and synthetic tests do not prove any later state. This child performs no website publication, Firebase deployment, provider configuration, payment/refund/dispute, production-data action, or live verification.
 
+PAY-003A5 [#542](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/542) adds one universal pre-target admission check for every `charge.refunded` Event. After the outer Event and embedded Charge realm checks, the embedded Charge `status` must be the exact primitive string `succeeded`. A missing field, `null`, `pending`, `failed`, an empty or unknown string, or a non-string value receives the fixed `charge_status_mismatch` processed-review outcome. The ledger has null target fields, the business record is unchanged, and no new Charge or PaymentIntent binding is created. This check runs before metadata, client-reference, legacy provider-ID record-field queries, ownership, binding, money, or state evaluation. Exact rejected replays are read-only; an already-processed Event keeps its stored outcome. Earlier realm failures keep precedence, while an exact-`succeeded` Charge continues to the existing metadata and target checks.
+
+```mermaid
+flowchart TD
+    A["Signed charge.refunded Event"] --> B{"Outer Event and embedded Charge realm compatible?"}
+    B -- "No" --> C["Record the earlier fixed realm-review outcome"]
+    B -- "Yes" --> D{"Charge status is exact string succeeded?"}
+    D -- "No" --> E["Record Charge-status review with no target"]
+    D -- "Yes" --> F["Continue existing metadata, reference, target, money, and state checks"]
+```
+
+Text alternative: a signed refund Event must first pass both realm checks and then carry an embedded Charge whose status is exactly string `succeeded`; incompatible status evidence is recorded for review without resolving or changing a business target, while compatible evidence only proceeds to the remaining checks.
+
+The PAY-003A5 status check is compatibility evidence, not proof that a refund succeeded, settled, has the correct amount, or belongs to a local record. It does not inspect nested Refund status, choose or configure a Stripe endpoint API version, reprocess historical Events, migrate data, or perform a provider retrieval. Endpoint-version compatibility therefore remains an operational prerequisite outside this source-only child.
+
+PAY-003A5 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, payment/refund performed, production data changed, and live behavior verified. Source and synthetic tests do not prove any later state. This child performs no website publication, Firebase deployment, provider configuration or retrieval, payment/refund, production-data action, or live verification.
+
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
 ## 12. Payment and business state machines

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -127,6 +127,13 @@ function validateEventAdmission(event, expectedLivemode) {
       'charge_livemode_mismatch',
     );
     if (!chargeRealm.ok) return chargeRealm;
+    if (event.data?.object?.status !== 'succeeded') {
+      return {
+        ok: false,
+        expected: expectedLivemode,
+        reason: 'charge_status_mismatch',
+      };
+    }
   } else if (DISPUTE_EVENT_TYPES.has(event.type)) {
     const disputeRealm = validateEmbeddedLivemode(
       event,

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -221,6 +221,18 @@ const INVALID_METADATA_SCHEMA_CASES = [
   ['object', {}],
   ['array', []],
 ];
+const INVALID_REFUND_CHARGE_STATUS_CASES = [
+  ['missing', 'delete', undefined],
+  ['null', 'value', null],
+  ['pending', 'value', 'pending'],
+  ['failed', 'value', 'failed'],
+  ['empty string', 'value', ''],
+  ['unknown string', 'value', 'hostile-status-do-not-log'],
+  ['number', 'value', 1],
+  ['boolean', 'value', true],
+  ['object', 'value', {}],
+  ['array', 'value', []],
+];
 const DISPUTE_REALM_CASES = [
   ['created', 'charge.dispute.created', 'needs_response'],
   ['updated', 'charge.dispute.updated', 'under_review'],
@@ -254,6 +266,8 @@ function stripeEvent(id, type, object) {
   let providerObject = object;
   if (checkoutStatus) {
     providerObject = { livemode: false, status: checkoutStatus, ...object };
+  } else if (type === 'charge.refunded') {
+    providerObject = { livemode: false, status: 'succeeded', ...object };
   } else if (PROVIDER_OBJECT_REALM_EVENT_TYPES.has(type)) {
     providerObject = { livemode: false, ...object };
   }
@@ -429,6 +443,11 @@ function setMetadataSchema(object, value) {
   object.metadata.schemaVersion = value;
 }
 
+function setRefundChargeStatus(charge, mutation, value) {
+  if (mutation === 'delete') delete charge.status;
+  else charge.status = value;
+}
+
 function providerBindingPaths(event) {
   const object = event.data.object;
   const descriptors = [];
@@ -469,6 +488,56 @@ function expectCompatibilityQuarantine({ response, event, businessPath, before, 
   providerBindingPaths(event).forEach((path) => {
     expect(admin.__get(path)).toBeUndefined();
   });
+}
+
+function refundAdmissionObservation({ response, event, businessSnapshots = [] }) {
+  const responseBody = response.json.mock.calls.at(-1)?.[0];
+  const ledger = admin.__get(`stripeEvents/${event.id}`);
+  return {
+    httpStatus: response.status.mock.calls.at(-1)?.[0] ?? null,
+    response: responseBody ? {
+      received: responseBody.received,
+      duplicate: responseBody.duplicate,
+      outcome: responseBody.outcome,
+      requiresReview: responseBody.requiresReview,
+    } : null,
+    businessUnchanged: businessSnapshots.every(([path, before]) => (
+      JSON.stringify(admin.__get(path)) === JSON.stringify(before)
+    )),
+    ledger: ledger ? {
+      status: ledger.status,
+      outcome: ledger.outcome,
+      requiresReview: ledger.requiresReview,
+      targetType: ledger.targetType,
+      targetPath: ledger.targetPath,
+      targetSource: ledger.targetSource,
+    } : null,
+    bindingPaths: providerBindingPaths(event).filter(
+      (path) => admin.__get(path) !== undefined,
+    ),
+  };
+}
+
+function expectedChargeStatusQuarantine(bindingPaths = []) {
+  return {
+    httpStatus: null,
+    response: {
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:charge_status_mismatch',
+      requiresReview: true,
+    },
+    businessUnchanged: true,
+    ledger: {
+      status: 'processed',
+      outcome: 'needs_review:charge_status_mismatch',
+      requiresReview: true,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    },
+    bindingPaths,
+  };
 }
 
 describe('stripeWebhook', () => {
@@ -1060,6 +1129,477 @@ describe('stripeWebhook', () => {
       });
     },
   );
+
+  test.each(INVALID_REFUND_CHARGE_STATUS_CASES)(
+    'PAY-003A5 quarantines a refund Charge with %s status evidence',
+    async (label, mutation, value) => {
+      seedOrder({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: 'pi_order_1',
+        stripeAmountTotalCents: 2000,
+      });
+      const businessPath = 'orders/order-1';
+      const before = storedCopy(businessPath);
+      const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const event = stripeEvent(
+        `evt_charge_status_${slug}`,
+        'charge.refunded',
+        orderRefundCharge({ id: `ch_charge_status_${slug}` }),
+      );
+      setRefundChargeStatus(event.data.object, mutation, value);
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedChargeStatusQuarantine());
+      expect(consoleError.mock.calls).toEqual([[
+        'Stripe event requires review',
+        {
+          eventId: event.id,
+          eventType: 'charge.refunded',
+          outcome: 'needs_review:charge_status_mismatch',
+          targetType: null,
+        },
+      ]]);
+    },
+  );
+
+  test.each([
+    [
+      'metadata-only claim',
+      {},
+      { stripePaymentIntentId: 'pi_order_1' },
+    ],
+    [
+      'client-reference-only claim',
+      {
+        metadata: { schemaVersion: '1' },
+        client_reference_id: 'mprc:order:order-1',
+      },
+      {},
+    ],
+    [
+      'matching dual claim',
+      { client_reference_id: 'mprc:order:order-1' },
+      {},
+    ],
+    [
+      'legacy PaymentIntent fallback',
+      { metadata: {} },
+      { stripePaymentIntentId: 'pi_order_1' },
+    ],
+    [
+      'legacy Charge fallback',
+      {
+        metadata: {},
+        payment_intent: 'pi_status_unowned',
+      },
+      {
+        stripePaymentIntentId: null,
+        stripeChargeId: 'ch_status_route_legacy_charge_fallback',
+      },
+    ],
+  ])('PAY-003A5 blocks a pending Charge on the %s path', async (
+    label,
+    chargePatch,
+    recordPatch,
+  ) => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripeAmountTotalCents: 2000,
+      ...recordPatch,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const event = stripeEvent(
+      `evt_charge_status_route_${slug}`,
+      'charge.refunded',
+      orderRefundCharge({
+        id: `ch_status_route_${slug}`,
+        status: 'pending',
+        ...chargePatch,
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedChargeStatusQuarantine());
+  });
+
+  test('PAY-003A5 blocks a pending unmatched refund before target handling', async () => {
+    const event = stripeEvent(
+      'evt_charge_status_unmatched',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_unmatched',
+        payment_intent: 'pi_charge_status_unmatched',
+        metadata: {},
+        status: 'pending',
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedChargeStatusQuarantine());
+  });
+
+  test('PAY-003A5 blocks an invalid Charge before ambiguous fallback queries', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_charge_status_ambiguous',
+      stripeAmountTotalCents: 2000,
+    });
+    seedRegistration({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_charge_status_ambiguous',
+      stripeAmountTotalCents: 5000,
+    });
+    const snapshots = [
+      ['orders/order-1', storedCopy('orders/order-1')],
+      [
+        'events/race-1/registrations/reg-1',
+        storedCopy('events/race-1/registrations/reg-1'),
+      ],
+    ];
+    const event = stripeEvent(
+      'evt_charge_status_ambiguous',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_ambiguous',
+        payment_intent: 'pi_charge_status_ambiguous',
+        metadata: {},
+        status: 'pending',
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: snapshots,
+    })).toEqual(expectedChargeStatusQuarantine());
+  });
+
+  test('PAY-003A5 blocks invalid status before provider-binding conflict reads', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_charge_status_binding',
+      stripeAmountTotalCents: 2000,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const chargeBindingPath = 'stripeObjectBindings/charge:ch_charge_status_binding';
+    admin.__seed(chargeBindingPath, {
+      providerObjectType: 'charge',
+      providerObjectId: 'ch_charge_status_binding',
+      targetType: 'registration',
+      targetPath: 'events/other/registrations/other',
+      firstEventId: 'evt_other',
+    });
+    const beforeBinding = storedCopy(chargeBindingPath);
+    const event = stripeEvent(
+      'evt_charge_status_binding_conflict',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_binding',
+        payment_intent: 'pi_charge_status_binding',
+        status: 'pending',
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedChargeStatusQuarantine([chargeBindingPath]));
+    expect(admin.__get(chargeBindingPath)).toEqual(beforeBinding);
+    expect(admin.__get(
+      'stripeObjectBindings/payment_intent:pi_charge_status_binding',
+    )).toBeUndefined();
+  });
+
+  test.each([
+    [
+      'outer Event realm',
+      'livemode_mismatch',
+      (event) => { event.livemode = true; },
+    ],
+    [
+      'embedded Charge realm',
+      'charge_livemode_mismatch',
+      (event) => { event.data.object.livemode = true; },
+    ],
+    [
+      'metadata schema',
+      'charge_status_mismatch',
+      (event) => { setMetadataSchema(event.data.object, '2'); },
+    ],
+    [
+      'malformed reference',
+      'charge_status_mismatch',
+      (event) => {
+        Object.assign(event.data.object.metadata, {
+          eventId: 'race-1',
+          registrationId: 'reg-1',
+        });
+      },
+    ],
+  ])('PAY-003A5 keeps %s precedence at the Charge-status boundary', async (
+    _label,
+    reason,
+    mutate,
+  ) => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_order_1',
+      stripeAmountTotalCents: 2000,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      `evt_charge_status_precedence_${reason}`,
+      'charge.refunded',
+      orderRefundCharge({
+        id: `ch_charge_status_precedence_${reason}`,
+        status: 'pending',
+      }),
+    );
+    mutate(event);
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({ response, event, businessPath, before, reason });
+  });
+
+  test('PAY-003A5 processes invalid status before a claimed missing target', async () => {
+    const event = stripeEvent(
+      'evt_charge_status_invalid_missing_target',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_invalid_missing_target',
+        payment_intent: 'pi_charge_status_invalid_missing_target',
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-missing',
+        },
+        status: 'pending',
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedChargeStatusQuarantine());
+  });
+
+  test('PAY-003A5 keeps exact-succeeded missing targets retryable', async () => {
+    const event = stripeEvent(
+      'evt_charge_status_succeeded_missing_target',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_succeeded_missing_target',
+        payment_intent: 'pi_charge_status_succeeded_missing_target',
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-missing',
+        },
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(admin.__get(`stripeEvents/${event.id}`)).toBeUndefined();
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
+    });
+  });
+
+  test('PAY-003A5 deduplicates rejected status without mutation or bindings', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_order_1',
+      stripeAmountTotalCents: 2000,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_charge_status_replay',
+      'charge.refunded',
+      orderRefundCharge({ id: 'ch_charge_status_replay', status: 'pending' }),
+    );
+
+    const firstResponse = await deliver(event);
+    const replayResponse = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response: firstResponse,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedChargeStatusQuarantine());
+    expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'needs_review:charge_status_mismatch',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+  });
+
+  test('PAY-003A5 preserves an already-processed Event before status admission', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_order_1',
+      stripeAmountTotalCents: 2000,
+    });
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_charge_status_already_processed',
+      'charge.refunded',
+      orderRefundCharge({ status: 'pending' }),
+    );
+    const ledgerPath = `stripeEvents/${event.id}`;
+    admin.__seed(ledgerPath, {
+      status: 'processed',
+      outcome: 'legacy_processed_outcome',
+      targetPath: 'orders/legacy-target',
+      sentinel: { preserve: true },
+    });
+    const beforeLedger = storedCopy(ledgerPath);
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'legacy_processed_outcome',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+    expect(admin.__get(ledgerPath)).toEqual(beforeLedger);
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
+    });
+  });
+
+  test('PAY-003A5 admits an exact-succeeded metadata refund Charge', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_order_1',
+      stripeAmountTotalCents: 2000,
+    });
+    const event = stripeEvent(
+      'evt_charge_status_succeeded_metadata',
+      'charge.refunded',
+      orderRefundCharge({ id: 'ch_charge_status_succeeded_metadata' }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'partially_refunded',
+    }));
+    expect(admin.__get('orders/order-1')).toMatchObject({
+      paymentStatus: 'partially_refunded',
+      stripeChargeId: 'ch_charge_status_succeeded_metadata',
+    });
+  });
+
+  test.each([
+    [
+      'PaymentIntent',
+      { metadata: {} },
+      { stripePaymentIntentId: 'pi_order_1' },
+      'payment_intent_query',
+    ],
+    [
+      'Charge',
+      { metadata: {}, payment_intent: 'pi_status_positive_unowned' },
+      { stripeChargeId: 'ch_charge_status_positive_charge' },
+      'charge_query',
+    ],
+  ])('PAY-003A5 admits exact-succeeded legacy %s fallback', async (
+    label,
+    chargePatch,
+    recordPatch,
+    targetSource,
+  ) => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripeAmountTotalCents: 2000,
+      ...recordPatch,
+    });
+    const slug = label.toLowerCase();
+    const event = stripeEvent(
+      `evt_charge_status_positive_${slug}`,
+      'charge.refunded',
+      orderRefundCharge({
+        id: `ch_charge_status_positive_${slug}`,
+        ...chargePatch,
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'partially_refunded',
+    }));
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      targetSource,
+      targetPath: 'orders/order-1',
+    });
+  });
+
+  test('PAY-003A5 keeps an exact-succeeded unmatched refund in review', async () => {
+    const event = stripeEvent(
+      'evt_charge_status_succeeded_unmatched',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_charge_status_succeeded_unmatched',
+        payment_intent: 'pi_charge_status_succeeded_unmatched',
+        metadata: {},
+      }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:unmatched_refund',
+      requiresReview: true,
+    }));
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    });
+  });
 
   test.each(DISPUTE_REALM_CASES)(
     'quarantines a %s Dispute with %s embedded livemode evidence',


### PR DESCRIPTION
## Outcome

Rejects incompatible embedded Charge lifecycle evidence before any refund target resolution or financial-state mutation.

- Requires exact primitive `Charge.status === "succeeded"` for every signed `charge.refunded` Event after the outer/embedded realm checks.
- Records fixed `needs_review:charge_status_mismatch` with null target attribution, no business mutation, and no new Charge/PaymentIntent binding for missing, contradictory, or malformed status evidence.
- Preserves processed-ledger precedence, deterministic replay, valid metadata/client-reference and legacy PaymentIntent/Charge lookup behavior, and every later money/state check.
- Documents the current boundary, Mermaid/text alternative, API-version residual, and separated evidence states.

Closes #542
Parent: #106

## Invariant and transitions

Admission order is: processed-ledger replay → signed/configured Event → outer Event realm → embedded Charge realm → exact Charge status → metadata/reference → target/ownership/binding → money/state. An invalid Charge status has one allowed transition: a processed, review-required Event ledger with fixed reason and null target fields. Exact `succeeded` is only compatible evidence that permits the existing checks; it does not prove a refund succeeded, settled, has the correct amount, or belongs to the local record.

Failure cases cover missing, null, pending, failed, empty/unknown string, number, boolean, object, and array evidence; direct and dual claims; legacy PaymentIntent and Charge record-field queries; unmatched and ambiguous targets; existing binding conflict; realm/schema/reference precedence; missing target; replay; and hostile log evidence.

Migration impact: none. No historical reprocessing, schema migration, provider retrieval, endpoint API-version selection, or live configuration is included.

## Verification

Node 20.20.2 / Java 21 where applicable:

- Trustworthy RED: 22 failed / 8 passed on the claimed base.
- PAY-003A5 focused: 30/30 passed.
- Full webhook: 270/270 passed.
- Functions lint: passed.
- Full Functions: 69 suites; 6,673 passed; 2 suites / 64 tests intentionally skipped.
- Frontend Jest: 940/940 passed.
- SPA callback safety: 11/11 passed.
- Workflow/static safety: 80/80 passed.
- Frontend lint baseline: exact 118 files / 113 reviewed legacy errors / 6 reviewed warnings.
- Diagnostic production build: compiled successfully without sitemap generation.
- Firestore Rules emulator (`demo-rules-test`): 418/418 passed.
- Commerce journal emulator (`demo-pay002b2-test`): 63/63 passed.
- `git diff --check`: passed.
- Independent final payment/security, lifecycle/test, and backup-officer/documentation reviews: GO.

## Handoff

Officer impact: None — commerce remains unavailable and no officer screen, procedure, permission, provider task, or live behavior changes.

Officer documentation: None — engineering current truth, diagram/text alternative, API-version residual, and evidence boundary are updated in `STRIPE_COMMERCE_DESIGN.md`.

Deployment evidence: Source changed and synthetic/local tests passed. Code is not merged at PR creation. No website was published; `runmprc.com` was not checked; Firebase was not deployed; Stripe/provider configuration or retrieval was not performed; and no payment, refund, production-data change, or live behavior was exercised or verified.