### PR TITLE
fix: reject invalid non-Dispute Stripe Event time

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -811,6 +811,48 @@ Residual work remains explicit. This check does not compare an Event time with t
 
 PAY-003A7 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed, Stripe/provider configured, a dispute or payment performed, production data changed, and live behavior verified. Source and synthetic tests do not prove any later state. This child performs no website publication, Firebase deployment, provider configuration or retrieval, dispute/payment, production-data action, or live verification. Officer impact and officer documentation are both none: this is a server-only admission boundary with no new officer screen, task, field, permission, approval, or available recovery step.
 
+### PAY-003A8 Checkout and refund Event-created admission — SOURCE ONLY, NOT LIVE
+
+PAY-003A8 [#572](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/572) closes PAY-003A7's explicit non-Dispute residual. Its purpose is to apply the same outer Stripe Event `created` contract to all four supported Checkout lifecycles and `charge.refunded` before any business target or provider binding work. PAY-003A7 remains the provenance for the three supported Dispute lifecycles; A8 only generalizes the shared predicate and safe ledger projection, so all eight supported Event types now require a primitive safe integer from Unix epoch second `0` through Firestore maximum second `253402300799`, inclusive.
+
+Approvers for this source boundary are the platform owner and payment reviewer. Prerequisites are verified webhook signature handling, the existing processed-Event ledger, the A2–A7 admission sequence, synthetic signed fixtures, and the current nullable `stripeCreatedAt` ledger field. Processing keeps this order:
+
+1. Return an exact processed-Event replay without changing its stored result.
+2. Check the outer Event realm and the applicable embedded Session, Charge, or Dispute realm.
+3. Check the applicable Checkout lifecycle, refund Charge status, or Dispute status.
+4. Check an explicit claimed-MPRC metadata version.
+5. Check the outer Event-created value for every supported Event type.
+6. Only then resolve a target or fallback, inspect ownership bindings, evaluate money or state, and persist the result.
+
+Malformed or unrelated reference classification is not an earlier admission result. Invalid supported Event time therefore wins before those target-handling paths. It produces durable `needs_review:invalid_event_created` with null target fields and `stripeCreatedAt: null`. It runs no target or fallback Firestore query, reads or changes no business record, and reads or creates no provider binding. The fixed review log contains only the Event ID, Event type, outcome, and null target type; it never includes the rejected value. The existing minimal reference classification may still supply redacted ledger ownership fields without performing target work. An exact replay returns the stored result read-only. A valid claimed Event whose target is missing remains retryable and writes no processed ledger.
+
+An earlier realm, lifecycle/status, or metadata failure keeps its existing outcome, while an unusable Event time is safely projected as null instead of reaching Firestore Timestamp construction. An unsupported Event never becomes `invalid_event_created`: it keeps its existing outcome and null target, and its ledger time is the valid projection or null. This safe projection prevents unrelated or already-rejected traffic from becoming a timestamp-construction retry storm.
+
+```mermaid
+flowchart TD
+    A["Verified Stripe Event"] --> B{"Already in the processed-Event ledger?"}
+    B -- "Yes" --> C["Return the stored result without changes"]
+    B -- "No" --> D{"Earlier realm, lifecycle or status, and metadata checks pass?"}
+    D -- "No" --> E["Keep the earlier result; store Event time or null safely"]
+    D -- "Yes" --> F{"Supported Event type?"}
+    F -- "No" --> G["Keep unsupported outcome; store Event time or null safely"]
+    F -- "Yes" --> H{"Event-created is an integer from 0 through 253402300799?"}
+    H -- "No" --> I["Record invalid-time review with no target"]
+    H -- "Yes" --> J["Continue target, binding, money, and state work"]
+```
+
+Text alternative: replay returns the existing ledger result first; a new Event keeps any earlier realm, lifecycle/status, or metadata result, unsupported traffic keeps its unsupported result, and both paths safely store a valid Event time or null. Only a supported Event with a Firestore-representable whole Unix timestamp may continue to target, binding, money, and state work.
+
+The expected result is target-free durable review for unusable supported time and unchanged behavior for valid representable time. Success proof requires separately named tests for all four Checkout lifecycles and refund Events; signed-JSON hostile shapes and bounds; earlier realm, lifecycle/status, and metadata precedence; target, fallback, binding, money, and state isolation; exact replay; inclusive epoch and Firestore-maximum controls; valid missing-target retry; unsupported-event compatibility; fixed redacted logging; and no rejected argument to `Timestamp.fromMillis()`. JSON fixtures label `NaN` and infinity honestly as normalized to `null`. A separate mocked post-parser Proxy control is defensive JavaScript evidence, not a claim that JSON can encode a Proxy. The complete PAY-003A7 suite and valid payment/refund behavior must remain green.
+
+Stop the merge if invalid time reaches a target query, provider binding, business mutation, log, serialized result detail, or Timestamp construction; if an earlier outcome changes; if a valid boundary regresses; or if a test needs a real credential, provider object, payment/refund, customer/member record, or production service. Escalate to the platform owner and payment reviewer. Undo is one small reviewed revert of the PAY-003A8 predicate/admission projection, tests, and this named section. Do not edit a provider object, processed ledger, or business record as an undo path.
+
+There is no schema, Rule, index, stored-data migration, or backfill. `stripeCreatedAt` already permits null. Valid Events, earlier admission precedence, target resolution, bindings, and payment/refund transitions remain compatible. Invalid supported time changes from target-capable behavior, or an above-range retrying `500`, to durable pre-target review. Above-range unsupported or earlier-rejected Events change from timestamp-construction `500` to their existing durable outcome with null time. Already-processed historical Events remain authoritative on replay and are neither inspected nor repaired.
+
+Residual work remains under PAY-003A9 and #106: embedded refund Charge-created admission, clock-skew/freshness policy, provider/API-version proof, provider retrieval and history repair, PAY-003B/C, reconciliation, alerts, protected release, and live verification. This source child validates no embedded Charge time, provider truth, payment/refund success, or production behavior.
+
+PAY-003A8 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed and read back, Stripe/provider configured or acted on, production data changed, payment/refund/dispute activity, and live behavior verified. Source and synthetic tests prove none of the later states. Officer impact and officer documentation are both none: this server-only boundary adds no officer screen, task, field, permission, approval, topology, or available recovery step. `SYSTEM_DESIGN.md`, `SECURITY.md`, `IMPLEMENTATION_PLAN.md`, `OPERATIONS_RUNBOOK.md`, `GITHUB_ISSUES.md`, and the officer guides remain compatible.
+
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
 ## 12. Payment and business state machines

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -34,7 +34,7 @@ const DISPUTE_EVENT_TYPES = new Set([
   'charge.dispute.closed',
 ]);
 
-function isValidDisputeEventCreated(value) {
+function isValidEventCreated(value) {
   return Number.isSafeInteger(value)
     && value >= 0
     && value <= FIRESTORE_TIMESTAMP_MAX_SECONDS;
@@ -165,8 +165,8 @@ function validateEventAdmission(event, expectedLivemode) {
   }
   const schemaValidation = validateMetadataSchemaVersion(event, expectedLivemode);
   if (!schemaValidation.ok) return schemaValidation;
-  if (DISPUTE_EVENT_TYPES.has(event.type)
-    && !isValidDisputeEventCreated(event.created)) {
+  if (isSupportedEventType(event.type)
+    && !isValidEventCreated(event.created)) {
     return {
       ok: false,
       expected: expectedLivemode,
@@ -1402,16 +1402,14 @@ function providerBindingCanBeRecorded(event, record, result) {
 
 function ledgerData(event, target, result, ownership) {
   const now = Date.now();
-  const unusableDisputeEventCreated = DISPUTE_EVENT_TYPES.has(event.type)
-    && !isValidDisputeEventCreated(event.created);
+  const eventCreated = event.created;
   return {
     eventId: event.id,
     type: event.type,
     objectId: objectId(event.data?.object) || null,
     livemode: event.livemode === true,
-    stripeCreatedAt: !unusableDisputeEventCreated
-      && Number.isSafeInteger(event.created)
-      ? Timestamp.fromMillis(event.created * 1000)
+    stripeCreatedAt: isValidEventCreated(eventCreated)
+      ? Timestamp.fromMillis(eventCreated * 1000)
       : null,
     status: 'processed',
     outcome: result.outcome,

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -202,6 +202,7 @@ jest.mock('firebase-admin/firestore', () => {
 
 const admin = require('firebase-admin');
 const { Timestamp } = require('firebase-admin/firestore');
+const Stripe = require('stripe');
 
 const WEBHOOK_SECRET = 'stripe_webhook_synthetic_test_material';
 process.env.ENVIRONMENT_NAME = 'test';
@@ -354,6 +355,24 @@ const DISPUTE_EVENT_CREATED_CASES = [
     value,
   ])
 ));
+const NON_DISPUTE_EVENT_TYPES = [
+  ['Checkout completed', 'checkout.session.completed'],
+  ['Checkout async success', 'checkout.session.async_payment_succeeded'],
+  ['Checkout async failure', 'checkout.session.async_payment_failed'],
+  ['Checkout expired', 'checkout.session.expired'],
+  ['refund', 'charge.refunded'],
+];
+const NON_DISPUTE_EVENT_CREATED_CASES = NON_DISPUTE_EVENT_TYPES.flatMap(
+  ([lifecycle, type]) => INVALID_DISPUTE_EVENT_CREATED_CASES.map(
+    ([evidence, mutation, value]) => [
+      lifecycle,
+      evidence,
+      type,
+      mutation,
+      value,
+    ],
+  ),
+);
 
 function stripeEvent(id, type, object) {
   const checkoutStatus = CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE[type];
@@ -500,6 +519,63 @@ function seedOrder(overrides = {}) {
   });
 }
 
+function nonDisputeEventFixture(type, suffix, { missingTarget = false } = {}) {
+  if (type === 'charge.refunded') {
+    if (!missingTarget) {
+      seedOrder({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: 'pi_order_1',
+        stripeAmountTotalCents: 2000,
+      });
+    }
+    return {
+      businessPath: missingTarget ? null : 'orders/order-1',
+      event: stripeEvent(
+        `evt_pay003a8_${suffix}`,
+        type,
+        orderRefundCharge({
+          id: `ch_pay003a8_${suffix}`,
+          metadata: missingTarget ? {
+            schemaVersion: '1',
+            type: 'merch',
+            orderId: 'order-missing',
+          } : {
+            schemaVersion: '1',
+            type: 'merch',
+            orderId: 'order-1',
+          },
+        }),
+      ),
+    };
+  }
+
+  if (!missingTarget) seedRegistration();
+  const unpaid = type === 'checkout.session.async_payment_failed'
+    || type === 'checkout.session.expired';
+  return {
+    businessPath: missingTarget ? null : 'events/race-1/registrations/reg-1',
+    event: stripeEvent(
+      `evt_pay003a8_${suffix}`,
+      type,
+      registrationSession({
+        payment_status: unpaid ? 'unpaid' : 'paid',
+        metadata: missingTarget ? {
+          schemaVersion: '1',
+          eventId: 'race-missing',
+          registrationId: 'registration-missing',
+          priceTier: 'nonMember',
+        } : {
+          schemaVersion: '1',
+          eventId: 'race-1',
+          registrationId: 'reg-1',
+          priceTier: 'nonMember',
+        },
+      }),
+    ),
+  };
+}
+
 function signedRequest(event, signatureOverride) {
   const timestamp = Math.floor(Date.now() / 1000);
   const signedPayload = createSignedStripePayload({
@@ -527,6 +603,23 @@ async function deliver(event) {
   const response = mockResponse();
   await stripeWebhook(signedRequest(event), response);
   return response;
+}
+
+async function deliverMockedConstructedEvent(event) {
+  const transportEvent = stripeEvent(
+    'evt_pay003a8_safe_transport',
+    'checkout.session.completed',
+    registrationSession(),
+  );
+  const constructEvent = jest.spyOn(Stripe.webhooks, 'constructEvent')
+    .mockReturnValueOnce(event);
+  try {
+    const response = mockResponse();
+    await stripeWebhook(signedRequest(transportEvent), response);
+    return response;
+  } finally {
+    constructEvent.mockRestore();
+  }
 }
 
 function storedCopy(path) {
@@ -666,7 +759,7 @@ function expectedDisputeStatusQuarantine(bindingPaths = []) {
   };
 }
 
-function expectedDisputeEventCreatedQuarantine(bindingPaths = []) {
+function expectedEventCreatedQuarantine(bindingPaths = []) {
   return {
     httpStatus: null,
     response: {
@@ -2289,7 +2382,7 @@ describe('stripeWebhook', () => {
         response,
         event,
         businessSnapshots: [[businessPath, before]],
-      })).toEqual(expectedDisputeEventCreatedQuarantine());
+      })).toEqual(expectedEventCreatedQuarantine());
       expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
         stripeCreatedAt: null,
       });
@@ -2363,7 +2456,7 @@ describe('stripeWebhook', () => {
       response,
       event,
       businessSnapshots: [[businessPath, before]],
-    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    })).toEqual(expectedEventCreatedQuarantine());
     expectOnlyEventLedgerReads(event);
   });
 
@@ -2384,7 +2477,7 @@ describe('stripeWebhook', () => {
     const response = await deliver(event);
 
     expect(refundAdmissionObservation({ response, event }))
-      .toEqual(expectedDisputeEventCreatedQuarantine());
+      .toEqual(expectedEventCreatedQuarantine());
     expectOnlyEventLedgerReads(event);
   });
 
@@ -2409,7 +2502,7 @@ describe('stripeWebhook', () => {
     const response = await deliver(event);
 
     expect(refundAdmissionObservation({ response, event }))
-      .toEqual(expectedDisputeEventCreatedQuarantine());
+      .toEqual(expectedEventCreatedQuarantine());
     expectOnlyEventLedgerReads(event);
   });
 
@@ -2448,7 +2541,7 @@ describe('stripeWebhook', () => {
       response,
       event,
       businessSnapshots: snapshots,
-    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    })).toEqual(expectedEventCreatedQuarantine());
     expectOnlyEventLedgerReads(event);
   });
 
@@ -2481,7 +2574,7 @@ describe('stripeWebhook', () => {
       response,
       event,
       businessSnapshots: [[businessPath, before]],
-    })).toEqual(expectedDisputeEventCreatedQuarantine([disputeBindingPath]));
+    })).toEqual(expectedEventCreatedQuarantine([disputeBindingPath]));
     expect(admin.__get(disputeBindingPath)).toEqual(beforeBinding);
     expect(admin.__get('stripeObjectBindings/charge:ch_order_1')).toBeUndefined();
     expect(admin.__get('stripeObjectBindings/payment_intent:pi_order_1')).toBeUndefined();
