### PR TITLE
OAUTH-001A2G — Redact Strava statistics connection read failures

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -1006,11 +1006,20 @@ exports.stravaFetchStats = functions
     }
     const { uid } = context.auth;
 
-    const connSnap = await connectionDocRef(uid).get();
-    if (!connSnap.exists) {
+    let connectionExists = false;
+    let conn = null;
+    try {
+      const connSnap = await connectionDocRef(uid).get();
+      connectionExists = connSnap.exists;
+      if (connectionExists) {
+        conn = snapshotStoredConnection(connSnap.data());
+      }
+    } catch (_error) {
+      throw stravaDataError('unavailable');
+    }
+    if (!connectionExists) {
       throw new functions.https.HttpsError('failed-precondition', 'Strava not connected');
     }
-    const conn = snapshotStoredConnection(connSnap.data());
     if (!conn) {
       throw stravaDataError('internal');
     }

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -2542,6 +2542,107 @@ describe('Strava token refresh failure boundary', () => {
     expectNoWritesOrLogs();
   });
 
+  describe('OAUTH-001A2G statistics connection-record read boundary', () => {
+    function hostileReadFailure() {
+      const probes = [
+        jest.fn(() => {
+          throw new Error('connection-read-cause-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('connection-read-details-getter-canary');
+        }),
+        jest.fn(() => {
+          throw new Error('connection-read-json-getter-canary');
+        }),
+      ];
+      const failure = new Error(
+        'connection-read-canary uid=synthetic-member path=members/private token=synthetic-token',
+      );
+      Object.defineProperties(failure, {
+        cause: { configurable: true, enumerable: true, get: probes[0] },
+        details: { configurable: true, enumerable: true, get: probes[1] },
+        toJSON: { configurable: true, enumerable: true, get: probes[2] },
+      });
+      return { failure, probes };
+    }
+
+    function expectFixedReadFailure(rejection, probes) {
+      const exposed = publicError(rejection);
+      expect(exposed).toEqual({
+        code: 'unavailable',
+        message: FIXED_DATA_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify({ exposed, logs: consoleSpies.map((spy) => spy.mock.calls) }))
+        .not.toMatch(
+          /connection-read-canary|synthetic-member|members\/private|synthetic-token|getter-canary/i,
+        );
+      probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+      expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH]);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(admin.__getBatchCreateAttempts()).toBe(0);
+      expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+      expect(admin.__getBatchDeletes()).toEqual([]);
+      expect(admin.__getBatchSetAttempts()).toEqual([]);
+      expect(admin.__getBatchCommitAttempts()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__getDirectSetAttempts()).toEqual([]);
+      expect(admin.__getTransactionRunAttempts()).toBe(0);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__hasDocument(CONNECTION_PATH)).toBe(true);
+      expect(admin.__hasDocument(SECRET_PATH)).toBe(true);
+      expect(dateNowSpy).not.toHaveBeenCalled();
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    }
+
+    test('maps a rejected connection read to one fixed result before secret work', async () => {
+      const { failure, probes } = hostileReadFailure();
+      seedExpiredConnection();
+      admin.__setReadFailure(CONNECTION_PATH, failure);
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+    });
+
+    test('maps a throwing snapshot exists value to the fixed read boundary', async () => {
+      const { failure, probes } = hostileReadFailure();
+      const exists = jest.fn(() => {
+        throw failure;
+      });
+      const snapshot = {};
+      Object.defineProperty(snapshot, 'exists', {
+        configurable: true,
+        enumerable: true,
+        get: exists,
+      });
+      seedExpiredConnection();
+      admin.__setReadSnapshot(CONNECTION_PATH, snapshot);
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+      expect(exists).toHaveBeenCalledTimes(1);
+    });
+
+    test('maps a throwing snapshot data method to the fixed read boundary', async () => {
+      const { failure, probes } = hostileReadFailure();
+      const data = jest.fn(() => {
+        throw failure;
+      });
+      seedExpiredConnection();
+      admin.__setReadSnapshot(CONNECTION_PATH, { exists: true, data });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expectFixedReadFailure(rejection, probes);
+      expect(data).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test('stops when the Strava connection record is missing', async () => {
     await expect(stravaFetchStats({}, CONTEXT)).rejects.toMatchObject({
       code: 'failed-precondition',


### PR DESCRIPTION
## Outcome

Strava statistics now fail with one fixed, non-identifying message when the lower-sensitivity connection record cannot be read safely. The raw storage failure is discarded before the server reads OAuth secrets, calls Strava, reads the clock, writes, deletes, starts a batch/transaction, or logs.

Known missing connections still return `Strava not connected`. Known malformed records still return the existing fixed internal result. Valid behavior is unchanged.

Closes #549

## Scope and invariant

- Exact reviewed base: `806b148cb95e017161323880ff2fca8fa956ed7b`
- Exact reviewed head: `2a143b68cac1d9f15471d69cfd1ed87eb8d80515`
- Exact two-file diff SHA-256: `2cdb478ed138a674acab70e18dc9946541d610306be00d32242a364b3f6a9665`
- Changed only `functions/strava.js` and `functions/strava.test.js`.
- Preserved released #544 dependency/SECURITY paths byte-for-byte.

## Verification

Pinned Node 20.20.2 after a clean Functions lockfile install:

- RED before runtime fix: 3/3 intended focused cases failed by exposing/touching the hostile synthetic error.
- Focused OAUTH-001A2G: 3/3 passed.
- Full Strava: 661/661 passed.
- SUPPLY-001D14 preservation: 5/5 passed.
- Full Functions: 6,684 passed; 64 intentionally skipped.
- Functions lint: passed.
- `git diff --check`: passed.
- Three independent exact-head security/scope/test reviews: GO, no findings.

## Safety and compatibility

- No caught error value is inspected, serialized, or logged.
- No production identifiers, tokens, or records were used.
- No schema or migration change.
- No browser, Rules, package, workflow, provider, or documentation change.

Officer impact: None. This is a server-only privacy boundary; it does not change an officer task or available screen.

Officer documentation: None — no officer procedure, page structure, data movement, account ownership, or deployment process changes.

Deployment evidence: Source and tests only. Website not published or verified; Firebase Functions not deployed; Strava/provider configuration not changed; production behavior not verified. Hosted exact-head CI is required before merge, followed by exact-main CI and deployment-truth audit.