### PR TITLE
PAY-003A10: reject impossible refund Charge/Event chronology

### DIFF
--- a/STRIPE_COMMERCE_DESIGN.md
+++ b/STRIPE_COMMERCE_DESIGN.md
@@ -897,6 +897,49 @@ Residual work remains under #106: clock-skew and freshness policy, Charge/Event 
 
 PAY-003A9 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed and read back, Stripe/provider configured or acted on, production data changed, payment/refund/dispute activity, and live behavior verified. Source and synthetic tests prove none of the later states. Officer impact and officer documentation are both none: this server-only evidence boundary adds no officer screen, task, field, permission, approval, topology, or available recovery step. The root design, security, implementation, operations, issue, and officer guides remain compatible.
 
+### PAY-003A10 Refund Charge/Event chronology — SOURCE ONLY, NOT LIVE
+
+PAY-003A10 [#584](https://github.com/Run-MPRC/Run-MPRC.github.io/issues/584) closes PAY-003A9's refund chronology residual. Its purpose is to reject a new `charge.refunded` Event when the embedded `Charge.created` second is later than the outer `Event.created` second. Stripe timestamps have whole-second resolution, so equality is allowed. An earlier Charge time is also allowed. A later Charge time is contradictory evidence and must stop before any target or fallback Firestore query, business-record read or change, provider-binding work, money check, or refund-state transition.
+
+Approvers for this source boundary are the platform owner and payment reviewer. Prerequisites are verified webhook signature handling, the processed-Event ledger, PAY-003A5 Charge realm and status admission, PAY-003A8 outer Event-time admission, PAY-003A9 embedded Charge-time admission, signed synthetic fixtures, and the existing nullable ledger target fields. A new refund Event keeps this order:
+
+1. Return an exact processed-Event replay without changing its stored result.
+2. Check the outer Event realm.
+3. Check the embedded Charge realm.
+4. Require the exact Charge status `succeeded`.
+5. Check an explicit claimed-MPRC metadata schema version.
+6. Check the outer Event-created value.
+7. Check the embedded Charge-created value.
+8. Require Charge-created to be less than or equal to Event-created.
+9. Only then resolve a target or fallback, inspect ownership bindings, evaluate money and state, and persist the refund result.
+
+A later Charge time produces durable `needs_review:invalid_charge_event_chronology`. The ledger keeps the valid outer `stripeCreatedAt` and null target fields. The handler performs only the normal two new-Event ledger reads. It does not query a target or fallback, read or change a business record, or read or create a Charge or PaymentIntent binding. The existing pure in-memory reference classifier may still supply redacted ledger ownership fields; it performs no Firestore query. The fixed review log names only the Event ID, Event type, outcome, and null target type. It never includes either timestamp. An exact replay returns the stored result read-only.
+
+Earlier outer or embedded realm, Charge-status, metadata-version, outer Event-time, and embedded Charge-time failures keep their existing outcomes. A valid claimed Event whose target is absent keeps the existing retryable behavior only when its chronology is possible. Impossible chronology is already final evidence review and does not become a missing-target retry.
+
+```mermaid
+flowchart TD
+    A["Verified charge.refunded Event"] --> B{"Already in the processed-Event ledger?"}
+    B -- "Yes" --> C["Return the stored result without changes"]
+    B -- "No" --> D{"Realm, Charge status, metadata, and both timestamps pass?"}
+    D -- "No" --> E["Keep the earlier fixed review result"]
+    D -- "Yes" --> F{"Charge-created is later than Event-created?"}
+    F -- "Yes" --> G["Record chronology review with no target"]
+    F -- "No" --> H["Continue target, binding, money, and refund-state work"]
+```
+
+Text alternative: replay returns an existing ledger result first; a new refund keeps every earlier admission result, then rejects a Charge time later than its Event time without target work, while an equal or earlier Charge time may continue to normal refund processing.
+
+The expected result is target-free durable review for impossible chronology and unchanged refund behavior for equal or earlier valid time. Success proof requires separately named registration and order tests for the contradiction; target, fallback, business, and binding isolation; valid outer ledger time; fixed redacted logging; claimed missing-target handling; all earlier admission precedence; exact replay; equality and earlier-time controls; the corrected PAY-003A9 upper-bound controls; and explicit Checkout Session and Dispute exclusions. The complete webhook suite and prior PAY-003A5/A8/A9 matrices must remain green.
+
+Stop the merge if impossible chronology reaches a target or fallback query, binding, business mutation, timestamp disclosure, money check, or transition; if an earlier outcome changes; if equality or an earlier Charge time regresses; if Checkout or Dispute behavior changes in this child; or if a test needs a real credential, provider object, refund/payment, customer/member record, or production service. Escalate to the platform owner and payment reviewer. Undo is one small reviewed revert of the PAY-003A10 comparison, named tests, the three A9 compatibility-control corrections, and this section. Do not edit a provider object, processed ledger, or business record as an undo path.
+
+There is no schema, Rule, index, package, workflow, stored-data migration, or backfill. Valid chronology, earlier admission precedence, target resolution, bindings, money checks, refund transitions, and existing `paidAt` values remain compatible. A newly delivered impossible Event changes from target-capable behavior to durable pre-target review. Already-processed historical Events remain authoritative on replay. Previously stored ledger, binding, refund, and `paidAt` values are not inspected or repaired.
+
+Residual work remains under #106: current-clock freshness and skew policy, Checkout Session and Dispute embedded-time decisions, provider endpoint and API-version proof, provider retrieval and history repair, PAY-003B/C, reconciliation, alerts, protected release, and live verification. This child proves no provider truth, payment/refund success, historical correctness, or production behavior.
+
+PAY-003A10 delivery evidence must separately name source changed, synthetic tests passed, code merged, website published, `runmprc.com` verified, Firebase deployed and read back, Stripe/provider configured or acted on, production data changed, payment/refund/dispute activity, and live behavior verified. Source and synthetic tests prove none of the later states. Officer impact and officer documentation are both none: this server-only evidence-ordering boundary adds no officer screen, task, field, permission, approval, topology, or available recovery step. The remaining root design, security, implementation, operations, issue, and officer guides stay compatible.
+
 Store actual total, discount, tax, shipping, Stripe customer reference if required, PaymentIntent ID, and Charge reference. An anomaly enters `payment_review`/quarantine and alerts operations; it never silently marks paid.
 
 ## 12. Payment and business state machines

--- a/functions/stripeWebhook.js
+++ b/functions/stripeWebhook.js
@@ -181,6 +181,14 @@ function validateEventAdmission(event, expectedLivemode) {
       reason: 'invalid_charge_created',
     };
   }
