### PR TITLE
OAUTH-001A2J — Safely admit Strava HTTP success markers

### DIFF
--- a/functions/strava.js
+++ b/functions/strava.js
@@ -152,7 +152,7 @@ function isValidStravaStatsRequest(data) {
   return isExactPlainRecord(data, []);
 }
 
-function isConfirmedStravaDisconnectResponse(response) {
+function isConfirmedStravaHttpSuccess(response) {
   if (isPlainJsonRecord(response)) {
     return selectedOwnDataValue(response, 'ok', true) === true;
   }
@@ -825,7 +825,7 @@ async function exchangeCode(code) {
   } catch (_error) {
     throw stravaAuthorizationError('unavailable');
   }
-  if (!resp || resp.ok !== true) {
+  if (!isConfirmedStravaHttpSuccess(resp)) {
     throw stravaAuthorizationError('invalid-argument');
   }
   let response;
@@ -864,7 +864,7 @@ async function refreshToken(refresh) {
   } catch (_error) {
     throw stravaRefreshError('unavailable');
   }
-  if (!resp || resp.ok !== true) {
+  if (!isConfirmedStravaHttpSuccess(resp)) {
     throw stravaRefreshError('failed-precondition');
   }
   let response;
@@ -1052,7 +1052,7 @@ exports.stravaFetchStats = functions
       throw stravaDataError('unavailable');
     }
 
-    if (!activitiesResp || !activitiesResp.ok) {
+    if (!isConfirmedStravaHttpSuccess(activitiesResp)) {
       throw stravaDataError('internal');
     }
     let rawActivities;
@@ -1067,7 +1067,7 @@ exports.stravaFetchStats = functions
     }
 
     let projectedStats = null;
-    if (statsResp && statsResp.ok) {
+    if (isConfirmedStravaHttpSuccess(statsResp)) {
       let rawStats;
       try {
         rawStats = await statsResp.json();
@@ -1145,7 +1145,7 @@ exports.stravaDisconnect = functions
           console.warn('strava_disconnect_revoke_failed');
           throw stravaDisconnectError();
         }
-        if (!isConfirmedStravaDisconnectResponse(revokeResponse)) {
+        if (!isConfirmedStravaHttpSuccess(revokeResponse)) {
           throw stravaDisconnectError();
         }
       }

--- a/functions/strava.test.js
+++ b/functions/strava.test.js
@@ -1511,6 +1511,68 @@ describe('Strava authorization exchange failure boundary', () => {
     expectNoSideEffects();
   });
 
+  describe('OAUTH-001A2J authorization response-status admission', () => {
+    test('rejects an ok accessor without invoking or exposing it', async () => {
+      const statusFailure = new Error(
+        'authorization-ok-canary client_secret=provider-secret-canary',
+      );
+      const okGetter = jest.fn(() => {
+        throw statusFailure;
+      });
+      const json = jest.fn();
+      const response = { json };
+      Object.defineProperty(response, 'ok', {
+        configurable: true,
+        enumerable: true,
+        get: okGetter,
+      });
+      fetchMock.mockResolvedValue(response);
+
+      const rejection = await captureFailure(() => stravaExchangeCode({
+        code: CODE,
+        state: STATE,
+      }, CONTEXT));
+
+      expect(rejection).not.toBe(statusFailure);
+      expect(publicError(rejection)).toEqual({
+        code: 'invalid-argument',
+        message: FIXED_AUTHORIZATION_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify(publicError(rejection)))
+        .not.toMatch(/authorization-ok-canary|provider-secret-canary/i);
+      expect(okGetter).not.toHaveBeenCalled();
+      expect(json).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(admin.__hasDocument(STATE_PATH)).toBe(false);
+      expect(admin.__getTransactionDeletes()).toEqual([STATE_PATH]);
+      expectNoSideEffects();
+    });
+
+    test('accepts a genuine successful Node Response', async () => {
+      const json = jest.fn().mockResolvedValue(validExchangeResponse());
+      const response = new Response(null, { status: 200 });
+      Object.defineProperty(response, 'json', {
+        configurable: true,
+        value: json,
+      });
+      fetchMock.mockResolvedValue(response);
+
+      const result = await stravaExchangeCode({ code: CODE, state: STATE }, CONTEXT);
+
+      expect(result).toEqual({ ok: true, athleteId: 123456 });
+      expect(json).toHaveBeenCalledTimes(1);
+      expect(response.bodyUsed).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(admin.__getWrites()).toEqual(expectedExchangeWrites());
+      expect(admin.__hasDocument(STATE_PATH)).toBe(false);
+      expect(admin.__getTransactionDeletes()).toEqual([STATE_PATH]);
+      expect(Timestamp.now).toHaveBeenCalledTimes(3);
+      consoleSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+    });
+  });
+
   test('turns a transport failure into one fixed unavailable result', async () => {
     fetchMock.mockRejectedValue(Object.assign(
       new Error('transport-canary https://provider.example.test/?code=secret-canary'),
@@ -3178,6 +3240,43 @@ describe('Strava token refresh failure boundary', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
     expectNoWritesOrLogs();
+  });
+
+  describe('OAUTH-001A2J refresh response-status admission', () => {
+    test('rejects an ok accessor without invoking or exposing it', async () => {
+      seedExpiredConnection();
+      const statusFailure = new Error(
+        'refresh-ok-canary refresh_token=provider-secret-canary',
+      );
+      const okGetter = jest.fn(() => {
+        throw statusFailure;
+      });
+      const json = jest.fn();
+      const response = { json };
+      Object.defineProperty(response, 'ok', {
+        configurable: true,
+        enumerable: true,
+        get: okGetter,
+      });
+      fetchMock.mockResolvedValue(response);
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expect(rejection).not.toBe(statusFailure);
+      expect(publicError(rejection)).toEqual({
+        code: 'failed-precondition',
+        message: FIXED_REFRESH_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify(publicError(rejection)))
+        .not.toMatch(/refresh-ok-canary|provider-secret-canary/i);
+      expect(okGetter).not.toHaveBeenCalled();
+      expect(json).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expectNoWritesOrLogs();
+    });
   });
 
   test('turns a refresh transport failure into one fixed unavailable result', async () => {
@@ -5472,6 +5571,180 @@ describe('Strava activity data failure boundary', () => {
     expectTwoFreshBearerReads();
     expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
     expectNoWritesOrLogs();
+  });
+
+  describe('OAUTH-001A2J Strava response-status admission', () => {
+    test('rejects an activities ok accessor without invoking or exposing it', async () => {
+      seedFreshConnection();
+      const statusFailure = new Error(
+        'activities-ok-canary access_token=provider-secret-canary',
+      );
+      const okGetter = jest.fn(() => {
+        throw statusFailure;
+      });
+      const activitiesJson = jest.fn();
+      const activitiesResponse = { json: activitiesJson };
+      Object.defineProperty(activitiesResponse, 'ok', {
+        configurable: true,
+        enumerable: true,
+        get: okGetter,
+      });
+      const statsJson = jest.fn();
+      fetchMock
+        .mockResolvedValueOnce(activitiesResponse)
+        .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expect(rejection).not.toBe(statusFailure);
+      expect(publicError(rejection)).toEqual({
+        code: 'internal',
+        message: FIXED_DATA_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(JSON.stringify(publicError(rejection)))
+        .not.toMatch(/activities-ok-canary|provider-secret-canary/i);
+      expect(okGetter).not.toHaveBeenCalled();
+      expect(activitiesJson).not.toHaveBeenCalled();
+      expect(statsJson).not.toHaveBeenCalled();
+      expectTwoFreshBearerReads();
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expectNoWritesOrLogs();
+    });
+
+    test('rejects a resolved activities Proxy without inspecting it after then lookup', async () => {
+      seedFreshConnection();
+      const activitiesJson = jest.fn();
+      const getTrap = jest.fn((_target, key) => {
+        if (key === 'then') return undefined;
+        throw new Error(`activities-response-canary ${String(key)}`);
+      });
+      const response = new Proxy({ ok: true, json: activitiesJson }, {
+        get: getTrap,
+        getOwnPropertyDescriptor: jest.fn(() => {
+          throw new Error('activities-response-canary descriptor');
+        }),
+        getPrototypeOf: jest.fn(() => {
+          throw new Error('activities-response-canary prototype');
+        }),
+        ownKeys: jest.fn(() => {
+          throw new Error('activities-response-canary keys');
+        }),
+      });
+      const statsJson = jest.fn();
+      fetchMock
+        .mockResolvedValueOnce(response)
+        .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expect(publicError(rejection)).toEqual({
+        code: 'internal',
+        message: FIXED_DATA_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      const requestedKeys = getTrap.mock.calls.map(([, key]) => key);
+      expect(requestedKeys.length).toBeGreaterThanOrEqual(1);
+      expect(requestedKeys.every((key) => key === 'then')).toBe(true);
+      expect(activitiesJson).not.toHaveBeenCalled();
+      expect(statsJson).not.toHaveBeenCalled();
+      expectTwoFreshBearerReads();
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expectNoWritesOrLogs();
+    });
+
+    test('contains an already-revoked activities Proxy as transport unavailable before status admission', async () => {
+      seedFreshConnection();
+      const { proxy: activitiesResponse, revoke } = Proxy.revocable({ ok: true }, {});
+      revoke();
+      const statsJson = jest.fn();
+      fetchMock
+        .mockResolvedValueOnce(activitiesResponse)
+        .mockResolvedValueOnce({ ok: true, json: statsJson });
+
+      const rejection = await captureFailure(() => stravaFetchStats({}, CONTEXT));
+
+      expect(publicError(rejection)).toEqual({
+        code: 'unavailable',
+        message: FIXED_DATA_ERROR,
+        details: undefined,
+        cause: undefined,
+      });
+      expect(statsJson).not.toHaveBeenCalled();
+      expectTwoFreshBearerReads();
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expectNoWritesOrLogs();
+    });
+
+    test('rejects a statistics Proxy revoked after Promise fulfillment without inspecting it', async () => {
+      seedFreshConnection();
+      const activitiesJson = jest.fn().mockResolvedValue([validProviderActivity()]);
+      const statsJson = jest.fn();
+      const { proxy: statsResponse, revoke } = Proxy.revocable({
+        ok: true,
+        json: statsJson,
+      }, {});
+      const fulfilledStatsResponse = Promise.resolve(statsResponse);
+      revoke();
+      fetchMock
+        .mockResolvedValueOnce({ ok: true, json: activitiesJson })
+        .mockReturnValueOnce(fulfilledStatsResponse);
+
+      const result = await stravaFetchStats({}, CONTEXT);
+
+      expect(result.recentActivities).toHaveLength(1);
+      expect(result.yearToDate).toBeNull();
+      expect(result.allTime).toBeNull();
+      expect(activitiesJson).toHaveBeenCalledTimes(1);
+      expect(statsJson).not.toHaveBeenCalled();
+      expectTwoFreshBearerReads();
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expectNoWritesOrLogs();
+    });
+
+    test('treats a statistics ok accessor as optional failure without invoking it', async () => {
+      seedFreshConnection();
+      const activitiesJson = jest.fn().mockResolvedValue([validProviderActivity()]);
+      const statsJson = jest.fn();
+      const okGetter = jest.fn(() => {
+        throw new Error('statistics-ok-canary access_token=provider-secret-canary');
+      });
+      const statsResponse = { json: statsJson };
+      Object.defineProperty(statsResponse, 'ok', {
+        configurable: true,
+        enumerable: true,
+        get: okGetter,
+      });
+      fetchMock
+        .mockResolvedValueOnce({ ok: true, json: activitiesJson })
+        .mockResolvedValueOnce(statsResponse);
+
+      const result = await stravaFetchStats({}, CONTEXT);
+
+      expect(result.recentActivities).toHaveLength(1);
+      expect(result.yearToDate).toBeNull();
+      expect(result.allTime).toBeNull();
+      expect(okGetter).not.toHaveBeenCalled();
+      expect(activitiesJson).toHaveBeenCalledTimes(1);
+      expect(statsJson).not.toHaveBeenCalled();
+      expectTwoFreshBearerReads();
+      expect(admin.__getReads()).toEqual([CONNECTION_PATH, SECRET_PATH]);
+      expect(admin.__getWrites()).toEqual([]);
+      expect(admin.__getDeletes()).toEqual([]);
+      expect(Timestamp.now).not.toHaveBeenCalled();
+      expectNoWritesOrLogs();
+    });
   });
 
   test('turns an activities transport failure into one fixed unavailable result', async () => {


### PR DESCRIPTION
Closes #604

Officer impact: After a future protected Firebase Functions release, an unexpected internal result while the website talks to Strava will remain behind the existing fixed authorization, refresh, or activity-loading outcome. There is no current officer-visible change and no new officer action.

Officer documentation: None — this is a server-only transport-object admission boundary. It changes no public page, officer duty, collected field, permission, account, deployment step, or recovery procedure. Existing Strava SOURCE ONLY / NOT LIVE failure guidance remains accurate.

Deployment evidence: Source and local-test evidence only at PR creation. Nothing is merged or live. No website publication, runmprc.com change, Firebase deployment, Strava/provider configuration or contact, production-data change, or live-behavior verification occurred. A green workflow will not prove that a Function is deployed.

## Outcome

Generalizes the existing safe disconnect response-success helper and routes all five Strava HTTP status decisions through it:

- authorization exchange;
- token refresh;
- recent activities;
- optional athlete statistics;
- disconnect revocation.

Only an ordinary plain record with an own data ok exactly equal to Boolean true, or a genuine exact-prototype native Response whose captured native getter reports success, is admitted.

## Failure behavior

- Authorization invalid status remains fixed invalid-argument.
- Refresh invalid status remains fixed failed-precondition.
- Activities invalid status remains fixed internal.
- Optional statistics retain valid activities with null totals.
- Disconnect preserves its fixed unavailable result and local records.
- Accessors, inherited markers, custom prototypes, live/revoked Proxies, non-Boolean markers, and malformed values fail closed before body access.
- A Proxy already revoked before Promise assimilation is contained by the existing fixed unavailable transport boundary.
- No rejected status, body, or raw error is logged or returned.

Ordinary provider wire bytes cannot create an accessor or Proxy. This is defense-in-depth containment for malformed or instrumented resolved transport objects.

## Trustworthy RED

Exact base: dff1a40194bd1f25938ac16564a6ce27bbb9eab5

Test-only diff SHA-256: c4c73b8cbfc4d6f3b65e066e271c91e1678f365852d6f463eaf24a54907d660f

Pinned Node 20 result on old runtime: 692 total / 691 passed / exactly the new activities-accessor test failed because the direct status read invoked and returned the hostile error by identity.

## Verification

Exact reviewed head: 604e51c0f3dd2700208bd3252b9d45864f5b9051

Exact patch SHA-256: 6d740feb8f55d9ce2afc2db56f1ddfeabf7fdc8a193e7be54127dbf5a837881f

- Focused Strava: 699/699 passed.
- Full Functions: 69 suites passed with 2 intended skips; 7,502 passed / 64 intended skips.
- Functions lint: passed.
- Frontend: 951/951 passed.
- TypeScript: passed.
- Diagnostic build: passed.
- Static SPA/workflow/release/dependency/artifact gates: 104/104 passed.
- Firestore Rules emulator: 418/418 passed.
- Real commerce emulator: 63/63 passed.
- Dependency audits: zero critical; no dependency changed.
- git diff --check: passed.
- Diff: exactly functions/strava.js and functions/strava.test.js.
- Three independent reviews: GO for security/compatibility, RED/tests, factual scope, and no-documentation determination.

## Migration and residual risk

No schema, dependency, client contract, data migration, or production fallback change. Existing plain test transports and genuine native fetch responses retain behavior. Exotic response wrappers now fail closed.

Response-byte streaming limits, JSON projection, lossless ID transport, refresh concurrency, provider policy/configuration, Firebase deployment, production data, and live verification remain explicitly outside this PR.
