### PR TITLE
PAY-003A7: reject invalid Dispute Event timestamps before target work

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -786,6 +786,31 @@ This admission check proves only that the source accepts an existing Event/statu
 
 PAY-003A6 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, a dispute or payment performed, production data changed, and live behavior verified. Source and synthetic tests do not prove any later state. This child performs no website publication, Firebase deployment, provider configuration or retrieval, dispute/payment, production-data action, or live verification.
 
+### PAY-003A7 Dispute Event-created admission — SOURCE ONLY, NOT LIVE
+
+PAY-003A7 [#561](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/561) adds one universal Event-time check for the three supported Dispute Event types. Its purpose is to reject unusable `event.created` evidence before any business target or provider binding is read. After the existing processed-Event replay check, a new Event keeps the outer Event realm, embedded Dispute realm, Event/status compatibility, and explicit metadata-version checks in that order. Its `created` value must then be a primitive safe integer from Unix epoch second `0` through the Firestore Timestamp maximum `253402300799`, inclusive.
+
+Missing, `null`, boolean, string, object, array, fractional, `NaN`, infinite, negative, unsafe, or above-range values receive the fixed `needs_review:invalid_event_created` processed-ledger result. The ledger has null target fields and a null `stripeCreatedAt`. If an earlier admission check owns the review result, the unusable Dispute time is still projected as null instead of being passed to Firestore Timestamp construction. The handler does not run reference or target queries, read or change a business record, or read or create Dispute, Charge, or PaymentIntent bindings. The fixed redacted log names only the reason and Event identifiers; it does not include the rejected value. An exact rejected replay is read-only and returns the stored result. An admissible claimed Event whose target is absent keeps the existing retryable behavior and writes no processed ledger.
+
+```mermaid
+flowchart TD
+    A["Signed supported Dispute Event"] --> B{"Already in the processed-Event ledger?"}
+    B -- "Yes" --> C["Return the stored result without changes"]
+    B -- "No" --> D{"Realm, Event/status, and metadata version compatible?"}
+    D -- "No" --> E["Record the earlier fixed review result"]
+    D -- "Yes" --> F{"Event-created is an integer from 0 through 253402300799?"}
+    F -- "No" --> G["Record invalid-time review with no target"]
+    F -- "Yes" --> H["Continue reference, target, binding, money, and state checks"]
+```
+
+Text alternative: after replay and the earlier realm, status, and metadata-version checks, a supported Dispute Event must carry a Firestore-representable whole Unix timestamp; unusable time evidence is recorded for review without resolving a target, while valid evidence proceeds to the remaining checks.
+
+Verification for this source-only child requires separately named synthetic tests for all three Dispute lifecycles, hostile shapes and bounds, admission precedence, target and binding isolation, redacted logging, replay, valid lower and upper boundaries, and valid missing-target retry. Review must also confirm that the later redundant predicate is removed, non-Dispute admission is unchanged, and no schema, migration, package, Rule, workflow, provider, or deployment surface changed. The expected result is a target-free processed review for invalid time evidence and unchanged behavior for valid representable values.
+
+Residual work remains explicit. This check does not compare an Event time with the current clock, establish provider truth, select or verify a Stripe endpoint API version, retrieve a provider object, inspect or repair history, migrate stored data, change non-Dispute Event admission, or complete PAY-003B or PAY-003C. If a focused or full check shows target access, business mutation, binding activity, hostile-value logging, a precedence change, or a valid-boundary regression, stop the merge and escalate to the platform owner and payment reviewer. Undo is a small reviewed revert of the PAY-003A7 source, tests, and this named design section; do not edit production records or provider objects as an undo path.
+
+PAY-003A7 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, a dispute or payment performed, production data changed, and live behavior verified. Source and synthetic tests do not prove any later state. This child performs no website publication, Firebase deployment, provider configuration or retrieval, dispute/payment, production-data action, or live verification. Officer impact and officer documentation are both none: this is a server-only admission boundary with no new officer screen, task, field, permission, approval, or available recovery step.
+
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
 ## 12. Payment and business state machines

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -14,6 +14,7 @@ const {
 } = require('./serverConfig');
 
 const LEDGER_RETENTION_DAYS = 90;
+const FIRESTORE_TIMESTAMP_MAX_SECONDS = 253_402_300_799;
 const CHECKOUT_EVENT_TYPES = new Set([
   'checkout.session.completed',
   'checkout.session.async_payment_succeeded',
@@ -32,6 +33,13 @@ const DISPUTE_EVENT_TYPES = new Set([
   'charge.dispute.updated',
   'charge.dispute.closed',
 ]);
+
+function isValidDisputeEventCreated(value) {
+  return Number.isSafeInteger(value)
+    && value >= 0
+    && value <= FIRESTORE_TIMESTAMP_MAX_SECONDS;
+}
+
 const DISPUTE_TERMINAL_STATUSES = new Set(['won', 'lost', 'warning_closed']);
 const DISPUTE_STATUSES = new Set([
   'needs_response',
@@ -157,6 +165,14 @@ function validateEventAdmission(event, expectedLivemode) {
   }
   const schemaValidation = validateMetadataSchemaVersion(event, expectedLivemode);
   if (!schemaValidation.ok) return schemaValidation;
+  if (DISPUTE_EVENT_TYPES.has(event.type)
+    && !isValidDisputeEventCreated(event.created)) {
+    return {
+      ok: false,
+      expected: expectedLivemode,
+      reason: 'invalid_event_created',
+    };
+  }
   return modeValidation;
 }
 
@@ -1216,9 +1232,6 @@ function disputeTransition({ event, dispute, target, record }) {
   if (!isCompatibleDisputeStatus(event.type, disputeStatus)) {
     return reviewTransition({ target, event, reason: 'invalid_dispute_status' });
   }
-  if (!Number.isSafeInteger(event.created) || event.created < 0) {
-    return reviewTransition({ target, event, reason: 'invalid_event_created' });
-  }
   const existingDisputes = record.stripeDisputes || {};
   const eventCreated = event.created;
   const existingEventCreated = nonNegativeInteger(existingDispute?.lastEventCreated);
@@ -1389,12 +1402,15 @@ function providerBindingCanBeRecorded(event, record, result) {
 
 function ledgerData(event, target, result, ownership) {
   const now = Date.now();
+  const unusableDisputeEventCreated = DISPUTE_EVENT_TYPES.has(event.type)
+    && !isValidDisputeEventCreated(event.created);
   return {
     eventId: event.id,
     type: event.type,
     objectId: objectId(event.data?.object) || null,
     livemode: event.livemode === true,
-    stripeCreatedAt: Number.isSafeInteger(event.created)
+    stripeCreatedAt: !unusableDisputeEventCreated
+      && Number.isSafeInteger(event.created)
       ? Timestamp.fromMillis(event.created * 1000)
       : null,
     status: 'processed',

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -2,6 +2,7 @@ const { createSignedStripePayload } = require('./testSupport/testSafety');
 
 jest.mock('firebase-admin', () => {
   const store = new Map();
+  const readOperations = [];
 
   const FieldValue = {
     arrayUnion: (...values) => ({ __op: 'arrayUnion', values }),
@@ -47,6 +48,7 @@ jest.mock('firebase-admin', () => {
     }
 
     async get() {
+      readOperations.push({ kind: 'document', path: this.path });
       return new FakeDocumentSnapshot(this);
     }
 
@@ -88,6 +90,11 @@ jest.mock('firebase-admin', () => {
     }
 
     async get() {
+      readOperations.push({
+        kind: 'query',
+        collectionPath: this.collectionPath,
+        collectionGroup: this.collectionGroup,
+      });
       let docs = Array.from(store.keys()).filter((path) => {
         const parts = path.split('/');
         if (this.collectionGroup) {
@@ -147,9 +154,13 @@ jest.mock('firebase-admin', () => {
     initializeApp: jest.fn(),
     apps: [{}],
     firestore: Object.assign(() => firestore, { FieldValue }),
-    __clear: () => store.clear(),
+    __clear: () => {
+      store.clear();
+      readOperations.length = 0;
+    },
     __seed: (path, data) => store.set(path, { ...data }),
     __get: (path) => store.get(path),
+    __readOperations: () => readOperations.map((operation) => ({ ...operation })),
   };
 });
 
@@ -176,13 +187,21 @@ jest.mock('firebase-admin/firestore', () => {
   return {
     Timestamp: {
       now: () => ({ _milliseconds: tick += 1 }),
-      fromMillis: (milliseconds) => ({ _milliseconds: milliseconds }),
+      fromMillis: jest.fn((milliseconds) => {
+        if (!Number.isFinite(milliseconds)
+          || milliseconds < -62_135_596_800_000
+          || milliseconds > 253_402_300_799_999) {
+          throw new RangeError('Timestamp milliseconds out of range');
+        }
+        return { _milliseconds: milliseconds };
+      }),
     },
     FieldValue: { arrayUnion: (...values) => ({ __op: 'arrayUnion', values }) },
   };
 });
 
 const admin = require('firebase-admin');
+const { Timestamp } = require('firebase-admin/firestore');
 
 const WEBHOOK_SECRET = 'stripe_webhook_synthetic_test_material';
 process.env.ENVIRONMENT_NAME = 'test';
@@ -302,6 +321,36 @@ const DISPUTE_METADATA_SCHEMA_CASES = [
     evidence,
     type,
     status,
+    value,
+  ])
+));
+const FIRESTORE_TIMESTAMP_MAX_SECONDS = 253_402_300_799;
+const INVALID_DISPUTE_EVENT_CREATED_CASES = [
+  ['missing', 'delete', undefined],
+  ['null', 'value', null],
+  ['negative', 'value', -1],
+  ['fractional', 'value', 1.5],
+  ['string', 'value', 'hostile-event-created-do-not-log'],
+  ['boolean', 'value', true],
+  ['object', 'value', { marker: 'hostile-event-created-do-not-log' }],
+  ['array', 'value', ['hostile-event-created-do-not-log']],
+  ['NaN serialized as null', 'value', Number.NaN],
+  ['infinity serialized as null', 'value', Number.POSITIVE_INFINITY],
+  ['Firestore maximum plus one', 'value', FIRESTORE_TIMESTAMP_MAX_SECONDS + 1],
+  ['maximum safe integer', 'value', Number.MAX_SAFE_INTEGER],
+  ['unsafe integer', 'value', Number.MAX_SAFE_INTEGER + 1],
+];
+const DISPUTE_EVENT_CREATED_CASES = [
+  ['created', 'charge.dispute.created', 'needs_response'],
+  ['updated', 'charge.dispute.updated', 'under_review'],
+  ['closed', 'charge.dispute.closed', 'won'],
+].flatMap(([lifecycle, type, status]) => (
+  INVALID_DISPUTE_EVENT_CREATED_CASES.map(([evidence, mutation, value]) => [
+    lifecycle,
+    evidence,
+    type,
+    status,
+    mutation,
     value,
   ])
 ));
@@ -498,6 +547,11 @@ function setDisputeStatus(dispute, mutation, value) {
   else dispute.status = value;
 }
 
+function setEventCreated(event, mutation, value) {
+  if (mutation === 'delete') delete event.created;
+  else event.created = value;
+}
+
 function providerBindingPaths(event) {
   const object = event.data.object;
   const descriptors = [];
@@ -612,6 +666,35 @@ function expectedDisputeStatusQuarantine(bindingPaths = []) {
   };
 }
 
+function expectedDisputeEventCreatedQuarantine(bindingPaths = []) {
+  return {
+    httpStatus: null,
+    response: {
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:invalid_event_created',
+      requiresReview: true,
+    },
+    businessUnchanged: true,
+    ledger: {
+      status: 'processed',
+      outcome: 'needs_review:invalid_event_created',
+      requiresReview: true,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    },
+    bindingPaths,
+  };
+}
+
+function expectOnlyEventLedgerReads(event) {
+  expect(admin.__readOperations()).toEqual([
+    { kind: 'document', path: `stripeEvents/${event.id}` },
+    { kind: 'document', path: `stripeEvents/${event.id}` },
+  ]);
+}
+
 function seedPaidDisputeOrder(overrides = {}) {
   seedOrder({
     status: 'paid',
@@ -632,6 +715,7 @@ describe('stripeWebhook', () => {
 
   beforeEach(() => {
     admin.__clear();
+    Timestamp.fromMillis.mockClear();
     delete process.env.COMMERCE_ENABLED;
     process.env.ENVIRONMENT_NAME = 'test';
     process.env.SITE_ORIGIN = 'https://runmprc.test';
@@ -2182,6 +2266,443 @@ describe('stripeWebhook', () => {
     expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
       targetSource,
       targetPath: 'orders/order-1',
+    });
+  });
+
+  test.each(DISPUTE_EVENT_CREATED_CASES)(
+    'PAY-003A7 quarantines a %s Dispute with %s Event-created evidence',
+    async (lifecycle, evidence, type, status, mutation, value) => {
+      seedPaidDisputeOrder();
+      const businessPath = 'orders/order-1';
+      const before = storedCopy(businessPath);
+      const slug = `${lifecycle}_${evidence}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const event = stripeEvent(
+        `evt_dispute_time_${slug}`,
+        type,
+        orderDispute({ id: `dp_dispute_time_${slug}`, status }),
+      );
+      setEventCreated(event, mutation, value);
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedDisputeEventCreatedQuarantine());
+      expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+        stripeCreatedAt: null,
+      });
+      expectOnlyEventLedgerReads(event);
+      if (Number.isSafeInteger(value)
+        && value > FIRESTORE_TIMESTAMP_MAX_SECONDS) {
+        expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(value * 1000);
+      }
+      expect(consoleError).toHaveBeenCalledWith(
+        'Stripe event requires review',
+        {
+          eventId: event.id,
+          eventType: type,
+          outcome: 'needs_review:invalid_event_created',
+          targetType: null,
+        },
+      );
+      expect(JSON.stringify(consoleError.mock.calls))
+        .not.toContain('hostile-event-created-do-not-log');
+    },
+  );
+
+  test.each([
+    ['metadata-only claim', {}, {}],
+    [
+      'client-reference-only claim',
+      {
+        metadata: { schemaVersion: '1' },
+        client_reference_id: 'mprc:order:order-1',
+      },
+      {},
+    ],
+    [
+      'matching dual claim',
+      { client_reference_id: 'mprc:order:order-1' },
+      {},
+    ],
+    [
+      'legacy PaymentIntent fallback',
+      { metadata: {} },
+      {},
+    ],
+    [
+      'legacy Charge fallback',
+      { metadata: {}, payment_intent: 'pi_dispute_time_unowned' },
+      { stripePaymentIntentId: null },
+    ],
+  ])('PAY-003A7 blocks invalid Event time on the %s path', async (
+    label,
+    disputePatch,
+    recordPatch,
+  ) => {
+    seedPaidDisputeOrder(recordPatch);
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const event = stripeEvent(
+      `evt_dispute_time_route_${slug}`,
+      'charge.dispute.updated',
+      orderDispute({
+        id: `dp_dispute_time_route_${slug}`,
+        status: 'under_review',
+        ...disputePatch,
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A7 blocks invalid Event time before unmatched target handling', async () => {
+    const event = stripeEvent(
+      'evt_dispute_time_unmatched',
+      'charge.dispute.updated',
+      orderDispute({
+        id: 'dp_dispute_time_unmatched',
+        charge: 'ch_dispute_time_unmatched',
+        payment_intent: 'pi_dispute_time_unmatched',
+        metadata: {},
+        status: 'under_review',
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedDisputeEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A7 processes invalid Event time before a claimed missing target', async () => {
+    const event = stripeEvent(
+      'evt_dispute_time_missing_target',
+      'charge.dispute.updated',
+      orderDispute({
+        id: 'dp_dispute_time_missing_target',
+        charge: 'ch_dispute_time_missing_target',
+        payment_intent: 'pi_dispute_time_missing_target',
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-missing',
+        },
+        status: 'under_review',
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedDisputeEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A7 blocks invalid Event time before ambiguous fallback queries', async () => {
+    seedPaidDisputeOrder({ stripePaymentIntentId: 'pi_dispute_time_ambiguous' });
+    seedRegistration({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_dispute_time_ambiguous',
+      stripeChargeId: 'ch_registration_dispute_time_ambiguous',
+      stripeAmountTotalCents: 5000,
+    });
+    const snapshots = [
+      ['orders/order-1', storedCopy('orders/order-1')],
+      [
+        'events/race-1/registrations/reg-1',
+        storedCopy('events/race-1/registrations/reg-1'),
+      ],
+    ];
+    const event = stripeEvent(
+      'evt_dispute_time_ambiguous',
+      'charge.dispute.updated',
+      orderDispute({
+        id: 'dp_dispute_time_ambiguous',
+        charge: 'ch_dispute_time_ambiguous',
+        payment_intent: 'pi_dispute_time_ambiguous',
+        metadata: {},
+        status: 'under_review',
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: snapshots,
+    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A7 blocks invalid Event time before provider-binding conflicts', async () => {
+    seedPaidDisputeOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const disputeBindingPath = 'stripeObjectBindings/dispute:dp_dispute_time_binding';
+    admin.__seed(disputeBindingPath, {
+      providerObjectType: 'dispute',
+      providerObjectId: 'dp_dispute_time_binding',
+      targetType: 'registration',
+      targetPath: 'events/other/registrations/other',
+      firstEventId: 'evt_other',
+    });
+    const beforeBinding = storedCopy(disputeBindingPath);
+    const event = stripeEvent(
+      'evt_dispute_time_binding_conflict',
+      'charge.dispute.updated',
+      orderDispute({
+        id: 'dp_dispute_time_binding',
+        status: 'under_review',
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedDisputeEventCreatedQuarantine([disputeBindingPath]));
+    expect(admin.__get(disputeBindingPath)).toEqual(beforeBinding);
+    expect(admin.__get('stripeObjectBindings/charge:ch_order_1')).toBeUndefined();
+    expect(admin.__get('stripeObjectBindings/payment_intent:pi_order_1')).toBeUndefined();
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test.each([
+    [
+      'outer Event realm',
+      'livemode_mismatch',
+      (event) => { event.livemode = true; },
+    ],
+    [
+      'embedded Dispute realm',
+      'dispute_livemode_mismatch',
+      (event) => { event.data.object.livemode = true; },
+    ],
+    [
+      'Event/status compatibility',
+      'invalid_dispute_status',
+      (event) => { event.data.object.status = 'hostile-dispute-status-do-not-log'; },
+    ],
+    [
+      'metadata schema',
+      'metadata_schema_version_mismatch',
+      (event) => { setMetadataSchema(event.data.object, '2'); },
+    ],
+  ])('PAY-003A7 keeps %s precedence at the Event-created boundary', async (
+    label,
+    reason,
+    mutate,
+  ) => {
+    seedPaidDisputeOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const event = stripeEvent(
+      `evt_dispute_time_precedence_${slug}`,
+      'charge.dispute.updated',
+      orderDispute({
+        id: `dp_dispute_time_precedence_${slug}`,
+        status: 'under_review',
+      }),
+    );
+    event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1;
+    mutate(event);
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({ response, event, businessPath, before, reason });
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      stripeCreatedAt: null,
+    });
+    expectOnlyEventLedgerReads(event);
+    expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
+      (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
+    );
+  });
+
+  test.each([
+    ['malformed reference', (event) => {
+      Object.assign(event.data.object.metadata, {
+        eventId: 'race-1',
+        registrationId: 'reg-1',
+      });
+    }],
+    ['object binding', (event) => { event.data.object.object = 'charge'; }],
+    ['currency', (event) => { event.data.object.currency = 'cad'; }],
+    ['amount', (event) => { event.data.object.amount = 0; }],
+  ])('PAY-003A7 keeps invalid Event time ahead of %s evaluation', async (
+    label,
+    mutate,
+  ) => {
+    seedPaidDisputeOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const event = stripeEvent(
+      `evt_dispute_time_later_${slug}`,
+      'charge.dispute.updated',
+      orderDispute({
+        id: `dp_dispute_time_later_${slug}`,
+        status: 'under_review',
+      }),
+    );
+    event.created = -1;
+    mutate(event);
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A7 deduplicates rejected Event time without mutation or bindings', async () => {
+    seedPaidDisputeOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_dispute_time_replay',
+      'charge.dispute.updated',
+      orderDispute({ id: 'dp_dispute_time_replay', status: 'under_review' }),
+    );
+    event.created = -1;
+
+    const firstResponse = await deliver(event);
+    const ledgerPath = `stripeEvents/${event.id}`;
+    const afterFirstLedger = storedCopy(ledgerPath);
+    const replayResponse = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response: firstResponse,
+      event,
+      businessSnapshots: [[businessPath, before]],
+    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'needs_review:invalid_event_created',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+    expect(admin.__get(ledgerPath)).toEqual(afterFirstLedger);
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
+    });
+  });
+
+  test('PAY-003A7 preserves a richer processed Event before timestamp admission', async () => {
+    seedPaidDisputeOrder();
+    const businessPath = 'orders/order-1';
+    const before = storedCopy(businessPath);
+    const event = stripeEvent(
+      'evt_dispute_time_already_processed',
+      'charge.dispute.updated',
+      orderDispute({ status: 'under_review' }),
+    );
+    event.created = -1;
+    const ledgerPath = `stripeEvents/${event.id}`;
+    admin.__seed(ledgerPath, {
+      status: 'processed',
+      outcome: 'legacy_processed_outcome',
+      targetPath: 'orders/legacy-target',
+      sentinel: { preserve: true },
+    });
+    const beforeLedger = storedCopy(ledgerPath);
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'legacy_processed_outcome',
+    }));
+    expect(admin.__get(businessPath)).toEqual(before);
+    expect(admin.__get(ledgerPath)).toEqual(beforeLedger);
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
+    });
+  });
+
+  test.each([
+    ['Unix epoch', 0],
+    ['Firestore maximum', FIRESTORE_TIMESTAMP_MAX_SECONDS],
+  ])('PAY-003A7 admits the inclusive %s Event-created boundary', async (
+    label,
+    eventCreated,
+  ) => {
+    seedPaidDisputeOrder();
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const event = stripeEvent(
+      `evt_dispute_time_valid_${slug}`,
+      'charge.dispute.created',
+      orderDispute({ id: `dp_dispute_time_valid_${slug}` }),
+    );
+    event.created = eventCreated;
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'dispute_needs_response',
+    }));
+    expect(admin.__get('orders/order-1')).toMatchObject({
+      lastDisputeEventCreated: eventCreated,
+      stripeDisputeId: `dp_dispute_time_valid_${slug}`,
+    });
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      stripeCreatedAt: { _milliseconds: eventCreated * 1000 },
+      targetPath: 'orders/order-1',
+    });
+  });
+
+  test('PAY-003A7 keeps an admissible claimed missing target retryable', async () => {
+    const event = stripeEvent(
+      'evt_dispute_time_valid_missing_target',
+      'charge.dispute.updated',
+      orderDispute({
+        id: 'dp_dispute_time_valid_missing_target',
+        charge: 'ch_dispute_time_valid_missing_target',
+        payment_intent: 'pi_dispute_time_valid_missing_target',
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-missing',
+        },
+        status: 'under_review',
+      }),
+    );
+    event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+
+    const response = await deliver(event);
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(admin.__get(`stripeEvents/${event.id}`)).toBeUndefined();
+    providerBindingPaths(event).forEach((path) => {
+      expect(admin.__get(path)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Outcome

Unusable Stripe Dispute Event timestamps are now rejected before target resolution, business-record access, or provider-binding access. Firestore-unrepresentable values produce a durable, target-free review ledger instead of mutating a business record, creating bindings, retrying a missing target, or throwing during Timestamp construction.

Closes #561
Parent: #106

## Invariant and failure behavior

For the three supported Dispute Event types, the order is:

1. processed-Event replay;
2. outer Event realm;
3. embedded Dispute realm;
4. Event/status compatibility;
5. explicit metadata version;
6. primitive safe-integer Event `created` from `0` through `253402300799`, inclusive;
7. only then target, ownership, binding, money, and state work.

Invalid time evidence receives `needs_review:invalid_event_created` with null target fields and null `stripeCreatedAt`. Even when an earlier admission reason wins, an unusable Dispute time is never passed to Firestore Timestamp construction. The rejected value is not logged.

## Changes

- Added the bounded Dispute Event-created admission predicate and moved it ahead of target work.
- Removed the redundant late predicate from the business transition.
- Kept non-Dispute admission and serialization unchanged.
- Made the timestamp test double enforce Firestore's actual range.
- Added separately named PAY-003A7 coverage for 39 hostile-value/lifecycle combinations, reference and fallback routes, read isolation, precedence, replay, both inclusive valid boundaries, and valid missing-target retry.
- Added the source-only design, diagram, text alternative, verification, residual, undo, escalation, and evidence boundary.

## Verification

Exact reviewed head: `90d8603ccdf95d55dac465bcf6c8ce2408264662`
Exact base: `7576bbaf937cb42d99c0ae1a3b179fb9a4323a41`
Patch SHA-256: `12fa02e022e9ab5bbcbfddfef58e01631ba5b4f836147af12a9fbce1a1d191bd`

- PAY-003A7 focused: 61 passed.
- Full webhook file: 401 passed.
- Functions lint: passed.
- Full Functions: 6,837 passed; 64 intentional skips.
- Static/workflow safety: 82 passed.
- Frontend: 940 passed.
- SPA navigation: 11 passed.
- Production build: passed.
- Firestore Rules emulator: 418 passed.
- Firestore-only commerce concurrency emulator: 63 passed.
- `git diff --check`: passed.
- Independent security/order review: GO.
- Independent test-quality review: GO.
- Independent design/evidence and backup-officer review: GO.

## Compatibility and residual risk

No schema or stored-data migration. Existing processed ledgers remain authoritative and are not reprocessed. Valid Firestore-representable Dispute Event times retain existing behavior. This does not add a clock-skew rule, establish provider truth, choose or verify a Stripe API version, retrieve provider objects, repair history, change non-Dispute admission, or complete PAY-003B/C.

Undo is a reviewed revert of this source, test, and named design section. Do not edit production records or provider objects as an undo path.

Officer impact: None — this hardens server-only payment-event admission and changes no officer screen, task, field, permission, approval, or available recovery procedure.

Officer documentation: None — `STRIPE_COMMERCE_DESIGN.md` records the internal source boundary; no officer procedure gains a new live step.

Deployment evidence:

- Source changed: yes, at the exact head above.
- Tests passed: yes, as listed above.
- Code merged: no at PR creation.
- Website published: no.
- `runmprc.com` verified for this change: no.
- Firebase deployed: no.
- Stripe or another outside provider configured/contacted: no.
- Production data changed: no.
- Dispute or payment performed: no.
- Production behavior verified: no.

This PR is **SOURCE ONLY / NOT DEPLOYED / NOT LIVE**. A green workflow does not prove a Firebase or provider release.