+  if (event.type === 'charge.refunded'
+    && event.data.object.created > event.created) {
+    return {
+      ok: false,
+      expected: expectedLivemode,
+      reason: 'invalid_charge_event_chronology',
+    };
+  }
   return modeValidation;
 }
 

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -887,6 +887,28 @@ function expectedChargeCreatedQuarantine(bindingPaths = []) {
   };
 }
 
+function expectedChargeEventChronologyQuarantine(bindingPaths = []) {
+  return {
+    httpStatus: null,
+    response: {
+      received: true,
+      duplicate: false,
+      outcome: 'needs_review:invalid_charge_event_chronology',
+      requiresReview: true,
+    },
+    businessUnchanged: true,
+    ledger: {
+      status: 'processed',
+      outcome: 'needs_review:invalid_charge_event_chronology',
+      requiresReview: true,
+      targetType: null,
+      targetPath: null,
+      targetSource: null,
+    },
+    bindingPaths,
+  };
+}
+
 function expectOnlyEventLedgerReads(event) {
   expect(admin.__readOperations()).toEqual([
     { kind: 'document', path: `stripeEvents/${event.id}` },
@@ -3469,6 +3491,7 @@ describe('stripeWebhook', () => {
         { missingTarget: true },
       );
       event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+      event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
 
       const response = await deliver(event);
 
@@ -3588,6 +3611,7 @@ describe('stripeWebhook', () => {
     const slug = `${domain}_${boundary}`.toLowerCase().replace(/[^a-z0-9]+/g, '_');
     const { event, businessPath } = refundChargeCreatedFixture(domain, `valid_${slug}`);
     event.data.object.created = chargeCreated;
+    if (chargeCreated === FIRESTORE_TIMESTAMP_MAX_SECONDS) event.created = chargeCreated;
 
     const response = await deliver(event);
 
@@ -3617,6 +3641,7 @@ describe('stripeWebhook', () => {
         { existingPaidAt },
       );
       event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
+      event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS;
 
       const response = await deliver(event);
 
@@ -3669,6 +3694,289 @@ describe('stripeWebhook', () => {
     expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
       outcome: 'ignored:unsupported_event',
     }));
+  });
+
+  describe('PAY-003A10 refund Charge/Event chronology', () => {
+    const eventCreated = 1_800_000_000;
+
+    test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+      'quarantines impossible %s refund Charge/Event chronology',
+      async (domain) => {
+        const { event, businessPath } = refundChargeCreatedFixture(
+          domain,
+          `chronology_${domain}`,
+        );
+        const before = storedCopy(businessPath);
+        event.created = eventCreated;
+        event.data.object.created = eventCreated + 1;
+
+        const response = await deliver(event);
+
+        expect(refundAdmissionObservation({
+          response,
+          event,
+          businessSnapshots: [[businessPath, before]],
+        })).toEqual(expectedChargeEventChronologyQuarantine());
+        expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+          stripeCreatedAt: { _milliseconds: event.created * 1000 },
+        });
+        expectOnlyEventLedgerReads(event);
+        expectOnlyEventLedgerTimestamps(event);
+        expect(Timestamp.now).not.toHaveBeenCalled();
+        expect(consoleError).toHaveBeenCalledWith(
+          'Stripe event requires review',
+          {
+            eventId: event.id,
+            eventType: 'charge.refunded',
+            outcome: 'needs_review:invalid_charge_event_chronology',
+            targetType: null,
+          },
+        );
+        expect(JSON.stringify({
+          response: response.json.mock.calls,
+          ledger: admin.__get(`stripeEvents/${event.id}`),
+          logs: consoleError.mock.calls,
+        })).not.toContain(String(event.data.object.created));
+      },
+    );
+
+    test('blocks impossible chronology before ambiguous legacy fallback', async () => {
+      const paymentIntentId = 'pi_pay003a10_ambiguous';
+      seedOrder({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: paymentIntentId,
+        stripeAmountTotalCents: 2000,
+      });
+      seedRegistration({
+        status: 'paid',
+        paymentStatus: 'paid',
+        stripePaymentIntentId: paymentIntentId,
+        stripeAmountTotalCents: 5000,
+      });
+      const snapshots = [
+        ['orders/order-1', storedCopy('orders/order-1')],
+        [
+          'events/race-1/registrations/reg-1',
+          storedCopy('events/race-1/registrations/reg-1'),
+        ],
+      ];
+      const event = stripeEvent(
+        'evt_pay003a10_ambiguous_fallback',
+        'charge.refunded',
+        orderRefundCharge({
+          id: 'ch_pay003a10_ambiguous_fallback',
+          payment_intent: paymentIntentId,
+          metadata: {},
+        }),
+      );
+      event.created = eventCreated;
+      event.data.object.created = eventCreated + 1;
+
+      const response = await deliver(event);
+
+      expect(refundAdmissionObservation({
+        response,
+        event,
+        businessSnapshots: snapshots,
+      })).toEqual(expectedChargeEventChronologyQuarantine());
+      expectOnlyEventLedgerReads(event);
+      expectOnlyEventLedgerTimestamps(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+    });
+
+    test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+      'makes impossible chronology durable before a missing %s target',
+      async (domain) => {
+        const { event } = refundChargeCreatedFixture(
+          domain,
+          `chronology_missing_${domain}`,
+          { missingTarget: true },
+        );
+        event.created = eventCreated;
+        event.data.object.created = eventCreated + 1;
+
+        const response = await deliver(event);
+
+        expect(refundAdmissionObservation({ response, event }))
+          .toEqual(expectedChargeEventChronologyQuarantine());
+        expect(response.status).not.toHaveBeenCalledWith(500);
+        expectOnlyEventLedgerReads(event);
+        expectOnlyEventLedgerTimestamps(event);
+        expect(Timestamp.now).not.toHaveBeenCalled();
+      },
+    );
+
+    test.each([
+      [
+        'outer Event realm',
+        'livemode_mismatch',
+        (event) => { event.livemode = true; },
+        { _milliseconds: eventCreated * 1000 },
+      ],
+      [
+        'embedded Charge realm',
+        'charge_livemode_mismatch',
+        (event) => { event.data.object.livemode = true; },
+        { _milliseconds: eventCreated * 1000 },
+      ],
+      [
+        'Charge status',
+        'charge_status_mismatch',
+        (event) => { event.data.object.status = 'pending'; },
+        { _milliseconds: eventCreated * 1000 },
+      ],
+      [
+        'metadata schema',
+        'metadata_schema_version_mismatch',
+        (event) => { setMetadataSchema(event.data.object, '2'); },
+        { _milliseconds: eventCreated * 1000 },
+      ],
+      [
+        'outer Event time',
+        'invalid_event_created',
+        (event) => { event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1; },
+        null,
+      ],
+      [
+        'embedded Charge time',
+        'invalid_charge_created',
+        (event) => { event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1; },
+        { _milliseconds: eventCreated * 1000 },
+      ],
+    ])('keeps %s precedence over chronology', async (
+      label,
+      reason,
+      mutate,
+      expectedStripeCreatedAt,
+    ) => {
+      const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const { event, businessPath } = refundChargeCreatedFixture(
+        'order',
+        `chronology_precedence_${slug}`,
+      );
+      const before = storedCopy(businessPath);
+      event.created = eventCreated;
+      event.data.object.created = eventCreated + 1;
+      mutate(event);
+
+      const response = await deliver(event);
+
+      expectCompatibilityQuarantine({ response, event, businessPath, before, reason });
+      expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+        stripeCreatedAt: expectedStripeCreatedAt,
+      });
+      expectOnlyEventLedgerReads(event);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
+        (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
+      );
+    });
+
+    test.each(REFUND_CHARGE_CREATED_DOMAINS)(
+      'deduplicates rejected %s chronology without target work',
+      async (domain) => {
+        const { event, businessPath } = refundChargeCreatedFixture(
+          domain,
+          `chronology_replay_${domain}`,
+        );
+        const before = storedCopy(businessPath);
+        event.created = eventCreated;
+        event.data.object.created = eventCreated + 1;
+
+        const firstResponse = await deliver(event);
+        const ledgerPath = `stripeEvents/${event.id}`;
+        const afterFirstLedger = storedCopy(ledgerPath);
+        const replayResponse = await deliver(event);
+
+        expect(refundAdmissionObservation({
+          response: firstResponse,
+          event,
+          businessSnapshots: [[businessPath, before]],
+        })).toEqual(expectedChargeEventChronologyQuarantine());
+        expect(replayResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+          received: true,
+          duplicate: true,
+          outcome: 'needs_review:invalid_charge_event_chronology',
+        }));
+        expect(admin.__get(businessPath)).toEqual(before);
+        expect(admin.__get(ledgerPath)).toEqual(afterFirstLedger);
+        expect(admin.__readOperations()).toEqual([
+          { kind: 'document', path: ledgerPath },
+          { kind: 'document', path: ledgerPath },
+          { kind: 'document', path: ledgerPath },
+        ]);
+        expectOnlyEventLedgerTimestamps(event);
+        expect(Timestamp.now).not.toHaveBeenCalled();
+        expect(consoleError).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    test.each(REFUND_CHARGE_CREATED_DOMAINS.flatMap((domain) => [
+      [domain, 'equal', eventCreated],
+      [domain, 'older', eventCreated - 1],
+    ]))('admits %s refund with %s Charge/Event chronology', async (
+      domain,
+      chronology,
+      chargeCreated,
+    ) => {
+      const { event, businessPath } = refundChargeCreatedFixture(
+        domain,
+        `chronology_${chronology}_${domain}`,
+      );
+      event.created = eventCreated;
+      event.data.object.created = chargeCreated;
+
+      const response = await deliver(event);
+
+      expect(response.status).not.toHaveBeenCalledWith(500);
+      expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+        received: true,
+        duplicate: false,
+        outcome: 'partially_refunded',
+      }));
+      expect(admin.__get(businessPath)).toMatchObject({
+        paymentStatus: 'partially_refunded',
+        paidAt: { _milliseconds: chargeCreated * 1000 },
+      });
+      expect(admin.__get(`stripeEvents/${event.id}`)).toMatchObject({
+        targetPath: businessPath,
+        stripeCreatedAt: { _milliseconds: event.created * 1000 },
+      });
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    test('leaves Checkout Session chronology outside this child', async () => {
+      seedRegistration();
+      const event = stripeEvent(
+        'evt_pay003a10_checkout_compatibility',
+        'checkout.session.completed',
+        registrationSession({ created: eventCreated + 1 }),
+      );
+      event.created = eventCreated;
+
+      const response = await deliver(event);
+
+      expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+        outcome: 'payment_confirmed',
+      }));
+    });
+
+    test('leaves Dispute chronology outside this child', async () => {
+      seedPaidDisputeOrder();
+      const event = stripeEvent(
+        'evt_pay003a10_dispute_compatibility',
+        'charge.dispute.updated',
+        orderDispute({ created: eventCreated + 1, status: 'under_review' }),
+      );
+      event.created = eventCreated;
+
+      const response = await deliver(event);
+
+      expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+        outcome: 'dispute_under_review',
+      }));
+    });
   });
 
   test('quarantines an incompatible claimed Dispute before resolving its missing target', async () => {

--- a/functions/stripeWebhook.test.js
+++ b/functions/stripeWebhook.test.js
@@ -3813,42 +3813,49 @@ describe('stripeWebhook', () => {
         'livemode_mismatch',
         (event) => { event.livemode = true; },
         { _milliseconds: eventCreated * 1000 },
+        null,
       ],
       [
         'embedded Charge realm',
         'charge_livemode_mismatch',
         (event) => { event.data.object.livemode = true; },
         { _milliseconds: eventCreated * 1000 },
+        null,
       ],
       [
         'Charge status',
         'charge_status_mismatch',
         (event) => { event.data.object.status = 'pending'; },
         { _milliseconds: eventCreated * 1000 },
+        null,
       ],
       [
         'metadata schema',
         'metadata_schema_version_mismatch',
         (event) => { setMetadataSchema(event.data.object, '2'); },
         { _milliseconds: eventCreated * 1000 },
+        null,
       ],
       [
         'outer Event time',
         'invalid_event_created',
-        (event) => { event.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1; },
+        (event) => { event.created = -1; },
         null,
+        -1000,
       ],
       [
         'embedded Charge time',
         'invalid_charge_created',
         (event) => { event.data.object.created = FIRESTORE_TIMESTAMP_MAX_SECONDS + 1; },
         { _milliseconds: eventCreated * 1000 },
+        (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
       ],
     ])('keeps %s precedence over chronology', async (
       label,
       reason,
       mutate,
       expectedStripeCreatedAt,
+      rejectedTimestampMillis,
     ) => {
       const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
       const { event, businessPath } = refundChargeCreatedFixture(
@@ -3868,9 +3875,9 @@ describe('stripeWebhook', () => {
       });
       expectOnlyEventLedgerReads(event);
       expect(Timestamp.now).not.toHaveBeenCalled();
-      expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(
-        (FIRESTORE_TIMESTAMP_MAX_SECONDS + 1) * 1000,
-      );
+      if (rejectedTimestampMillis !== null) {
+        expect(Timestamp.fromMillis).not.toHaveBeenCalledWith(rejectedTimestampMillis);
+      }
     });
 
     test.each(REFUND_CHARGE_CREATED_DOMAINS)(


### PR DESCRIPTION
## Outcome

Reject a signed refund whose embedded Charge claims it was created after its outer Stripe Event. Record a fixed target-free review result before any target, fallback, business, binding, money, or refund-state work.

Closes #584. Atomic child of #106 after released PAY-003A9 / #578.

## Scope

- Issue: #584 / PAY-003A10.
- What changed: one post-A9 admission comparison in `functions/stripeWebhook.js`; one named 19-case chronology block and three corrected A9 compatibility controls in `functions/stripeWebhook.test.js`; one source-only engineering section in `STRIPE_COMMERCE_DESIGN.md`.
- What did not change: Checkout Session or Dispute chronology; clock freshness/skew; schemas, Rules, indexes, packages, workflows, configuration, migrations, historical records, reconciliation, deployment, provider state, production data, or live commerce.

The check runs only after both timestamp values are primitive safe integers in the Firestore range. `Charge.created > Event.created` becomes `needs_review:invalid_charge_event_chronology`. Equality and an earlier Charge time retain current behavior. Exact processed replay remains first.

Trustworthy RED on released source used test-only diff SHA-256 `d09bfa01972d2c4a81341a3a3439d17989c794c7a5fcfdca1f311df4db50ff6a`: both registration and order rows returned `partially_refunded`, changed business state, resolved targets, and created Charge and PaymentIntent bindings.

Final reviewed head: `51a8029dd791029e34e99a4d363283c7c3ab11bf` on exact base `4b2e144deaaa79439a5f47dd50028405ad018eb5`.

Final tree: `b95ae19166d642d3ad0dd2885087214a560a063f`. Base-to-head binary patch SHA-256: `a5c8b85518ba9a8614dd61618d70443e2f4b7e5be9b1476137312bc640f363fd`.

## Officer handoff

- Officer impact: None — server-only Stripe evidence ordering; no officer action becomes available.
- Officer documentation: None — no officer screen, task, field, permission, approval, topology, deployment step, or recovery procedure changes. The engineering truth is documented in `STRIPE_COMMERCE_DESIGN.md`.
- Approving role: platform owner and payment reviewer.
- Preview or redacted screenshot: Not relevant — no visible interface changes.
- Screenshot checked at: Not relevant.
- Plain-language undo plan: use one reviewed revert of this PR. Do not edit Stripe objects, processed ledgers, bindings, or business records by hand.
- Deployment evidence: source and synthetic tests only. This PR does not deploy or verify any website, Firebase, Stripe/provider, production-data, payment/refund, or live surface.

## Proof by surface

- Source changed: yes — exact head above.
- Tests passed: yes — PAY-003A10 19/19; webhook 581/581; Functions 7,043 pass with 64 expected skips; frontend 951/951; workflow/release/Firebase-verification/artifact/dependency safety 86/86; SPA 11/11; Rules emulator 418/418; commerce emulator 63/63; Functions and frontend lint; diagnostic build.
- Code merged: not yet.
- Website published: not relevant; not changed or verified.
- Netlify intended commit verified: not relevant; no publication requested.
- `runmprc.com` verified: not relevant; not changed or verified.
- Firebase deployed: not relevant; not changed or verified.
- Outside provider configured: not relevant; no provider action.
- Outside provider verified: not relevant; no provider call or readback.
- Production data changed: no.
- Payment/refund/dispute activity: no.
- Production behavior verified: not relevant; not changed or verified.

Dependency audits are unchanged and no forced upgrade was applied: root full 59, root production 4, Functions 8. Three independent read-only exact-head security/runtime, compatibility/test, and documentation/backup-officer reviews returned GO after one test-strengthening correction.

## Safety review

- [x] No secrets, recovery codes, private member data, or payment data are included.
- [x] Planned behavior is marked `SOURCE ONLY, NOT LIVE`.
- [x] Skipped checks or deployments are reported as incomplete, not green/live.
- [x] The admission-flow Mermaid diagram and text alternative were added.
- [x] No officer procedure changed; specialist-only source review and escalation roles are explicit.
