### PR TITLE
OAUTH-001A1G: redact missing Strava credential failures

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -810,7 +810,13 @@ async function consumeOAuthState(session, state) {
 }
 
 async function exchangeCode(code) {
-  const { clientId, clientSecret } = getStravaCreds();
+  let credentials;
+  try {
+    credentials = getStravaCreds();
+  } catch {
+    throw stravaAuthorizationError('failed-precondition');
+  }
+  const { clientId, clientSecret } = credentials;
   let resp;
   try {
     resp = await fetch(STRAVA_TOKEN_URL, {
@@ -843,7 +849,13 @@ async function exchangeCode(code) {
 }
 
 async function refreshToken(refresh) {
-  const { clientId, clientSecret } = getStravaCreds();
+  let credentials;
+  try {
+    credentials = getStravaCreds();
+  } catch {
+    throw stravaRefreshError('failed-precondition');
+  }
+  const { clientId, clientSecret } = credentials;
   let resp;
   try {
     resp = await fetch(STRAVA_TOKEN_URL, {

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -1046,27 +1046,50 @@ describe('Strava authorization exchange failure boundary', () => {
     expectNoSideEffects();
   });
 
-  test('consumes valid state before missing provider credentials and never restores it', async () => {
-    delete process.env.STRAVA_CLIENT_ID;
-    delete process.env.STRAVA_CLIENT_SECRET;
+  test.each([
+    ['a missing client ID', ['STRAVA_CLIENT_ID']],
+    ['a missing client secret', ['STRAVA_CLIENT_SECRET']],
+    ['both missing application credentials', ['STRAVA_CLIENT_ID', 'STRAVA_CLIENT_SECRET']],
+  ])('OAUTH-001A1G consumes valid state before %s and never restores it', async (
+    _case,
+    missingVariables,
+  ) => {
+    process.env.STRAVA_CLIENT_ID = 'strava-client-id-canary';
+    process.env.STRAVA_CLIENT_SECRET = 'strava-client-secret-canary';
+    missingVariables.forEach((name) => delete process.env[name]);
 
     const credentialFailure = await captureFailure(() => stravaExchangeCode({
       code: CODE,
       state: STATE,
     }, CONTEXT));
+    const exposed = publicError(credentialFailure);
 
-    expect(publicError(credentialFailure)).toEqual({
+    expect(exposed).toEqual({
       code: 'failed-precondition',
-      message: 'Strava credentials not configured',
+      message: FIXED_AUTHORIZATION_ERROR,
       details: undefined,
       cause: undefined,
     });
+    expect(JSON.stringify({ exposed, logs: consoleSpies.map((spy) => spy.mock.calls) }))
+      .not.toMatch(
+        /credentials not configured|strava-client-id-canary|strava-client-secret-canary/i,
+      );
     expect(admin.__hasDocument(STATE_PATH)).toBe(false);
+    expect(admin.__getTransactionRunAttempts()).toBe(1);
+    expect(admin.__getTransactionReads()).toEqual([STATE_PATH]);
+    expect(admin.__getTransactionDeleteAttempts()).toEqual([STATE_PATH]);
     expect(admin.__getTransactionDeletes()).toEqual([STATE_PATH]);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
     expect(admin.__getWrites()).toEqual([]);
     expect(admin.__getDirectSetAttempts()).toEqual([]);
+    expect(admin.__getBatchCreateAttempts()).toBe(0);
+    expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+    expect(admin.__getBatchSetAttempts()).toEqual([]);
     expect(Timestamp.now).not.toHaveBeenCalled();
+    expect(dateNowSpy).toHaveBeenCalledTimes(1);
+    consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
 
     process.env.STRAVA_CLIENT_ID = 'strava_client_test';
     process.env.STRAVA_CLIENT_SECRET = 'strava_secret_test';
@@ -1081,9 +1104,20 @@ describe('Strava authorization exchange failure boundary', () => {
       details: undefined,
       cause: undefined,
     });
+    expect(admin.__getTransactionRunAttempts()).toBe(2);
+    expect(admin.__getTransactionReads()).toEqual([STATE_PATH, STATE_PATH]);
+    expect(admin.__getTransactionDeleteAttempts()).toEqual([STATE_PATH]);
+    expect(admin.__getTransactionDeletes()).toEqual([STATE_PATH]);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(admin.__getReads()).toEqual([]);
+    expect(admin.__getDeletes()).toEqual([]);
     expect(admin.__getWrites()).toEqual([]);
     expect(admin.__getDirectSetAttempts()).toEqual([]);
+    expect(admin.__getBatchCreateAttempts()).toBe(0);
+    expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+    expect(admin.__getBatchSetAttempts()).toEqual([]);
+    expect(Timestamp.now).not.toHaveBeenCalled();
+    expect(dateNowSpy).toHaveBeenCalledTimes(1);
     consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
   });
 
@@ -3932,6 +3966,62 @@ describe('Strava token refresh failure boundary', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(Timestamp.now).toHaveBeenCalledTimes(1);
       consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+  });
+
+  describe('OAUTH-001A1G missing application-credential boundary', () => {
+    function expectNoCredentialFailureWork() {
+      expect(requireAppCheck).toHaveBeenCalledWith(CONTEXT);
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(admin.__getBatchCreateAttempts()).toBe(0);
+      expect(admin.__getBatchDeleteAttempts()).toEqual([]);
+      expect(admin.__getBatchDeletes()).toEqual([]);
+      expect(admin.__getBatchSetAttempts()).toEqual([]);
+      expect(admin.__getBatchCommitAttempts()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(admin.__getDirectSetAttempts()).toEqual([]);
+      expect(admin.__getTransactionRunAttempts()).toBe(0);
+      expect(admin.__getTransactionReads()).toEqual([]);
+      expect(admin.__getTransactionDeleteAttempts()).toEqual([]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDocument(CONNECTION_PATH)).toBe(CONNECTION);
+      expect(admin.__getDocument(SECRET_PATH)).toBe(EXPIRED_SECRET);
+      expect(dateNowSpy).toHaveBeenCalledTimes(1);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    }
+
+    test.each([
+      ['a missing client ID', ['STRAVA_CLIENT_ID']],
+      ['a missing client secret', ['STRAVA_CLIENT_SECRET']],
+      ['both missing application credentials', ['STRAVA_CLIENT_ID', 'STRAVA_CLIENT_SECRET']],
+    ])('returns one fixed refresh result for %s', async (_case, missingVariables) => {
+      process.env.STRAVA_CLIENT_ID = 'strava-client-id-canary';
+      process.env.STRAVA_CLIENT_SECRET = 'strava-client-secret-canary';
+      missingVariables.forEach((name) => delete process.env[name]);
+      seedExpiredConnection();
+      let readsAtClock;
+      dateNowSpy.mockImplementationOnce(() => {
+        readsAtClock = admin.__getReads();
+        return NOW_SECONDS * 1_000;
+      });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+      const exposed = publicError(rejection);
+
+      expect(readsAtClock).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(exposed).toEqual({
+        code: 'failed-precondition',
+        message: FIXED_REFRESH_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify({ exposed, logs: consoleSpies.map((spy) => spy.mock.calls) }))
+        .not.toMatch(
+          /credentials not configured|strava-client-id-canary|strava-client-secret-canary/i,
+        );
+      expectNoCredentialFailureWork();
     });
   });
 


### PR DESCRIPTION
## Outcome

Members no longer receive the configuration-specific phrase `Strava credentials not configured` when server-side Strava application credentials are missing. Authorization and refresh preserve `failed-precondition` while returning their existing fixed endpoint messages.

Closes #567. Bounded child of #88; this does not complete the tracker.

## Change

- Guard only the `getStravaCreds()` call in `exchangeCode()`.
- Guard only the `getStravaCreds()` call in `refreshToken()`.
- Catch without a binding and map to the existing fixed authorization or refresh error.
- Cover missing client ID, missing client secret, and both absent on both endpoints.
- Preserve one-use authorization-state consumption and replay denial.
- Preserve refresh connection/secret reads, one clock sample, unchanged records, and disconnect behavior.

Exact reviewed head: `e133d4c84e997524a50df46fbe504029cb954d0f`  
Exact base: `4bf6f94157ede05d2f755df1c6af15dd63d06701`  
Two-file patch SHA-256: `59454966d37639ed5282301e15e40848df158ab0372cccacc70291add47cc6d5`

## Security and compatibility review

- Public status remains `failed-precondition`.
- Exchange message is fixed `Strava authorization could not be completed.`.
- Refresh message is fixed `Strava connection could not be refreshed.`.
- Details and cause remain absent.
- No caught error value is read, retained, logged, serialized, or attached.
- Exchange consumes the state exactly once before credential lookup; restored credentials cannot replay it.
- Refresh reads connection then secret, samples the valid clock once, and stops before provider, timestamp, mutation, or bearer work.
- No schema, Rules, index, endpoint, dependency, workflow, migration, provider-request, valid-success, or disconnect change.

Three independent final-diff reviews returned GO for security, test isolation/false-green resistance, scope/compatibility, and officer continuity. One test review first found missing direct-delete and cross-operation clock-order assertions. A second pass found the initial inline clock assertion could be swallowed by the production clock boundary. Both findings were corrected; the final test captures the read trace and asserts it outside that catch boundary.

## Verification

Node `v20.20.2`; Java `21.0.12` for emulator checks.

- Trustworthy RED on the unchanged source: 6 intended failures, all actual raw configuration text versus expected fixed text.
- Focused `OAUTH-001A1G`: 6 passed.
- Full Strava suite: 687 passed.
- Functions lint: passed.
- Full Functions suite: 6,846 passed; 64 intentional skips.
- Frontend lint baseline: passed.
- Frontend Jest: 940 passed.
- SPA navigation: 11 passed.
- Workflow/release/artifact/dependency guards: 82 passed.
- Direct non-mutating production build: passed.
- Demo-project Firestore Rules emulator: 418 passed.
- Demo-project commerce command-journal emulator: 63 passed.
- `git diff --check`: passed.
- Worktree: clean after commit.

Dependency audits were run without applying fixes. The root audit still reports the existing four production-tree findings, including the tracked high-severity nested `minimatch` baseline; the Functions audit reports nine moderate transitive findings. This PR changes no package or lockfile and does not broaden those residuals.

## Officer impact

None — this is server-only callable error containment. Existing member screens already discard backend details and show fixed callback/activity messages. No officer task, screen, field, permission, approval, data flow, account ownership, provider setting, or recovery procedure changes.

## Officer documentation

None — current root design/security material, canonical #88, and officer Strava guidance remain accurate. No procedure, topology, Mermaid diagram, or text alternative changes.

## Deployment evidence

- Source changed: **yes**, exactly the two paths listed above.
- Tests passed: **yes**, local synthetic and demo-emulator evidence listed above.
- Code merged: **no** at PR creation.
- Website published: **no**; website source is unchanged and the local build is only diagnostic.
- `runmprc.com` verified for this change: **no**.
- Firebase deployed/read back: **no**.
- Strava or outside provider configured/called: **no**.
- Production data changed: **no**.
- Checkout/payment behavior changed or verified: **no**.
- Production/live behavior verified: **no**.

A green workflow will prove repository checks only. It will not prove Firebase deployment, Strava configuration, website publication, production data, or live behavior.