### PR TITLE
OAUTH-001A2H — Reject precision-unsafe Strava activity IDs

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -24,7 +24,6 @@ const STRAVA_RECENT_ACTIVITY_LIMIT = 5;
 const STRAVA_ACTIVITY_NAME_MAX_LENGTH = 1_024;
 const STRAVA_ACTIVITY_TYPE_MAX_LENGTH = 128;
 const STRAVA_ACTIVITY_DATE_MAX_LENGTH = 64;
-const STRAVA_LONG_MAX_AS_NUMBER = 9_223_372_036_854_776_000;
 const STRAVA_REFRESH_ERROR_MESSAGE = 'Strava connection could not be refreshed.';
 const STRAVA_DATA_ERROR_MESSAGE = 'Strava activity data could not be loaded.';
 const STRAVA_STATS_REQUEST_ERROR_MESSAGE = 'Strava statistics request is invalid.';
@@ -45,7 +44,6 @@ const arrayIsArray = Array.isArray;
 const arrayPrototype = Array.prototype;
 const arrayPush = Array.prototype.push;
 const numberIsFinite = Number.isFinite;
-const numberIsInteger = Number.isInteger;
 const numberIsSafeInteger = Number.isSafeInteger;
 const reflectApply = Reflect.apply;
 const reflectHas = Reflect.has;
@@ -344,14 +342,6 @@ function isFiniteNumberInRange(value, maximum) {
     && value <= maximum;
 }
 
