### PR TITLE
WEB-PRIVACY-001Z: bind Admin Events to current context

### DIFF
--- a/docs/officers/EVENTS_SHOP_MEMBERS.md
+++ b/docs/officers/EVENTS_SHOP_MEMBERS.md
@@ -2709,48 +2709,65 @@ No system-topology diagram changes are required because this source slice change
 
 **Status: NOT AVAILABLE YET**
 
-**Purpose:** give an officer one plain instruction when the Admin Events list cannot load, without showing a Firebase, database, provider, account, endpoint, token-shaped, or technical detail and without falsely saying that the event list is empty.
+**Purpose:** keep an older Admin Events list hidden when the page's ready database setup is removed or replaced, and give an officer one plain message when the current mocked list cannot load.
 
 **Approver:** events lead plus platform/security and privacy owners. Add the treasurer before any future live commerce-admin review.
 
-**Prerequisites:** issue [#290](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/290) must be merged for source review. Use only a mocked admin identity, mocked database reference, made-up event, and mocked rejected list lookup. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply: this slice does not approve the screen, role, permissions, backup, preview, rollback, event editing, publication, registration, payment, or production use. It does not choose the event source reserved to #121, deploy Firebase, change Rules, permissions, or event records, contact Stripe or another provider, use production data, or prove live behavior.
+**Prerequisites:** issues [#290](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/290) and [#565](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/565) must be merged for source review. Use only a mocked admin identity, plain made-up database references, made-up events, and controlled mocked lookups. The **Admin screens — NOT AVAILABLE YET** restrictions above still apply. This work does not approve the screen, role, permissions, backup, preview, rollback, event editing, publication, registration, payment, or production use. It does not choose the event source reserved to #121. It does not deploy Firebase, change Rules, permissions, or event records, contact Stripe or another provider, use production data, or prove live behavior.
 
 ```mermaid
 flowchart LR
-    A["Made-up Admin Events route"] --> B["Mocked event-list lookup"]
-    B -- "Fulfilled empty" --> C["Existing No events yet state"]
-    B -- "Fulfilled with events" --> D["Existing events table"]
-    B -- "Rejected" --> E["Fixed alert; no empty state or table"]
+    A["Made-up Admin Events route"] --> B{"Ready database reference?"}
+    B -- "No" --> C["Loading; no old rows or row actions"]
+    B -- "Yes" --> D["One current mocked lookup"]
+    D -- "Fulfilled empty" --> E["Existing No events yet state"]
+    D -- "Fulfilled with events" --> F["Existing current events table"]
+    D -- "Rejected" --> G["Fixed alert; no empty state or table"]
+    H["Readiness or services removed"] --> C
+    I["Ready database replaced"] --> K["Hide old rows; show loading"]
+    K --> D
+    L["Same database repeated"] -. "No second lookup" .-> J["No display change"]
+    M["Older or closed-page result"] -. "Ignored" .-> J
 ```
 
-In words: only a successful mocked lookup may show the existing empty event list or events table. A mocked rejection shows one fixed alert while keeping the Events heading and New event navigation; it does not turn an unknown result into an empty or current event list.
+In words: without one ready mocked database reference, the page shows loading and no old event rows. A changed database hides the earlier table before one current lookup starts. Only that current lookup may show the existing empty state, current table, or fixed alert. Repeating the same made-up database setup does not reload. An older or closed-page result changes nothing.
 
 Officer review steps after the source merge:
 
 1. Keep this failure sentence and the complete Admin Events screen marked **NOT AVAILABLE YET**.
-2. Ask the platform owner for the exact #290 issue, reviewed pull request, merged commit, and synthetic frontend test result.
-3. Confirm the tests use only a made-up admin identity, mocked database reference, made-up event, and mocked lookup.
-4. Confirm a mocked rejection shows exactly `We could not load events right now. Please try again later.`
-5. Confirm assistive technology receives the complete sentence immediately as one alert.
-6. Confirm no rejection-only database, Firebase, provider, account, endpoint, token-shaped, or technical detail appears on the page, in analytics, or in the browser console.
-7. Confirm a hostile rejected value is not inspected and its throwing `message` property is never touched.
-8. Confirm the rejected lookup ends loading and shows neither **No events yet.** nor an events table.
-9. Confirm the **Events** heading and **+ New event** link remain without following the link.
-10. Confirm the mocked lookup receives the same mocked database reference exactly once.
-11. Confirm a successful mocked empty list still shows **No events yet.**, and a successful made-up event keeps its existing table display.
-12. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, event-record, production-data, Admin-screen approval, and live behavior as separate results.
+2. Ask the platform owner for the exact #290 and #565 issues, reviewed pull requests, merged commits, and synthetic test results.
+3. Confirm the tests use only a made-up admin identity, made-up database references, made-up events, and controlled mocked results.
+4. Confirm a missing ready database shows **Loading...**.
+5. Confirm that missing ready database starts no event-list lookup.
+6. Confirm that missing ready database shows no old event row or row action.
+7. Confirm losing readiness immediately hides an earlier made-up table.
+8. Confirm losing services immediately hides an earlier made-up table.
+9. Confirm losing the database reference immediately hides an earlier made-up table.
+10. Confirm changing database A to database B hides every A row before the B result arrives.
+11. Confirm database B starts exactly one current mocked lookup.
+12. Confirm repeating the same made-up database setup starts no second lookup.
+13. Confirm an older success cannot replace the current empty state or table.
+14. Confirm an older failed result is ignored without reading or revealing any private detail.
+15. Confirm a result received after the page closes is ignored without reading it.
+16. Confirm a current mocked rejection shows exactly `We could not load events right now. Please try again later.`
+17. Confirm assistive technology receives the complete failure sentence immediately as one alert.
+18. Confirm the current failure shows neither **No events yet.** nor an events table.
+19. Confirm the **Events** heading and **+ New event** link remain without following the link.
+20. Confirm a current mocked empty list keeps **No events yet.**
+21. Confirm a current made-up event keeps the existing table display and row links.
+22. Record source change, tests, merge, preview, website publication, exact `runmprc.com` revision, Firebase, provider, event records, production data, Admin-screen approval, and live behavior as separate results.
 
-**Expected result:** the reviewed source discards the complete rejected value without binding or inspecting it and shows one fixed accessible retry-later sentence. A failure is not treated as an empty or populated event list. The Events heading and New event navigation remain, while genuine successful empty and populated results keep their existing displays. This does not authorize an officer to open or use the Admin Events screen live.
+**Expected result:** no result appears until one ready mocked database completes its current lookup. A missing or changed database context immediately hides earlier rows and actions. Older and closed-page results are inert. A current failure is discarded without inspection and becomes one fixed accessible sentence. A current successful empty or populated result keeps the existing display. The Events heading and New event navigation remain. This does not authorize an officer to open or use the Admin Events screen live.
 
-**Stop conditions:** any real officer, member, event, registration, location, discount, waiver, price, capacity, payment, Firebase, Stripe, provider, endpoint, credential, or production record used to exercise the failure; a request to force a production error; a raw detail on the page, in analytics, or in the console; the false empty state or an events table after rejection; an attempted event/admin write; a Firebase, Rules, provider, permission, or event-source change; an attempt to decide #121 work; or a claim that source, tests, merge, preview, or a green workflow proves the sentence or Admin screen is live.
+**Stop conditions:** any real officer, member, event, registration, location, discount, waiver, price, capacity, payment, Firebase, Stripe, provider, endpoint, credential, or production record used in a check; any request to force a production error; any raw detail on the page, in analytics, or in the console; any old row or action visible after readiness, services, or database identity changes; any lookup made without a database; any older result changing the page; any extra lookup caused only by repeating the same made-up database setup; any false empty state or table after rejection; any event or admin write; any Firebase, Rules, provider, permission, or event-source change; any attempt to decide #121 work; or any claim that source, tests, merge, preview, or a green workflow proves this behavior is live.
 
-**Success proof:** for source completion, record the exact #290 issue, reviewed pull request, merged commit, intended old-source failures, green synthetic actual-route tests, relevant full checks, and independent privacy, accessibility, and officer-continuity reviews. The safe review path stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability requires a later separately approved Admin-screen release and dated exact-revision verification after every prerequisite above is complete. Record website publication, `runmprc.com`, Firebase deployment, Rules or permission changes, provider configuration, event-record changes, production-data actions, and live behavior as **not performed** unless separate evidence proves otherwise.
+**Success proof:** for source completion, record the exact #290 and #565 issues, reviewed pull requests, merged commits, intended old-source failures, green synthetic current-context tests, relevant full checks, and independent privacy, lifecycle, compatibility, accessibility, and officer-continuity reviews. The safe review stops at source and synthetic tests because the Admin screen is not approved for officer use. Live availability still needs a separately approved Admin-screen release and dated exact-revision verification. Record website publication, `runmprc.com`, Firebase deployment, Rules or permission changes, provider configuration, event-record changes, production-data actions, and live behavior as **not performed** unless separate evidence proves otherwise.
 
-**Undo:** before publication, use one reviewed frontend revert or safe roll-forward. After any later approved publication, use the same protected website release path and verify the replacement revision. Do not undo by changing or deleting an event, registration, payment, officer account, permission, database record, source document, or provider setting.
+**Undo:** before publication, use one reviewed frontend-and-guide revert or safe roll-forward. After any later approved publication, use the protected website release path and verify the replacement revision. Never undo by changing or deleting an event, registration, payment, officer account, permission, database record, source document, or provider setting.
 
-**Escalation:** events lead plus platform/security owner. Add the privacy owner and use the private incident path if any database, Firebase, provider, account, event, registration, endpoint, token-shaped, or technical detail appeared. Add the treasurer if commerce or payment state might be involved. Do not copy private details into an issue, message, screenshot, email, or AI tool.
+**Escalation:** stop and contact the events lead plus platform/security owner. Add the privacy owner if any old or private detail appeared. Add the treasurer if commerce or payment state might be involved. Use the private incident path if stale data appeared under another account or database context. Do not copy private details into an issue, message, screenshot, email, or AI tool.
 
-No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected failure display.
+No system-topology diagram changes for this source slice because page structure, data movement, permissions, account ownership, and deployment topology are unchanged. The state-flow diagram above records only the corrected list lifecycle and display.
 
 ### Admin dashboard summary load failure privacy — SOURCE ONLY, NOT LIVE
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6263,6 +6263,298 @@ describe('Admin Events list-load failure boundary', () => {
   });
 });
 
