### PR TITLE
PAY-003A9: reject invalid refund Charge timestamps

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -853,6 +853,50 @@ Residual work remains under PAY-003A9 and #106: embedded refund Charge-created a
 
 PAY-003A8 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed and read back, Stripe/provider configured or acted on, production data changed, payment/refund/dispute activity, and live behavior verified. Source and synthetic tests prove none of the later states. Officer impact and officer documentation are both none: this server-only boundary adds no officer screen, task, field, permission, approval, topology, or available recovery step. `SYSTEM_DESIGN.md`, `SECURITY.md`, `IMPLEMENTATION_PLAN.md`, `OPERATIONS_RUNBOOK.md`, `GITHUB_ISSUES.md`, and the officer guides remain compatible.
 
+### PAY-003A9 Refund Charge-created admission — SOURCE ONLY, NOT LIVE
+
+PAY-003A9 [#578](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/578) closes PAY-003A8's embedded-refund-time residual. Its purpose is to reject unusable `Charge.created` evidence on a new `charge.refunded` Event before any reference or fallback Firestore query, business-record read or change, provider-binding work, money check, or business-state transition. The embedded value must be a primitive safe integer from Unix epoch second `0` through Firestore maximum second `253402300799`, inclusive. A valid refund uses that provider time for a missing `paidAt`; it never invents payment time from the current server clock. An existing `paidAt` remains unchanged, but it cannot bypass admission.
+
+Approvers for this source boundary are the platform owner and payment reviewer. Prerequisites are verified webhook signature handling, the processed-Event ledger, PAY-003A5 Charge realm/status admission, PAY-003A8 outer Event-time admission, synthetic signed fixtures, and the existing nullable ledger fields. A new refund Event keeps this order:
+
+1. Return an exact processed-Event replay without changing its stored result.
+2. Check the outer Event realm.
+3. Check the embedded Charge realm.
+4. Require the exact Charge status `succeeded`.
+5. Check an explicit claimed-MPRC metadata schema version.
+6. Check the outer Event-created value.
+7. Check the embedded Charge-created value.
+8. Only then resolve a reference or fallback, inspect ownership and bindings, evaluate money and state, and persist the result.
+
+Missing, `null`, boolean, string, object, array, fractional, non-finite, negative, unsafe, or above-range Charge time produces durable `needs_review:invalid_charge_created`. The ledger keeps the valid outer `stripeCreatedAt` but has null target fields. The handler performs only the normal two new-Event ledger reads. It does not query a target or fallback, read or change a business record, or read or create a Charge or PaymentIntent binding. The fixed review log names only the Event ID, Event type, outcome, and null target type. It never contains the rejected value. An exact replay returns the stored result read-only.
+
+Earlier outer or embedded realm, Charge-status, metadata-version, and outer Event-time failures keep their existing outcomes. The metadata-version check and ledger ownership fields may use the existing pure in-memory reference classifier, but full malformed or unrelated reference handling remains later. Invalid Charge time therefore wins before any reference or fallback Firestore query. A valid claimed Event whose target is absent keeps the existing retryable behavior and writes no processed ledger.
+
+```mermaid
+flowchart TD
+    A["Verified charge.refunded Event"] --> B{"Already in the processed-Event ledger?"}
+    B -- "Yes" --> C["Return the stored result without changes"]
+    B -- "No" --> D{"Realm, Charge status, and metadata version pass?"}
+    D -- "No" --> E["Keep the earlier fixed review result"]
+    D -- "Yes" --> F{"Outer Event-created is valid?"}
+    F -- "No" --> G["Record invalid Event-time review"]
+    F -- "Yes" --> H{"Embedded Charge-created is an integer from 0 through 253402300799?"}
+    H -- "No" --> I["Record invalid Charge-time review with no target"]
+    H -- "Yes" --> J["Continue target, binding, money, and state work"]
+```
+
+Text alternative: replay returns an existing ledger result first; a new refund keeps earlier realm, status, metadata, and outer Event-time outcomes, then rejects unusable embedded Charge time without target work, while valid time may continue to normal refund processing.
+
+The expected result is target-free durable review for unusable embedded time and unchanged refund behavior for valid representable time. Success proof requires signed synthetic cases for both registration and order targets across every hostile shape and bound; honest labels for JSON-normalized `NaN` and infinity; a separately labeled mocked post-parser Proxy control; existing-`paidAt`, fallback, malformed-reference, missing-target, earlier-precedence, replay, lower/upper-bound, and non-refund compatibility controls; exact read isolation; fixed redacted logs; and proof that rejected values reach neither `Timestamp.fromMillis()` nor `Timestamp.now()`. The complete webhook suite and prior PAY-003A5/A8 matrices must remain green.
+
+Stop the merge if invalid Charge time reaches a target or fallback query, binding, business mutation, timestamp construction, log, response detail, or ledger detail; if an earlier outcome changes; if either valid boundary regresses; if current time is again substituted for missing provider evidence; or if a test needs a real credential, provider object, refund/payment, customer/member record, or production service. Escalate to the platform owner and payment reviewer. Undo is one small reviewed revert of the PAY-003A9 predicate/admission and refund-time projection, tests, and this named section. Do not edit a provider object, processed ledger, or business record as an undo path.
+
+There is no schema, Rule, index, package, workflow, stored-data migration, or backfill. Valid Events, earlier admission precedence, target resolution, bindings, money checks, refund transitions, and existing `paidAt` values remain compatible. Invalid embedded time changes from target-capable behavior, fabricated current time, or an above-range retrying `500` to durable pre-target review. Already-processed historical Events remain authoritative on replay. Previously stored `paidAt` values are not inspected or repaired.
+
+Residual work remains under #106: clock-skew and freshness policy, Charge/Event chronology, Checkout Session and Dispute embedded-time decisions, provider endpoint/API-version proof, provider retrieval and history repair, PAY-003B/C, reconciliation, alerts, protected release, and live verification. This child proves no provider truth, payment/refund success, historical correctness, or production behavior.
+
+PAY-003A9 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed and read back, Stripe/provider configured or acted on, production data changed, payment/refund/dispute activity, and live behavior verified. Source and synthetic tests prove none of the later states. Officer impact and officer documentation are both none: this server-only evidence boundary adds no officer screen, task, field, permission, approval, topology, or available recovery step. The root design, security, implementation, operations, issue, and officer guides remain compatible.
+
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
 ## 12. Payment and business state machines

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -34,7 +34,7 @@ const DISPUTE_EVENT_TYPES = new Set([
   'charge.dispute.closed',
 ]);
 
-function isValidEventCreated(value) {
+function isValidStripeCreated(value) {
   return Number.isSafeInteger(value)
     && value >= 0
     && value <= FIRESTORE_TIMESTAMP_MAX_SECONDS;
@@ -166,11 +166,19 @@ function validateEventAdmission(event, expectedLivemode) {
   const schemaValidation = validateMetadataSchemaVersion(event, expectedLivemode);
   if (!schemaValidation.ok) return schemaValidation;
   if (isSupportedEventType(event.type)
-    && !isValidEventCreated(event.created)) {
+    && !isValidStripeCreated(event.created)) {
     return {
       ok: false,
       expected: expectedLivemode,
       reason: 'invalid_event_created',
+    };
+  }
+  if (event.type === 'charge.refunded'
+    && !isValidStripeCreated(event.data?.object?.created)) {
+    return {
+      ok: false,
+      expected: expectedLivemode,
+      reason: 'invalid_charge_created',
     };
   }
   return modeValidation;
@@ -1139,11 +1147,7 @@ function refundTransition({ event, charge, target, record }) {
     stripeChargeId: record.stripeChargeId || chargeId,
     stripeAmountTotalCents: totalAmount,
     stripeAmountRefundedCents: amountRefunded,
-    paidAt: record.paidAt || (
-      Number.isSafeInteger(charge.created)
-        ? Timestamp.fromMillis(charge.created * 1000)
-        : Timestamp.now()
-    ),
+    paidAt: record.paidAt || Timestamp.fromMillis(charge.created * 1000),
     refundedAt: Timestamp.now(),
     lastStripeEventId: event.id,
     updatedAt: Timestamp.now(),
@@ -1408,7 +1412,7 @@ function ledgerData(event, target, result, ownership) {
     type: event.type,
     objectId: objectId(event.data?.object) || null,
     livemode: event.livemode === true,
-    stripeCreatedAt: isValidEventCreated(eventCreated)
+    stripeCreatedAt: isValidStripeCreated(eventCreated)
       ? Timestamp.fromMillis(eventCreated * 1000)
       : null,
     status: 'processed',

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -186,7 +186,7 @@ jest.mock('firebase-admin/firestore', () => {
   let tick = 1_800_000_000_000;
   return {
     Timestamp: {
-      now: () => ({ _milliseconds: tick += 1 }),
+      now: jest.fn(() => ({ _milliseconds: tick += 1 })),
       fromMillis: jest.fn((milliseconds) => {
         if (!Number.isFinite(milliseconds)
           || milliseconds < -62_135_596_800_000
@@ -373,6 +373,28 @@ const NON_DISPUTE_EVENT_CREATED_CASES = NON_DISPUTE_EVENT_TYPES.flatMap(
     ],
   ),
 );
+const REFUND_CHARGE_CREATED_DOMAINS = ['registration', 'order'];
+const INVALID_REFUND_CHARGE_CREATED_CASES = [
+  ['missing', 'delete', undefined],
+  ['null', 'value', null],
+  ['negative', 'value', -1],
+  ['fractional', 'value', 1.5],
+  ['string', 'value', 'hostile-charge-created-do-not-log'],
+  ['boolean', 'value', true],
+  ['object', 'value', { marker: 'hostile-charge-created-do-not-log' }],
+  ['array', 'value', ['hostile-charge-created-do-not-log']],
+  ['NaN serialized as null', 'value', Number.NaN],
+  ['positive infinity serialized as null', 'value', Number.POSITIVE_INFINITY],
+  ['negative infinity serialized as null', 'value', Number.NEGATIVE_INFINITY],
+  ['Firestore maximum plus one', 'value', FIRESTORE_TIMESTAMP_MAX_SECONDS + 1],
+  ['maximum safe integer', 'value', Number.MAX_SAFE_INTEGER],
+  ['unsafe integer', 'value', Number.MAX_SAFE_INTEGER + 1],
+];
+const REFUND_CHARGE_CREATED_CASES = REFUND_CHARGE_CREATED_DOMAINS.flatMap(
+  (domain) => INVALID_REFUND_CHARGE_CREATED_CASES.map(
+    ([evidence, mutation, value]) => [domain, evidence, mutation, value],
+  ),
+);
 
 function stripeEvent(id, type, object) {
   const checkoutStatus = CHECKOUT_SESSION_STATUS_BY_EVENT_TYPE[type];
@@ -380,7 +402,12 @@ function stripeEvent(id, type, object) {
   if (checkoutStatus) {
     providerObject = { livemode: false, status: checkoutStatus, ...object };
   } else if (type === 'charge.refunded') {
-    providerObject = { livemode: false, status: 'succeeded', ...object };
+    providerObject = {
+      created: 1_799_999_900,
+      livemode: false,
+      status: 'succeeded',
+      ...object,
+    };
   } else if (PROVIDER_OBJECT_REALM_EVENT_TYPES.has(type)) {
     providerObject = { livemode: false, ...object };
   }
@@ -576,6 +603,58 @@ function nonDisputeEventFixture(type, suffix, { missingTarget = false } = {}) {
   };
 }
 
+function refundChargeCreatedFixture(
+  domain,
+  suffix,
+  { missingTarget = false, existingPaidAt = null } = {},
+) {
+  const registration = domain === 'registration';
+  const businessPath = registration
+    ? 'events/race-1/registrations/reg-1'
+    : 'orders/order-1';
+  const paymentIntentId = `pi_pay003a9_${suffix}`;
+  const amount = registration ? 5000 : 2000;
+  const metadata = registration ? {
+    schemaVersion: '1',
+    eventId: missingTarget ? 'race-missing' : 'race-1',
+    registrationId: missingTarget ? 'registration-missing' : 'reg-1',
+  } : {
+    schemaVersion: '1',
+    type: 'merch',
+    orderId: missingTarget ? 'order-missing' : 'order-1',
+  };
+
+  if (!missingTarget) {
+    const record = {
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: paymentIntentId,
+      stripeAmountTotalCents: amount,
+      ...(existingPaidAt ? { paidAt: existingPaidAt } : {}),
+    };
+    if (registration) seedRegistration(record);
+    else seedOrder(record);
+  }
+
+  return {
+    businessPath: missingTarget ? null : businessPath,
+    event: stripeEvent(
+      `evt_pay003a9_${suffix}`,
+      'charge.refunded',
+      {
+        id: `ch_pay003a9_${suffix}`,
+        object: 'charge',
+        payment_intent: paymentIntentId,
+        amount,
+        amount_refunded: 500,
+        currency: 'usd',
+        metadata,
+        refunds: { data: [{ id: `re_pay003a9_${suffix}` }] },
+      },
+    ),
+  };
+}
+
 function signedRequest(event, signatureOverride) {
   const timestamp = Math.floor(Date.now() / 1000);
   const signedPayload = createSignedStripePayload({
@@ -643,6 +722,11 @@ function setDisputeStatus(dispute, mutation, value) {
 function setEventCreated(event, mutation, value) {
   if (mutation === 'delete') delete event.created;
   else event.created = value;
+}
+
+function setChargeCreated(charge, mutation, value) {
+  if (mutation === 'delete') delete charge.created;
+  else charge.created = value;
 }
 
 function providerBindingPaths(event) {
@@ -781,11 +865,44 @@ function expectedEventCreatedQuarantine(bindingPaths = []) {
   };
 }
 
+function expectedChargeCreatedQuarantine(bindingPaths = []) {
+  return {
+    httpStatus: null,
+    response: {
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:invalid_charge_created',
+      requiresReview: true,
+    },
+    businessUnchanged: true,
+    ledger: {
+      status: 'processed',
+      outcome: 'needs_review:invalid_charge_created',
+      requiresReview: true,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    },
+    bindingPaths,
+  };
+}
+
 function expectOnlyEventLedgerReads(event) {
   expect(admin.__readOperations()).toEqual([
     { kind: 'document', path: `stripeEvents/${event.id}` },
     { kind: 'document', path: `stripeEvents/${event.id}` },
   ]);
+}
+
+function expectOnlyEventLedgerTimestamps(event) {
+  const ledger = admin.__get(`stripeEvents/${event.id}`);
+  expect(Timestamp.fromMillis.mock.calls).toEqual([
+    [event.created * 1000],
+    [ledger.processedAt._milliseconds],
+    [ledger.expiresAt._milliseconds],
+  ]);
+  expect(ledger.expiresAt._milliseconds - ledger.processedAt._milliseconds)
+    .toBe(90 * 24 * 60 * 60 * 1000);
 }
 
 function seedPaidDisputeOrder(overrides = {}) {
@@ -808,6 +925,7 @@ describe('stripeWebhook', () => {
 
   beforeEach(() => {
     admin.__clear();
+    Timestamp.now.mockClear();
     Timestamp.fromMillis.mockClear();
     delete process.env.COMMERCE_ENABLED;
     process.env.ENVIRONMENT_NAME = 'test';
@@ -3165,6 +3283,392 @@ describe('stripeWebhook', () => {
     expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
       (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
     );
+  });
+
+  test.each(REFUND_CHARGE_CREATED_CASES)(
+    'PAY-003A9 quarantines %s refund with %s Charge-created evidence',
+    async (domain, evidence, mutation, value) => {
+      const slug = `${domain}_${evidence}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event, businessPath } = refundChargeCreatedFixture(domain, slug);
+      const before = storedCopy(businessPath);
+      setChargeCreated(event.data.object, mutation, value);
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedChargeCreatedQuarantine());
+      expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+        stripeCreatedAt: { _milliseconds: event.created * 1000 },
+      });
+      expectOnlyEventLedgerReads(event);
+      expectOnlyEventLedgerTimestamps(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        'Stripe event requires review',
+        {
+          eventId: event.id,
+          eventType: 'charge.refunded',
+          outcome: 'needs_review:invalid_charge_created',
+          targetType: null,
+        },
+      );
+      expect(JSON.stringify({
+        response: response.json.mock.calls,
+        ledger: admin.__get(`stripeEvents/${event.id}`),
+        logs: consoleError.mock.calls,
+      })).not.toContain('hostile-charge-created-do-not-log');
+    },
+  );
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 defensively rejects a post-parser Proxy for %s Charge-created',
+    async (domain) => {
+      const { event, businessPath } = refundChargeCreatedFixture(domain, `proxy_${domain}`);
+      const before = storedCopy(businessPath);
+      const trap = jest.fn(() => {
+        throw new Error('Charge-created Proxy trap must not run');
+      });
+      event.data.object.created = new Proxy({}, {
+        get: trap,
+        getOwnPropertyDescriptor: trap,
+        ownKeys: trap,
+      });
+
+      const response = await deliverMockedConstructedEvent(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedChargeCreatedQuarantine());
+      expectOnlyEventLedgerReads(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expect(trap).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 does not let existing %s paidAt bypass invalid Charge-created admission',
+    async (domain) => {
+      const existingPaidAt = { _milliseconds: 1_700_000_000_000 };
+      const { event, businessPath } = refundChargeCreatedFixture(
+        domain,
+        `existing_paid_at_${domain}`,
+        { existingPaidAt },
+      );
+      const before = storedCopy(businessPath);
+      event.data.object.created = -1;
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedChargeCreatedQuarantine());
+      expectOnlyEventLedgerReads(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(-1000);
+    },
+  );
+
+  test('PAY-003A9 blocks invalid Charge time before ambiguous legacy fallback', async () => {
+    const paymentIntentId = 'pi_pay003a9_ambiguous';
+    seedOrder({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: paymentIntentId,
+      stripeAmountTotalCents: 2000,
+    });
+    seedRegistration({
+      status: 'paid',
+      paymentStatus: 'paid',
+      stripePaymentIntentId: paymentIntentId,
+      stripeAmountTotalCents: 5000,
+    });
+    const snapshots = [
+      ['orders/order-1', storedCopy('orders/order-1')],
+      [
+        'events/race-1/registrations/reg-1',
+        storedCopy('events/race-1/registrations/reg-1'),
+      ],
+    ];
+    const event = stripeEvent(
+      'evt_pay003a9_ambiguous_fallback',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_pay003a9_ambiguous_fallback',
+        payment_intent: paymentIntentId,
+        metadata: {},
+      }),
+    );
+    event.data.object.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({
+      response,
+      event,
+      businessSnapshots: snapshots,
+    })).toEqual(expectedChargeCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test('PAY-003A9 keeps invalid Charge time ahead of malformed reference handling', async () => {
+    const event = stripeEvent(
+      'evt_pay003a9_malformed_reference',
+      'charge.refunded',
+      orderRefundCharge({
+        id: 'ch_pay003a9_malformed_reference',
+        metadata: {
+          schemaVersion: '1',
+          type: 'merch',
+          orderId: 'order-1',
+          eventId: 'race-1',
+          registrationId: 'reg-1',
+        },
+      }),
+    );
+    event.data.object.created = -1;
+
+    const response = await deliver(event);
+
+    expect(refundAdmissionObservation({ response, event }))
+      .toEqual(expectedChargeCreatedQuarantine());
+    expectOnlyEventLedgerReads(event);
+  });
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 processes invalid Charge time before a claimed missing %s target',
+    async (domain) => {
+      const { event } = refundChargeCreatedFixture(
+        domain,
+        `invalid_missing_${domain}`,
+        { missingTarget: true },
+      );
+      event.data.object.created = -1;
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({ response, event }))
+        .toEqual(expectedChargeCreatedQuarantine());
+      expectOnlyEventLedgerReads(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 keeps a valid Charge time with a claimed missing %s target retryable',
+    async (domain) => {
+      const { event } = refundChargeCreatedFixture(
+        domain,
+        `valid_missing_${domain}`,
+        { missingTarget: true },
+      );
+      event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+
+      const response = await deliver(event);
+
+      expect(response.status).toHaveBeenCalledWith(500);
+      expect(admin.__get(`stripeEvents/${event.id}`)).toBeUndefined();
+      providerBindingPaths(event).forEach((path) => {
+        expect(admin.__get(path)).toBeUndefined();
+      });
+    },
+  );
+
+  test.each([
+    [
+      'outer Event realm',
+      'livemode_mismatch',
+      (event) => { event.livemode = true; },
+      { _milliseconds: 1_800_000_000_000 },
+    ],
+    [
+      'embedded Charge realm',
+      'charge_livemode_mismatch',
+      (event) => { event.data.object.livemode = true; },
+      { _milliseconds: 1_800_000_000_000 },
+    ],
+    [
+      'Charge status',
+      'charge_status_mismatch',
+      (event) => { event.data.object.status = 'pending'; },
+      { _milliseconds: 1_800_000_000_000 },
+    ],
+    [
+      'metadata schema',
+      'metadata_schema_version_mismatch',
+      (event) => { setMetadataSchema(event.data.object, '2'); },
+      { _milliseconds: 1_800_000_000_000 },
+    ],
+    [
+      'outer Event time',
+      'invalid_event_created',
+      (event) => { event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1; },
+      null,
+    ],
+  ])('PAY-003A9 keeps %s precedence over invalid Charge time', async (
+    label,
+    reason,
+    mutate,
+    expectedStripeCreatedAt,
+  ) => {
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const { event, businessPath } = refundChargeCreatedFixture(
+      'order',
+      `precedence_${slug}`,
+    );
+    const before = storedCopy(businessPath);
+    event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1;
+    mutate(event);
+
+    const response = await deliver(event);
+
+    expectCompatibilityQuarantine({ response, event, businessPath, before, reason });
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      stripeCreatedAt: expectedStripeCreatedAt,
+    });
+    expectOnlyEventLedgerReads(event);
+    expect(Timestamp.now).not.toHaveBeenCalled();
+    expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
+      (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
+    );
+  });
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 deduplicates rejected %s Charge time without target work',
+    async (domain) => {
+      const { event, businessPath } = refundChargeCreatedFixture(
+        domain,
+        `replay_${domain}`,
+      );
+      const before = storedCopy(businessPath);
+      event.data.object.created = -1;
+
+      const firstResponse = await deliver(event);
+      const ledgerPath = `stripeEvents/${event.id}`;
+      const afterFirstLedger = storedCopy(ledgerPath);
+      const replayResponse = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response: firstResponse,
+        event,
+        businessSnapshots: [[businessPath, before]],
+      })).toEqual(expectedChargeCreatedQuarantine());
+      expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+        received: true,
+        duplicate: true,
+        outcome: 'needs_review:invalid_charge_created',
+      }));
+      expect(admin.__get(businessPath)).toEqual(before);
+      expect(admin.__get(ledgerPath)).toEqual(afterFirstLedger);
+      expect(admin.__readOperations()).toEqual([
+        { kind: 'document', path: ledgerPath },
+        { kind: 'document', path: ledgerPath },
+        { kind: 'document', path: ledgerPath },
+      ]);
+      expect(Timestamp.fromMillis).toHaveBeenCalledTimes(3);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS.flatMap((domain) => [
+    [domain, 'Unix epoch', 0],
+    [domain, 'Firestore maximum', FIRESTORE_TIMESTAMP_MAX_SECONDS],
+  ]))('PAY-003A9 admits the inclusive %s %s Charge-created boundary', async (
+    domain,
+    boundary,
+    chargeCreated,
+  ) => {
+    const slug = `${domain}_${boundary}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const { event, businessPath } = refundChargeCreatedFixture(domain, `valid_${slug}`);
+    event.data.object.created = chargeCreated;
+
+    const response = await deliver(event);
+
+    expect(response.status).not.toHaveBeenCalledWith(500);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      received: true,
+      duplicate: false,
+      outcome: 'partially_refunded',
+    }));
+    expect(admin.__get(businessPath)).toMatchObject({
+      paymentStatus: 'partially_refunded',
+      paidAt: { _milliseconds: chargeCreated * 1000 },
+    });
+    expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+      targetPath: businessPath,
+      stripeCreatedAt: { _milliseconds: event.created * 1000 },
+    });
+  });
+
+  test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+    'PAY-003A9 preserves an existing %s paidAt for valid Charge time',
+    async (domain) => {
+      const existingPaidAt = { _milliseconds: 1_700_000_000_000 };
+      const { event, businessPath } = refundChargeCreatedFixture(
+        domain,
+        `valid_existing_paid_at_${domain}`,
+        { existingPaidAt },
+      );
+      event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+
+      const response = await deliver(event);
+
+      expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+        outcome: 'partially_refunded',
+      }));
+      expect(admin.__get(businessPath).paidAt).toEqual(existingPaidAt);
+    },
+  );
+
+  test('PAY-003A9 leaves Checkout Session-created evidence outside this child', async () => {
+    seedRegistration();
+    const event = stripeEvent(
+      'evt_pay003a9_checkout_compatibility',
+      'checkout.session.completed',
+      registrationSession({ created: -1 }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'payment_confirmed',
+    }));
+  });
+
+  test('PAY-003A9 leaves Dispute-created evidence outside this child', async () => {
+    seedPaidDisputeOrder();
+    const event = stripeEvent(
+      'evt_pay003a9_dispute_compatibility',
+      'charge.dispute.updated',
+      orderDispute({ created: -1, status: 'under_review' }),
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'dispute_under_review',
+    }));
+  });
+
+  test('PAY-003A9 leaves unsupported embedded created evidence unchanged', async () => {
+    const event = stripeEvent(
+      'evt_pay003a9_unsupported_compatibility',
+      'customer.created',
+      { id: 'cus_pay003a9_unsupported', object: 'customer', created: -1 },
+    );
+
+    const response = await deliver(event);
+
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'ignored:unsupported_event',
+    }));
   });
 
   test('quarantines an incompatible claimed Dispute before resolving its missing target', async () => {


### PR DESCRIPTION
Closes #578
Parent: #106

## Outcome
Refund webhooks now reject unusable embedded `Charge.created` evidence before any reference or fallback Firestore query, business-record read or mutation, provider-binding work, money check, or state transition. A valid primitive safe integer from Unix epoch second 0 through Firestore maximum second 253402300799 remains admissible. Missing payment time now comes only from admitted provider evidence; the server clock is no longer a fallback.

## Invariant and failure behavior

- Processed-Event replay remains first and read-only.
- Existing admission precedence remains outer Event realm, embedded Charge realm, exact `succeeded` status, explicit claimed metadata version, and outer Event time.
- Invalid embedded Charge time produces durable `needs_review:invalid_charge_created`, retains valid outer `stripeCreatedAt`, leaves target fields null, uses only the two normal new-Event ledger reads, and emits the existing fixed redacted review log.
- Valid claimed missing targets remain retryable without a processed ledger.
- Existing `paidAt` is preserved but cannot bypass admission.
- Checkout Session, Dispute, unsupported Event, reference, binding, money, and refund-state algorithms are unchanged.

## Verification

Trustworthy RED: https://github.com/Run-MPRC/Run-MPRC.github.io/issues/578#issuecomment-5153980053 — test-only SHA-256 `7a724807e4af2fdc4cd2f04ec819a0b61a315b99fc72219655f06fe3d4cd6b5c`; untouched base produced 38 intended failures / 16 controls passed / 508 skipped.

Reviewed head: `1664ab02d5ff6014dfef7de950a9038f2f01abbd`
Tree: `2fac1e664edf1e71afce82435b31567db478f1da`
Patch SHA-256: `09c6678a35b4b214b7bcaf838b9ca38a0158872e3c0784369d9e83253149548f`
Exact base: `4c7cdd0d8b0ae28a388254924c96b6579e62b084`

- PAY-003A9: 54 passed / 508 skipped.
- Full webhook: 562/562 passed.
- Full Functions: 7,016 passed / 64 intentional skips; Functions lint passed.
- Frontend: 951/951 passed.
- Static and artifact safety: 93/93 passed.
- SPA navigation: 11/11 passed.
- Firestore Rules: 418/418 passed against demo project only.
- Commerce command journal: 63/63 passed against demo project only.
- Frontend lint baseline: 118 files, 113 reviewed legacy errors, 6 reviewed legacy warnings.
- TypeScript, diagnostic production build, and `git diff --check` passed.
- Dependency audits were diagnostic only: root retains 59 known findings and Functions retains 8 moderate findings. No dependency or lockfile changed, and no automatic fix was applied.
- Three independent read-only reviews returned GO after one timestamp-construction assertion gap was corrected and re-reviewed.

## Compatibility and migration
No schema, Firestore Rule, index, package, workflow, stored-data migration, or backfill changes. Already-processed historical Events remain authoritative and are not repaired.

Officer impact: None. This is a server-only evidence admission boundary and adds no officer screen, task, field, permission, approval, topology, or available recovery action.

Officer documentation: None — no officer-visible or operational procedure changes. `STRIPE_COMMERCE_DESIGN.md` records the source-only design, success proof, stop conditions, undo, escalation, diagram, compatibility, and residuals.

Deployment evidence:

- Source changed: yes, at the reviewed head above.
- Synthetic tests passed: yes, as listed above.
- Code merged: no; this pull request is awaiting review and CI.
- Website published: no.
- `runmprc.com` verified for this behavior: no.
- Firebase deployed/read back: no.
- Stripe or outside provider configured/contacted: no.
- Production data changed: no.
- Payment, refund, or dispute performed: no.
- Production behavior verified: no.

## Residual risk
Clock-skew/freshness policy, Charge/Event chronology, Checkout Session and Dispute embedded-time decisions, provider API-version proof, provider retrieval/history repair, later PAY-003B/C work, reconciliation, alerts, protected release, and live verification remain under #106.