-function isPositiveIntegerInRange(value, maximum) {
-  return typeof value === 'number'
-    && numberIsFinite(value)
-    && numberIsInteger(value)
-    && value > 0
-    && value <= maximum;
-}
-
 function hasLoneSurrogate(value) {
   for (let index = 0; index < value.length; index += 1) {
     const codeUnit = reflectApply(stringCharCodeAt, value, [index]);
@@ -515,7 +505,7 @@ function snapshotProviderActivity(record) {
     (value) => isBoundedVisibleAscii(value, STRAVA_ACTIVITY_DATE_MAX_LENGTH),
   );
   if (
-    !isPositiveIntegerInRange(id, STRAVA_LONG_MAX_AS_NUMBER)
+    !isPositiveSafeInteger(id)
     || !isBoundedActivityName(name)
     || type === INVALID_SELECTED_VALUE
     || !isFiniteNumberInRange(distance, Number.MAX_SAFE_INTEGER)

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -4890,6 +4890,45 @@ describe('Strava activity data failure boundary', () => {
       });
     });
 
+    describe('OAUTH-001A2H precision-safe activity IDs', () => {
+      test('rejects the first precision-unsafe integer before statistics JSON', async () => {
+        await expectInvalidSuccessfulProviderData({
+          activities: [validProviderActivity({
+            id: Number.MAX_SAFE_INTEGER + 1,
+          })],
+          invalidSurface: 'activities',
+        });
+      });
+
+      test('preserves the safe-integer ceiling as an exact numeric result', async () => {
+        seedFreshConnection();
+        const { activitiesJson, statsJson } = mockSuccessfulProviderData({
+          activities: [validProviderActivity({
+            id: Number.MAX_SAFE_INTEGER,
+          })],
+        });
+
+        const result = await stravaFetchStats({}, CONTEXT);
+
+        expect(result.recentActivities[0]).toEqual({
+          id: Number.MAX_SAFE_INTEGER,
+          name: 'Synthetic Morning Run',
+          type: 'Run',
+          distanceMeters: 5000.5,
+          movingTimeSeconds: 1500,
+          startDate: '2026-01-02T12:00:00Z',
+        });
+        expect(typeof result.recentActivities[0].id).toBe('number');
+        expect(activitiesJson).toHaveBeenCalledTimes(1);
+        expect(statsJson).toHaveBeenCalledTimes(1);
+        expectTwoFreshBearerReads();
+        expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+        expect(admin.__getDeletes()).toEqual([]);
+        expect(Timestamp.now).not.toHaveBeenCalled();
+        expectNoWritesOrLogs();
+      });
+    });
+
     test.each([
       ['id', 987654],
       ['name', 'Synthetic Morning Run'],
@@ -4961,11 +5000,11 @@ describe('Strava activity data failure boundary', () => {
       expectNoWritesOrLogs();
     });
 
-    test('accepts exact bounds, five dense entries, and the rounded signed-Long ceiling', async () => {
+    test('accepts exact bounds, five dense entries, and the safe-integer activity ceiling', async () => {
       seedFreshConnection();
-      const longId = MAX_STRAVA_LONG_AS_NUMBER;
+      const safeId = Number.MAX_SAFE_INTEGER;
       const activities = Array.from({ length: 5 }, (_unused, index) => validProviderActivity({
-        id: index === 0 ? longId : index + 1,
+        id: index === 0 ? safeId : index + 1,
         name: index === 0 ? '🏃'.repeat(MAX_ACTIVITY_NAME_LENGTH / 2) : `Run ${index}`,
         type: index === 0 ? 't'.repeat(MAX_ACTIVITY_TYPE_LENGTH) : undefined,
         sport_type: index === 0 ? 'ignored' : 'Run',
@@ -4979,7 +5018,7 @@ describe('Strava activity data failure boundary', () => {
 
       expect(result.recentActivities).toHaveLength(5);
       expect(result.recentActivities[0]).toEqual({
-        id: longId,
+        id: safeId,
         name: '🏃'.repeat(MAX_ACTIVITY_NAME_LENGTH / 2),
         type: 't'.repeat(MAX_ACTIVITY_TYPE_LENGTH),
         distanceMeters: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
## Outcome

A successful parsed Strava activities response is now rejected when a selected activity ID is not a positive JavaScript safe integer. Safe IDs retain the exact existing numeric client shape. Unsafe IDs use only the existing fixed internal / Strava activity data could not be loaded. result.

Closes #600.
Canonical tracker: #88.
Follows complete/released OAUTH-001A2E/#325.

## Defect and invariant

The previous predicate admitted positive finite integers through the rounded signed-64-bit ceiling, including values above Number.MAX_SAFE_INTEGER that JavaScript Number cannot represent uniquely. The value was returned as a non-authoritative browser projection/React key, not persisted or used for provider requests, membership, authorization, or payment.

This PR uses the existing isPositiveSafeInteger helper for only the selected activity ID. It removes the obsolete source Long ceiling, single-use range helper, and sole Number.isInteger alias. App Check/Auth, stored connection/token validation, refresh, provider URLs/headers, concurrent request order, parsed-response snapshotting, fixed error shape, writes/logs, statistics behavior, and output type for admitted IDs remain unchanged.

Both bearer HTTP requests may already have started concurrently. Invalid activities stop before statistics JSON is read; this PR makes no cancellation claim.

## Trustworthy test-first proof

On untouched source, the test-only patch produced exactly one intended failure after 688 existing/control passes: an otherwise valid activity with id Number.MAX_SAFE_INTEGER + 1 resolved successfully instead of taking the fixed failure path.

The same test helper proves activities JSON once, statistics JSON zero, both bearer requests exactly once, exact connection/secret reads, zero writes/deletes/timestamps/logs, and no provider/token detail. The Number.MAX_SAFE_INTEGER positive control passed before the runtime change and returned the exact ID as a number.

## Exact scope

- functions/strava.js — only selected activity-ID admission and removal of its now-unused source constants/helper.
- functions/strava.test.js — one separately named OAUTH-001A2H block and the existing exact-bounds control updated from rounded Long to safe ceiling.

Exact base: 57ac85b9f0248068e60dd741154877f1d539f3e4.
Exact head: 426b1238405770534b699d62ba40826d90fcd2a4.
Exact tree: 8351062fdd7d5f8f3bbef985620bb3f1748a91dd.
Binary patch SHA-256: 98f68df14c8911ec29c531b93110be3e64ef5046be18dae7044cdf3d728ff849.

## Verification

- Focused Strava: 689/689.
- Functions lint: passed.
- Full Functions: 69 suites passed / 2 intentionally skipped; 7,492 passed / 64 intentionally skipped.
- Frontend: 951/951.
- TypeScript: passed.
- Frontend lint: 118 files / 113 reviewed legacy errors / 6 reviewed warnings.
- SPA: 11/11.
- Workflow/release/artifact/dependency safety: 93/93.
- Diagnostic build: passed.
- Rules emulator: 418/418.
- Real demo-only commerce emulator: 63/63.
- Audit snapshot: root 59 total with zero critical; root production 4; Functions 8. No dependency file changed and no forced update was applied.

## Security and compatibility review

- No authorization, App Check, provider request, stored athlete ID, persistence, log, timestamp, retry, schema, Rules, index, package, client type, UI, or response field change.
- Primitive safe IDs from 1 through Number.MAX_SAFE_INTEGER keep the exact numeric projection.
- Missing and malformed ID behavior stays within the same fixed activity-data failure.
- The deliberate change is that a legitimate provider ID above the safe ceiling now fails generically because the current Number transport cannot represent it losslessly.
- Tests use invented local values only; no Firebase network, Strava host, production data, or real member data.

Residuals remain: raw response-byte/memory bounds before response.json; lossless Long/string and React-key/type migration; token/athlete/account binding; refresh concurrency; scope; revoke/audit/reconciliation; IAM/provider configuration; deployment/readback and live proof. This child does not complete #88.

## Migration and rollback

No schema, stored-data, client, Rules, index, package, provider, or production migration. Roll back the single merge if the narrower admission causes an unexpected regression; no data reversal is required. A future lossless ID migration requires a separately reviewed string/raw-JSON contract.

Officer impact: None — this is an internal, undeployed server response-validation correction. Safe activity IDs keep the same result; after a future protected Function release, a precision-unsafe ID receives the existing generic Strava activity-load failure.

Officer documentation: None — no screen wording, navigation, officer duty, collected or stored field, permission, account ownership, data movement, provider configuration, or deployment procedure changes. The existing Strava activity-failure procedure already covers the generic outcome.

Deployment evidence: Source changed; synthetic/local tests and hosted PR CI run 30733062824 passed. Netlify deploy preview 6a6ecc961614c10008c6b73d was created for exact head 426b1238405770534b699d62ba40826d90fcd2a4 and is ready with HTTP 200, x-robots-tag noindex, and published_at null. This deploy-preview is not production publication or live proof. Code is not merged. The production website and runmprc.com were not published or verified; Firebase was not deployed or read back; Strava/provider configuration or calls, production data, migration, and live behavior were not changed or verified.