+describe('WEB-PRIVACY-001Z Admin Events current-context lifecycle', () => {
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+  }
+
+  function syntheticListedEvent({
+    id = 'synthetic-listed-event',
+    slug = id,
+    title = 'Synthetic Listed Event',
+  } = {}) {
+    return {
+      id,
+      slug,
+      title,
+      startAt: { toDate: () => new Date(2030, 0, 12, 12, 0) },
+      capacity: 20,
+      registeredCount: 7,
+      status: 'open',
+      visibility: 'public',
+      pricing: { memberCents: 1000, nonMemberCents: 1500 },
+    };
+  }
+
+  function configureAdminEventsContext({
+    database = firestore,
+    ready = true,
+    servicesAvailable = true,
+  } = {}) {
+    useServiceLocator.mockReturnValue({
+      services: servicesAvailable ? { firebaseResources: { firestore: database } } : null,
+      isReady: ready,
+    });
+  }
+
+  function expectEventResultsHidden() {
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create the first one' }))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Signups' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+  }
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: { uid: 'synthetic-admin' },
+      isLoading: false,
+      isAuthenticated: true,
+      isMember: true,
+      isAdmin: true,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      register: jest.fn(),
+    });
+    configureAdminEventsContext();
+    listAllEvents.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    ['readiness is lost', { ready: false }],
+    ['services are missing', { servicesAvailable: false }],
+    ['the database is missing', { database: null }],
+  ])('hides an earlier table immediately when %s', async (_label, unavailableContext) => {
+    const titleGetter = jest.fn(() => 'Earlier Synthetic Event');
+    const earlierEvent = Object.defineProperty(syntheticListedEvent(), 'title', {
+      configurable: true,
+      get: titleGetter,
+    });
+    listAllEvents.mockResolvedValueOnce([earlierEvent]);
+    const view = renderAdminEvents();
+    expect(await screen.findByText('Earlier Synthetic Event')).toBeInTheDocument();
+    titleGetter.mockClear();
+
+    configureAdminEventsContext(unavailableContext);
+    view.rerender(<App />);
+
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Synthetic Event')).not.toBeInTheDocument();
+    expectEventResultsHidden();
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('starts no lookup before a complete ready database context exists', async () => {
+    configureAdminEventsContext({ database: null });
+
+    renderAdminEvents();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Events' }))
+      .toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectEventResultsHidden();
+    expect(listAllEvents).not.toHaveBeenCalled();
+  });
+
+  test('does not reload when only the services wrapper changes', async () => {
+    listAllEvents.mockResolvedValueOnce([syntheticListedEvent()]);
+    const view = renderAdminEvents();
+    expect(await screen.findByText('Synthetic Listed Event')).toBeInTheDocument();
+
+    listAllEvents.mockReturnValueOnce(new Promise(() => {}));
+    configureAdminEventsContext();
+    view.rerender(<App />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByText('Synthetic Listed Event')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenCalledTimes(1);
+    expect(listAllEvents).toHaveBeenCalledWith(firestore);
+  });
+
+  test('hides earlier events while a changed-database lookup is pending', async () => {
+    const titleGetter = jest.fn(() => 'Earlier Database Event');
+    const earlierEvent = Object.defineProperty(syntheticListedEvent(), 'title', {
+      configurable: true,
+      get: titleGetter,
+    });
+    listAllEvents.mockResolvedValueOnce([earlierEvent]);
+    const view = renderAdminEvents();
+    expect(await screen.findByText('Earlier Database Event')).toBeInTheDocument();
+    titleGetter.mockClear();
+
+    const currentLookup = deferred();
+    listAllEvents.mockReturnValueOnce(currentLookup.promise);
+    const currentFirestore = { name: 'synthetic-current-events-firestore' };
+    configureAdminEventsContext({ database: currentFirestore });
+    view.rerender(<App />);
+
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Database Event')).not.toBeInTheDocument();
+    expectEventResultsHidden();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Database Event')).not.toBeInTheDocument();
+    expectEventResultsHidden();
+
+    await act(async () => {
+      currentLookup.resolve([syntheticListedEvent({
+        id: 'synthetic-current-event',
+        title: 'Current Database Event',
+      })]);
+    });
+    expect(await screen.findByText('Current Database Event')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Database Event')).not.toBeInTheDocument();
+    expect(listAllEvents).toHaveBeenNthCalledWith(1, firestore);
+    expect(listAllEvents).toHaveBeenNthCalledWith(2, currentFirestore);
+  });
+
+  test('treats ready to not-ready to ready as distinct attempts for one database', async () => {
+    const titleGetter = jest.fn(() => 'Earlier Ready Event');
+    const earlierEvent = Object.defineProperty(syntheticListedEvent(), 'title', {
+      configurable: true,
+      get: titleGetter,
+    });
+    listAllEvents.mockResolvedValueOnce([earlierEvent]);
+    const view = renderAdminEvents();
+    expect(await screen.findByText('Earlier Ready Event')).toBeInTheDocument();
+    titleGetter.mockClear();
+
+    configureAdminEventsContext({ ready: false });
+    view.rerender(<App />);
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectEventResultsHidden();
+
+    const recoveredLookup = deferred();
+    listAllEvents.mockReturnValueOnce(recoveredLookup.promise);
+    configureAdminEventsContext();
+    view.rerender(<App />);
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expectEventResultsHidden();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      recoveredLookup.resolve([syntheticListedEvent({
+        id: 'synthetic-recovered-event',
+        title: 'Recovered Current Event',
+      })]);
+    });
+
+    expect(await screen.findByText('Recovered Current Event')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier Ready Event')).not.toBeInTheDocument();
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(listAllEvents).toHaveBeenCalledTimes(2);
+  });
+
+  test('keeps a newer empty result when an older lookup later resolves', async () => {
+    const olderLookup = deferred();
+    listAllEvents.mockReturnValueOnce(olderLookup.promise);
+    const view = renderAdminEvents();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-newer-empty-events-firestore' };
+    listAllEvents.mockResolvedValueOnce([]);
+    configureAdminEventsContext({ database: currentFirestore });
+    view.rerender(<App />);
+    expect(await screen.findByRole('link', { name: 'Create the first one' }))
+      .toBeInTheDocument();
+
+    await act(async () => {
+      olderLookup.resolve([syntheticListedEvent({ title: 'Obsolete Synthetic Event' })]);
+    });
+
+    expect(screen.getByRole('link', { name: 'Create the first one' })).toBeInTheDocument();
+    expect(screen.queryByText('Obsolete Synthetic Event')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('keeps a newer event when an older hostile rejection later arrives', async () => {
+    const olderLookup = deferred();
+    listAllEvents.mockReturnValueOnce(olderLookup.promise);
+    const view = renderAdminEvents();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(1));
+
+    const currentFirestore = { name: 'synthetic-newer-events-firestore' };
+    listAllEvents.mockResolvedValueOnce([syntheticListedEvent({
+      id: 'synthetic-current-event',
+      title: 'Current Synthetic Event',
+    })]);
+    configureAdminEventsContext({ database: currentFirestore });
+    view.rerender(<App />);
+    expect(await screen.findByText('Current Synthetic Event')).toBeInTheDocument();
+
+    const messageGetter = jest.fn(() => 'obsolete-events-private-canary');
+    await act(async () => {
+      olderLookup.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(screen.getByText('Current Synthetic Event')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('obsolete-events-private-canary');
+  });
+
+  test('does not inspect a hostile rejection after the page unmounts', async () => {
+    const lookup = deferred();
+    listAllEvents.mockReturnValueOnce(lookup.promise);
+    const view = renderAdminEvents();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const messageGetter = jest.fn(() => 'unmounted-events-private-canary');
+    await act(async () => {
+      lookup.reject(Object.defineProperty({}, 'message', {
+        configurable: true,
+        get: messageGetter,
+      }));
+      await Promise.resolve();
+    });
+
+    expect(messageGetter).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  test('does not inspect or display a successful result after the page unmounts', async () => {
+    const lookup = deferred();
+    listAllEvents.mockReturnValueOnce(lookup.promise);
+    const view = renderAdminEvents();
+    await waitFor(() => expect(listAllEvents).toHaveBeenCalledTimes(1));
+    view.unmount();
+
+    const titleGetter = jest.fn(() => 'Unmounted Synthetic Event');
+    const event = Object.defineProperty(syntheticListedEvent(), 'title', {
+      configurable: true,
+      get: titleGetter,
+    });
+    await act(async () => {
+      lookup.resolve([event]);
+      await Promise.resolve();
+    });
+
+    expect(titleGetter).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent('Unmounted Synthetic Event');
+    expect(track).not.toHaveBeenCalled();
+  });
+});
+
 describe('Admin Event editor load-failure boundary', () => {
   function syntheticAdminEvent({
     slug = 'synthetic-event',

--- a/src/pages/admin/events/AdminEventsList.tsx
+++ b/src/pages/admin/events/AdminEventsList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../../../components/SEO';
 import { useServiceLocator } from '../../../services/ServiceLocatorContext';
@@ -8,6 +8,24 @@ import { listAllEvents } from '../../../services/events/adminService';
 import { formatEventDate, formatPrice } from '../../../services/events/eventsService';
 
 const LOAD_FAILURE = 'We could not load events right now. Please try again later.';
+const firestoreIdentities = new WeakMap<object, number>();
+let nextFirestoreIdentity = 1;
+
+function getFirestoreIdentity(value: object | null): number {
+  if (value === null) return 0;
+  const existing = firestoreIdentities.get(value);
+  if (existing !== undefined) return existing;
+  const identity = nextFirestoreIdentity;
+  nextFirestoreIdentity += 1;
+  firestoreIdentities.set(value, identity);
+  return identity;
+}
+
+interface EventsLoadOutcome {
+  firestore: unknown;
+  status: 'loading' | 'resolved' | 'unavailable';
+  events: Event[];
+}
 
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
@@ -23,31 +41,48 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function Inner() {
-  const { services, isReady } = useServiceLocator();
-  const [events, setEvents] = useState<Event[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+type EventsFirestore = Parameters<typeof listAllEvents>[0];
+
+function EventsAttempt({ firestore }: { firestore: EventsFirestore | null }) {
+  const currentFirestoreRef = useRef(firestore);
+  currentFirestoreRef.current = firestore;
+  const requestSequence = useRef(0);
+  const [loadOutcome, setLoadOutcome] = useState<EventsLoadOutcome | null>(null);
+
+  const currentOutcome = loadOutcome?.firestore === firestore ? loadOutcome : null;
+  const currentStatus = currentOutcome?.status ?? 'loading';
+  const events = currentOutcome?.status === 'resolved' ? currentOutcome.events : [];
+  const loading = currentStatus === 'loading';
+  const error = currentStatus === 'unavailable' ? LOAD_FAILURE : null;
 
   useEffect(() => {
-    if (!isReady || !services) return undefined;
-    let active = true;
-    setLoading(true);
-    setError(null);
-    listAllEvents(services.firebaseResources.firestore)
-      .then((evs) => {
-        if (!active) return;
-        setEvents(evs);
-        setError(null);
-        setLoading(false);
-      })
-      .catch(() => {
-        if (!active) return;
-        setError(LOAD_FAILURE);
-        setLoading(false);
-      });
-    return () => { active = false; };
-  }, [services, isReady]);
+    if (!firestore) {
+      requestSequence.current += 1;
+      return () => undefined;
+    }
+
+    const requestFirestore = firestore;
+    requestSequence.current += 1;
+    const requestId = requestSequence.current;
+    const outcomeKey = { firestore: requestFirestore };
+    setLoadOutcome({ ...outcomeKey, status: 'loading', events: [] });
+
+    async function load() {
+      try {
+        const all = await listAllEvents(requestFirestore);
+        if (requestId !== requestSequence.current
+          || currentFirestoreRef.current !== requestFirestore) return;
+        setLoadOutcome({ ...outcomeKey, status: 'resolved', events: all });
+      } catch {
+        if (requestId !== requestSequence.current
+          || currentFirestoreRef.current !== requestFirestore) return;
+        setLoadOutcome({ ...outcomeKey, status: 'unavailable', events: [] });
+      }
+    }
+
+    load();
+    return () => { requestSequence.current += 1; };
+  }, [firestore]);
 
   return (
     <>
@@ -136,6 +171,20 @@ function Inner() {
         )}
       </div>
     </>
+  );
+}
+
+function Inner() {
+  const { services, isReady } = useServiceLocator();
+  const firestore = isReady && services
+    ? services.firebaseResources.firestore
+    : null;
+
+  return (
+    <EventsAttempt
+      key={getFirestoreIdentity(firestore)}
+      firestore={firestore}
+    />
   );
 }
 


### PR DESCRIPTION
Closes #565.

## Outcome

The Admin Events list now belongs to the exact currently ready Firestore object:

- losing readiness, services, or Firestore immediately shows loading and hides every prior event row/action;
- replacing Firestore starts one fresh attempt and hides the prior result before settlement;
- repeating the same Firestore through a new services wrapper neither hides the current result nor reloads;
- obsolete and unmounted success/rejection results are inert without rejected-value inspection;
- existing #290 fixed failure, successful empty/table displays, heading, fields, formatting, and links are preserved.

This is source-only. The Admin screen remains **NOT AVAILABLE YET**.

## Scope

Exactly three files:

- `src/pages/admin/events/AdminEventsList.tsx`
- separately named `WEB-PRIVACY-001Z` block in `src/App.test.jsx`
- only the existing Admin event-list procedure/diagram in `docs/officers/EVENTS_SHOP_MEMBERS.md`

Exact reviewed head: `7efef5d2307ab4d28f7720ca3eba7c049c3e70c9`

Exact tree: `14806153d81785b77ff092955f0968d0ac888844`

Exact binary diff SHA-256: `cf50766f89b65861a2bc844ddc08db9df2d2eeabbff38f7a3983303dffaa4f0a`

## Verification

- Final current tests on untouched old source: 7 failed / 4 passed (independent disposable-clone RED).
- Focused final block: 11/11 passed.
- Existing #290 plus #565 focused behavior: 18/18 passed in independent review.
- Full frontend: 18 suites / 951 tests passed; `src/App.test.jsx` 360/360.
- TypeScript no-emit passed.
- Lint ledger passed unchanged: 118 files / 113 reviewed errors / 6 reviewed warnings.
- SPA/workflow/release/readback/artifact/dependency safety: 93/93.
- Diagnostic production build passed without sitemap generation.
- Functions lint passed; full Functions: 6,841 passed / 64 intended skips.
- Local Rules not run because this host has no Java; hosted Java-backed CI is required before merge.
- `git diff --check` and exact three-path scope audit passed.
- Three independent reviews GO: privacy/lifecycle, test/mutation/compatibility, and scope/officer continuity.

## Safety and compatibility

No event source, event record, create/edit/delete action, registration, payment, price, capacity, waiver, Admin authorization, service contract, route, Rules, Function, package, workflow, provider, migration, or production data changes. Synthetic tests only.

## Officer continuity

Officer impact: No current live screen change. A later approved website release would hide older Admin Events rows/actions when the page's ready database setup is removed or replaced.

Officer documentation: `docs/officers/EVENTS_SHOP_MEMBERS.md` updates the existing source-only Admin event-list procedure and plain-language state diagram. It remains **NOT AVAILABLE YET**.

Deployment evidence: Source, tests, and review only before merge. Website publication, exact `runmprc.com` verification, Firebase deployment, outside-provider configuration, event/registration/payment records, production data, Admin-screen approval, and live behavior were not performed or verified.

## Residual

A green PR does not publish this source. A later approved protected website release and exact-revision check are required before describing the behavior as live. #121 still owns the event-source decision.