@@ -2576,7 +2669,7 @@ describe('stripeWebhook', () => {
       response,
       event,
       businessSnapshots: [[businessPath, before]],
-    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    })).toEqual(expectedEventCreatedQuarantine());
     expectOnlyEventLedgerReads(event);
   });
 
@@ -2600,7 +2693,7 @@ describe('stripeWebhook', () => {
       response: firstResponse,
       event,
       businessSnapshots: [[businessPath, before]],
-    })).toEqual(expectedDisputeEventCreatedQuarantine());
+    })).toEqual(expectedEventCreatedQuarantine());
     expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
       received: true,
       duplicate: true,
@@ -2704,6 +2797,374 @@ describe('stripeWebhook', () => {
     providerBindingPaths(event).forEach((path) => {
       expect(admin.__get(path)).toBeUndefined();
     });
+  });
+
+  test.each(NON_DISPUTE_EVENT_CREATED_CASES)(
+    'PAY-003A8 quarantines %s with %s outer Event-created evidence',
+    async (lifecycle, evidence, type, mutation, value) => {
+      const slug = `${lifecycle}_${evidence}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event, businessPath } = nonDisputeEventFixture(type, slug);
+      const before = storedCopy(businessPath);
+      setEventCreated(event, mutation, value);
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedEventCreatedQuarantine());
+      expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+        stripeCreatedAt: null,
+      });
+      expectOnlyEventLedgerReads(event);
+      if (Number.isSafeInteger(value)) {
+        expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(value * 1000);
+      }
+      expect(consoleError).toHaveBeenCalledWith(
+        'Stripe event requires review',
+        {
+          eventId: event.id,
+          eventType: type,
+          outcome: 'needs_review:invalid_event_created',
+          targetType: null,
+        },
+      );
+      expect(JSON.stringify({
+        response: response.json.mock.calls,
+        ledger: admin.__get(`stripeEvents/${event.id}`),
+        logs: consoleError.mock.calls,
+      })).not.toContain('hostile-event-created-do-not-log');
+    },
+  );
+
+  test.each(NON_DISPUTE_EVENT_TYPES)(
+    'PAY-003A8 defensively rejects a parser-return Proxy for %s without coercion',
+    async (lifecycle, type) => {
+      const slug = lifecycle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event, businessPath } = nonDisputeEventFixture(type, `proxy_${slug}`);
+      const before = storedCopy(businessPath);
+      const trap = jest.fn(() => {
+        throw new Error('Event-created Proxy trap must not run');
+      });
+      event.created = new Proxy({}, {
+        get: trap,
+        getOwnPropertyDescriptor: trap,
+        ownKeys: trap,
+      });
+
+      const response = await deliverMockedConstructedEvent(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedEventCreatedQuarantine());
+      expectOnlyEventLedgerReads(event);
+      expect(trap).not.toHaveBeenCalled();
+    },
+  );
+
+  test('PAY-003A8 blocks invalid Checkout time before ambiguous legacy fallback', async () => {
+    seedOrder({ stripeSessionId: 'cs_pay003a8_ambiguous' });
+    seedRegistration({ stripeSessionId: 'cs_pay003a8_ambiguous' });
+    const snapshots = [
+      ['orders/order-1', storedCopy('orders/order-1')],
+      [
+        'events/race-1/registrations/reg-1',
+        storedCopy('events/race-1/registrations/reg-1'),
+      ],
+    ];
+    const event = stripeEvent(
+      'evt_pay003a8_checkout_fallback',
+      'checkout.session.completed',
+      registrationSession({
+        id: 'cs_pay003a8_ambiguous',
+        metadata: {},
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: snapshots,
+    })).toEqual(expectedEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A8 blocks invalid refund time before ambiguous legacy fallback', async () => {
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_pay003a8_ambiguous',
+      stripeAmountTotalCents: 2000,
+    });
+    seedRegistration({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: 'pi_pay003a8_ambiguous',
+      stripeAmountTotalCents: 5000,
+    });
+    const snapshots = [
+      ['orders/order-1', storedCopy('orders/order-1')],
+      [
+        'events/race-1/registrations/reg-1',
+        storedCopy('events/race-1/registrations/reg-1'),
+      ],
+    ];
+    const event = stripeEvent(
+      'evt_pay003a8_refund_fallback',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_pay003a8_refund_fallback',
+        payment_intent: 'pi_pay003a8_ambiguous',
+        metadata: {},
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: snapshots,
+    })).toEqual(expectedEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A8 keeps invalid time ahead of malformed reference handling', async () => {
+    const event = stripeEvent(
+      'evt_pay003a8_malformed_reference',
+      'checkout.session.completed',
+      registrationSession({
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-1',
+          eventId: 'race-1',
+          registrationId: 'reg-1',
+        },
+      }),
+    );
+    event.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedEventCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test.each([
+    [
+      'Checkout outer realm',
+      'checkout.session.completed',
+      'livemode_mismatch',
+      (event) => { event.livemode = true; },
+    ],
+    [
+      'Checkout embedded realm',
+      'checkout.session.completed',
+      'checkout_session_livemode_mismatch',
+      (event) => { event.data.object.livemode = true; },
+    ],
+    [
+      'Checkout lifecycle',
+      'checkout.session.completed',
+      'checkout_session_status_mismatch',
+      (event) => { event.data.object.status = 'hostile-checkout-status'; },
+    ],
+    [
+      'Checkout metadata schema',
+      'checkout.session.completed',
+      'metadata_schema_version_mismatch',
+      (event) => { setMetadataSchema(event.data.object, '2'); },
+    ],
+    [
+      'refund outer realm',
+      'charge.refunded',
+      'livemode_mismatch',
+      (event) => { event.livemode = true; },
+    ],
+    [
+      'refund embedded realm',
+      'charge.refunded',
+      'charge_livemode_mismatch',
+      (event) => { event.data.object.livemode = true; },
+    ],
+    [
+      'refund Charge status',
+      'charge.refunded',
+      'charge_status_mismatch',
+      (event) => { event.data.object.status = 'pending'; },
+    ],
+    [
+      'refund metadata schema',
+      'charge.refunded',
+      'metadata_schema_version_mismatch',
+      (event) => { setMetadataSchema(event.data.object, '2'); },
+    ],
+  ])('PAY-003A8 keeps %s precedence with unusable Event time', async (
+    label,
+    type,
+    reason,
+    mutate,
+  ) => {
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const { event, businessPath } = nonDisputeEventFixture(type, `precedence_${slug}`);
+    const before = storedCopy(businessPath);
+    event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1;
+    mutate(event);
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({ response, event, businessPath, before, reason });
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      stripeCreatedAt: null,
+    });
+    expectOnlyEventLedgerReads(event);
+    expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
+      (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
+    );
+  });
+
+  test.each(NON_DISPUTE_EVENT_TYPES)(
+    'PAY-003A8 processes invalid %s Event time before a claimed missing target',
+    async (lifecycle, type) => {
+      const slug = lifecycle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event } = nonDisputeEventFixture(type, `missing_${slug}`, {
+        missingTarget: true,
+      });
+      event.created = -1;
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({ response, event }))
+        .toEqual(expectedEventCreatedQuarantine());
+      expectOnlyEventLedgerReads(event);
+    },
+  );
+
+  test.each(NON_DISPUTE_EVENT_TYPES)(
+    'PAY-003A8 deduplicates rejected %s Event time without target work',
+    async (lifecycle, type) => {
+      const slug = lifecycle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event, businessPath } = nonDisputeEventFixture(type, `replay_${slug}`);
+      const before = storedCopy(businessPath);
+      event.created = -1;
+
+      const firstResponse = await deliver(event);
+      const ledgerPath = `stripeEvents/${event.id}`;
+      const afterFirstLedger = storedCopy(ledgerPath);
+      const replayResponse = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response: firstResponse,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedEventCreatedQuarantine());
+      expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+        received: true,
+        duplicate: true,
+        outcome: 'needs_review:invalid_event_created',
+      }));
+      expect(admin.__get(businessPath)).toEqual(before);
+      expect(admin.__get(ledgerPath)).toEqual(afterFirstLedger);
+      expect(admin.__readOperations()).toEqual([
+        { kind: 'document', path: ledgerPath },
+        { kind: 'document', path: ledgerPath },
+        { kind: 'document', path: ledgerPath },
+      ]);
+      expect(Timestamp.fromMillis).toHaveBeenCalledTimes(2);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(NON_DISPUTE_EVENT_TYPES.flatMap(([lifecycle, type]) => [
+    [lifecycle, type, 'Unix epoch', 0],
+    [lifecycle, type, 'Firestore maximum', FIRESTORE_TIMESTAMP_MAX_SECONDS],
+  ]))('PAY-003A8 admits the inclusive %s %s %s Event-created boundary', async (
+    lifecycle,
+    type,
+    boundary,
+    eventCreated,
+  ) => {
+    const slug = `${lifecycle}_${boundary}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const { event } = nonDisputeEventFixture(type, `valid_${slug}`);
+    event.created = eventCreated;
+
+    const response = await deliver(event);
+
+    expect(response.status).not.toHaveBeenCalledWith(500);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+    }));
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      stripeCreatedAt: { _milliseconds: eventCreated * 1000 },
+    });
+  });
+
+  test.each(NON_DISPUTE_EVENT_TYPES)(
+    'PAY-003A8 keeps an admissible claimed missing %s target retryable',
+    async (lifecycle, type) => {
+      const slug = lifecycle.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event } = nonDisputeEventFixture(type, `valid_missing_${slug}`, {
+        missingTarget: true,
+      });
+      event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+
+      const response = await deliver(event);
+
+      expect(response.status).toHaveBeenCalledWith(500);
+      expect(admin.__get(`stripeEvents/${event.id}`)).toBeUndefined();
+      providerBindingPaths(event).forEach((path) => {
+        expect(admin.__get(path)).toBeUndefined();
+      });
+    },
+  );
+
+  test('PAY-003A8 safely preserves an unsupported Event with unusable time', async () => {
+    const event = stripeEvent(
+      'evt_pay003a8_unsupported',
+      'customer.created',
+      { id: 'cus_pay003a8_unsupported', object: 'customer' },
+    );
+    event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1;
+
+    const firstResponse = await deliver(event);
+    const ledgerPath = `stripeEvents/${event.id}`;
+    const afterFirstLedger = admin.__get(ledgerPath) === undefined
+      ? undefined
+      : storedCopy(ledgerPath);
+    const replayResponse = await deliver(event);
+
+    expect(firstResponse.status).not.toHaveBeenCalledWith(500);
+    expect(firstResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'ignored:unsupported_event',
+    }));
+    expect(admin.__get(ledgerPath)).toMatchObject({
+      outcome: 'ignored:unsupported_event',
+      stripeCreatedAt: null,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    });
+    expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: true,
+      outcome: 'ignored:unsupported_event',
+    }));
+    expect(admin.__get(ledgerPath)).toEqual(afterFirstLedger);
+    expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
+      (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
+    );
   });
 
   test('quarantines an incompatible claimed Dispute before resolving its missing target', async () => {


### PR DESCRIPTION
Closes #572

## Outcome

Every supported Checkout/refund Stripe Event must now carry a Firestore-representable outer Event timestamp before target, fallback, provider-binding, money, or state work. Earlier realm/lifecycle/status/metadata review reasons retain precedence, and unsupported Events retain their existing outcome with a safely nullable ledger timestamp.

## Invariant and transitions

- Processed replay remains first and read-only.
- Outer realm, embedded realm, lifecycle/status, and explicit claimed metadata version remain ahead of Event-time admission.
- Supported `event.created` must be a primitive safe integer in `0..253402300799`.
- Invalid time produces durable `needs_review:invalid_event_created`, null target fields, and `stripeCreatedAt: null`.
- No invalid value reaches `Timestamp.fromMillis`, logs, serialized details, target queries, provider bindings, or business mutation.
- Valid claimed missing targets remain retryable without a processed ledger.
- Valid payment/refund transitions and PAY-003A7 Dispute behavior remain unchanged.

## Change

- Generalize the existing Dispute Event-created predicate to all supported Event types.
- Reuse it for safe ledger projection for every Event, including unsupported and earlier-rejected traffic.
- Add a separately named 107-test PAY-003A8 matrix and controls.
- Add the named source-only design section with order, proof, stop/undo/escalation, Mermaid/text alternative, compatibility, residuals, and evidence boundaries.

## Trustworthy RED

On untouched source at exact base `511d117972e2fcd951abc1c91f3e111e158acaee`, the test-only slice produced 85 intended failures and 15 valid controls. Old source mutated targets/created bindings for invalid non-Dispute time, retried invalid claimed-missing targets, and returned 500 for above-range earlier quarantines and unsupported Events. NaN/infinity are labeled as signed-JSON normalization to null; Proxy coverage is separately labeled as a mocked post-parser defensive control.

## Verification

Pinned Node `20.20.2`:

- PAY-003A8: 107/107
- Webhook: 508/508
- Functions lint: passed
- Complete Functions after clean post-#573 lock install: 6,959 passed / 64 intentional skips
- Frontend: 951/951
- TypeScript no-emit: passed
- Frontend lint ledger: 118 files / 113 reviewed legacy errors / 6 reviewed warnings
- SPA: 11/11
- Repository safety: 82/82
- Diagnostic build: passed
- Firestore Rules emulator: 418/418
- Real demo-only commerce emulator: 63/63
- Three independent exact-rebased reviews: GO, no findings

Current exact base is `8f238e57574b2913f0563727ce8dedfb6a6f1876`; exact head is `a6f69cc569653d9a4d9d3c78f86eb65ff57bbf19`; tree is `a5a2290754a487b6ae5a6d03e3d19e90d4cdd856`; exact three-file binary patch SHA-256 is `14ac30fdd98afc6a370f7e13d7da4210a08d5e08d1be30e4016b5d3510704dc0`. #573 was disjoint, its exact-main CI passed all five jobs, and the PAY-003A8 patch remained byte-identical across the controlled refresh. Fresh exact-head hosted CI is required.

## Compatibility and migration

No schema, Rule, index, migration, backfill, package, or workflow change. Existing nullable `stripeCreatedAt` storage is reused. Historical processed ledgers remain authoritative and are not inspected or repaired. PAY-003A9 retains embedded refund Charge-created evidence; clock freshness, provider/API-version proof, reconciliation, release, and live proof remain under #106.

Officer impact: None — this is a server-only pre-target payment Event boundary and adds no officer screen, task, field, permission, approval, or recovery step.

Officer documentation: None — no officer-visible procedure, navigation, topology, data movement, permission, or deployment process changed. Engineering current truth is updated in `STRIPE_COMMERCE_DESIGN.md`.

Deployment evidence: Source changed and synthetic tests passed. Code is not yet merged. Website publication, `runmprc.com` verification, Firebase deployment/readback, Stripe/provider configuration/action, production-data change, payment/refund/dispute activity, and live behavior are all unperformed and unverified.