### PR TITLE
OAUTH-001A1F: fail closed on invalid Strava refresh clocks

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -225,7 +225,9 @@ function requireStravaAuthSession(context) {
 function currentEpochSeconds() {
   let nowSeconds;
   try {
-    nowSeconds = Math.floor(Date.now() / 1_000);
+    const nowMilliseconds = Date.now();
+    if (!isPositiveSafeInteger(nowMilliseconds)) return null;
+    nowSeconds = Math.floor(nowMilliseconds / 1_000);
   } catch (_error) {
     return null;
   }
@@ -891,7 +893,8 @@ async function getFreshAccessToken(uid) {
   if (!stored) {
     throw stravaRefreshError('internal');
   }
-  const nowSec = Math.floor(Date.now() / 1000);
+  const nowSec = currentEpochSeconds();
+  if (nowSec === null) throw stravaRefreshError('internal');
   if (stored.expiresAt - nowSec > 60) {
     return stored.accessToken;
   }

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -2791,6 +2791,175 @@ describe('Strava token refresh failure boundary', () => {
     });
   });
 
+  describe('OAUTH-001A1F refresh freshness-clock boundary', () => {
+    function expectNoPostClockWork() {
+      expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(admin.__getBatchCreateAttempts()).toBe(0);
+      expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+      expect(admin.__getBatchDeletes()).toEqual([]);
+      expect(admin.__getBatchSetAttempts()).toEqual([]);
+      expect(admin.__getBatchCommitAttempts()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__getDirectSetAttempts()).toEqual([]);
+      expect(admin.__getTransactionRunAttempts()).toBe(0);
+      expect(admin.__getTransactionReads()).toEqual([]);
+      expect(admin.__getTransactionDeleteAttempts()).toEqual([]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDocument(CONNECTION_PATH)).toBe(CONNECTION);
+      expect(admin.__getDocument(SECRET_PATH)).toBe(EXPIRED_SECRET);
+      expect(dateNowSpy).toHaveBeenCalledTimes(1);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    }
+
+    async function expectInvalidClock(value) {
+      seedExpiredConnection();
+      dateNowSpy.mockReturnValueOnce(value);
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expect(publicError(rejection)).toEqual({
+        code: 'internal',
+        message: FIXED_REFRESH_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expectNoPostClockWork();
+    }
+
+    test('discards a hostile thrown clock value without reading or exposing it', async () => {
+      const failure = Object.create(null);
+      const probes = ['cause', 'code', 'details', 'message', 'stack', 'toJSON', 'toString']
+        .map((field) => {
+          const probe = jest.fn(() => {
+            throw new Error(`refresh-clock-${field}-getter-canary`);
+          });
+          Object.defineProperty(failure, field, {
+            configurable: false,
+            enumerable: true,
+            get: probe,
+          });
+          return probe;
+        });
+      seedExpiredConnection();
+      dateNowSpy.mockImplementationOnce(() => {
+        throw failure;
+      });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      if (rejection === failure) {
+        throw new Error('Raw hostile refresh-clock failure escaped the fixed boundary.');
+      }
+      const exposed = publicError(rejection);
+      expect(exposed).toEqual({
+        code: 'internal',
+        message: FIXED_REFRESH_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify({ exposed, logs: consoleSpies.map((spy) => spy.mock.calls) }))
+        .not.toMatch(/refresh-clock|getter-canary/i);
+      probes.forEach((probe) => expect(probe).not.toHaveBeenCalled());
+      expectNoPostClockWork();
+    });
+
+    test('maps a clock-projection failure to the same fixed boundary', async () => {
+      seedExpiredConnection();
+      const floorSpy = jest.spyOn(Math, 'floor').mockImplementationOnce(() => {
+        throw new Error('refresh-clock-floor-canary');
+      });
+      let rejection;
+      try {
+        rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+      } finally {
+        floorSpy.mockRestore();
+      }
+
+      const exposed = publicError(rejection);
+      expect(exposed).toEqual({
+        code: 'internal',
+        message: FIXED_REFRESH_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify({ exposed, logs: consoleSpies.map((spy) => spy.mock.calls) }))
+        .not.toMatch(/refresh-clock-floor-canary/i);
+      expectNoPostClockWork();
+    });
+
+    test.each([
+      ['not-a-number', Number.NaN],
+      ['positive infinity', Number.POSITIVE_INFINITY],
+      ['negative infinity', Number.NEGATIVE_INFINITY],
+      ['zero', 0],
+      ['a negative value', -1],
+      ['a fractional millisecond', (NOW_SECONDS * 1_000) + 0.5],
+      ['an unsafe millisecond integer', Number.MAX_SAFE_INTEGER + 1],
+      ['a numeric string', String(NOW_SECONDS * 1_000)],
+      ['a boxed number', Object(NOW_SECONDS * 1_000)],
+      ['a bigint', 1n],
+      ['a symbol', Symbol('refresh-clock-canary')],
+    ])('rejects %s before provider or persistence work', async (_case, value) => {
+      await expectInvalidClock(value);
+    });
+
+    test('rejects an invalid clock before application credentials are required', async () => {
+      delete process.env.STRAVA_CLIENT_ID;
+      delete process.env.STRAVA_CLIENT_SECRET;
+
+      await expectInvalidClock(Number.NaN);
+    });
+
+    test('rejects a coercible clock object without invoking its hooks', async () => {
+      const hooks = {
+        toString: jest.fn(() => String(NOW_SECONDS * 1_000)),
+        valueOf: jest.fn(() => NOW_SECONDS * 1_000),
+        [Symbol.toPrimitive]: jest.fn(() => NOW_SECONDS * 1_000),
+      };
+
+      await expectInvalidClock(hooks);
+
+      expect(hooks.toString).not.toHaveBeenCalled();
+      expect(hooks.valueOf).not.toHaveBeenCalled();
+      expect(hooks[Symbol.toPrimitive]).not.toHaveBeenCalled();
+    });
+
+    test('rejects a clock Proxy without invoking any trap', async () => {
+      const traps = {
+        get: jest.fn(() => {
+          throw new Error('refresh-clock-proxy-get-canary');
+        }),
+        getOwnPropertyDescriptor: jest.fn(() => {
+          throw new Error('refresh-clock-proxy-descriptor-canary');
+        }),
+        getPrototypeOf: jest.fn(() => {
+          throw new Error('refresh-clock-proxy-prototype-canary');
+        }),
+        has: jest.fn(() => {
+          throw new Error('refresh-clock-proxy-has-canary');
+        }),
+        ownKeys: jest.fn(() => {
+          throw new Error('refresh-clock-proxy-ownKeys-canary');
+        }),
+      };
+      const value = new Proxy(Object(NOW_SECONDS * 1_000), traps);
+
+      await expectInvalidClock(value);
+
+      Object.values(traps).forEach((trap) => expect(trap).not.toHaveBeenCalled());
+    });
+
+    test('rejects a revoked clock Proxy without reflection', async () => {
+      const { proxy, revoke } = Proxy.revocable(Object(NOW_SECONDS * 1_000), {});
+      revoke();
+
+      await expectInvalidClock(proxy);
+    });
+  });
+
   describe('OAUTH-001A1E refreshed-secret persistence boundary', () => {
     function hostilePersistenceFailure() {
       const probes = [


### PR DESCRIPTION
## Outcome

Fail closed when the Strava refresh freshness decision cannot obtain one strict server-clock value.

The shared clock projection now rejects non-number, fractional, non-finite, non-positive, unsafe, boxed, coercible, and proxied values before arithmetic. `getFreshAccessToken()` uses that projection and returns the existing fixed internal refresh error before credentials, provider traffic, timestamps, persistence, or bearer use when time is unknown.

Fixes #559. Atomic child of #88.

## Security invariant

- Sample `Date.now()` once.
- Accept only a primitive positive safe-integer millisecond value before projecting seconds.
- Keep acquisition and projection failures inside the fixed catch.
- Preserve native OAuth-state timing and the exact refresh boundary: 60 seconds refreshes; 61 seconds reuses the validated stored token.
- Invalid clock: fixed `internal / Strava connection could not be refreshed.`, two required reads only, no caught-value access/logging, credentials, Strava request, `Timestamp.now()`, Firestore mutation, or downstream bearer request.

## Exact scope

- `functions/strava.js`: `currentEpochSeconds()` primitive clock admission and `getFreshAccessToken()` freshness-clock use only.
- `functions/strava.test.js`: separately named OAUTH-001A1F block only.

No schema, data migration, endpoint/export, Rules/index, package, workflow, browser, documentation, provider configuration, or deployment change.

## Verification

- Trustworthy RED on untouched runtime: 15/15 then-current named tests failed for raw escape, later provider behavior, or expired-token bearer use.
- Final focused block: 17/17.
- Full Strava: 682/682.
- Functions lint: passed.
- Full Functions fresh no-cache: 6,776 passed; 64 intended skips.
- Frontend Jest: 940/940.
- Frontend lint ledger: 118 files / 113 reviewed legacy errors / 6 warnings.
- SPA callback: 11/11.
- Workflow/release/artifact/dependency safety: 82/82.
- Diagnostic production build: passed.
- `git diff --check`: passed.
- Three independent final reviews: GO (security, tests, scope/compatibility).

Exact reviewed head: `2b9228c65ae279e4a3f055afd2b1e8ecf9973a13`  
Exact tree: `873529eac602400c19468a15a2edf92108184055`  
Exact two-file diff SHA-256: `d3293c1abe47dc88871fe2ead0eb09aef25a739be0efa5af0868138e0d81f4c4`

## Compatibility and residual risk

No migration. Native valid clock behavior is unchanged. #88 remains open for clock-health monitoring, refresh concurrency/versioning and reconciliation, durable audit, IAM/encryption, scope/governance, provider configuration, protected Firebase deployment, and live verification.

## Officer impact

None — internal server failure admission only.

## Officer documentation

None — no officer task, screen, field, permission, data flow, or topology changed.

## Deployment evidence

Source/test only at PR creation. Website publication and `runmprc.com` verification: not performed. Firebase deployment: not performed. Strava/provider configuration or call: not performed. Production data/migration: not performed. Live behavior: not verified.
